### PR TITLE
Revamp admin panel UI/UX with filtering, status pills, and refreshed navigation

### DIFF
--- a/services/admin-panel/src/components/AuthView.jsx
+++ b/services/admin-panel/src/components/AuthView.jsx
@@ -22,8 +22,9 @@ export default function AuthView({ onLogin }) {
   return (
     <div className="auth-shell">
       <form className="panel auth-card" onSubmit={handleSubmit}>
-        <h1>zTTato Auth</h1>
-        <p>Sign in to access dashboards and control panels.</p>
+        <p className="eyebrow">zTTato Platform</p>
+        <h1>Sign in to workspace</h1>
+        <p className="muted-text">Access dashboards, rent workflows, and admin operations in one place.</p>
         <label>
           Email
           <input name="email" type="email" value={credentials.email} onChange={handleChange} required />

--- a/services/admin-panel/src/components/Navigation.jsx
+++ b/services/admin-panel/src/components/Navigation.jsx
@@ -1,34 +1,37 @@
 import React from "react"
 
 const links = [
-  { key: "overview", label: "Overview Dashboard" },
-  { key: "user", label: "User Dashboard" },
-  { key: "admin", label: "Admin Dashboard" },
-  { key: "admin-control", label: "Admin Control Panel" },
-  { key: "rent-control", label: "Rent Control Panel" }
+  { key: "overview", label: "Overview" },
+  { key: "user", label: "User" },
+  { key: "admin", label: "Admin" },
+  { key: "admin-control", label: "Access Control" },
+  { key: "rent-control", label: "Rent Ops" }
 ]
 
 export default function Navigation({ activePage, onNavigate, onLogout, currentUser }) {
   return (
     <header className="top-nav panel">
-      <div>
-        <h2>zTTato Platform</h2>
-        <p>
-          Signed in as <strong>{currentUser.name}</strong> ({currentUser.role})
+      <div className="brand-block">
+        <p className="eyebrow">zTTato Platform</p>
+        <h2>Operations Workspace</h2>
+        <p className="muted-text">
+          Signed in as <strong>{currentUser.name}</strong> · {currentUser.role}
         </p>
       </div>
-      <nav>
+
+      <nav className="tab-nav" aria-label="Main navigation">
         {links.map((item) => (
           <button
             type="button"
             key={item.key}
-            className={activePage === item.key ? "active" : ""}
+            className={activePage === item.key ? "active" : "ghost"}
             onClick={() => onNavigate(item.key)}
           >
             {item.label}
           </button>
         ))}
       </nav>
+
       <button type="button" className="secondary" onClick={onLogout}>
         Logout
       </button>

--- a/services/admin-panel/src/pages/AdminControlPanel.jsx
+++ b/services/admin-panel/src/pages/AdminControlPanel.jsx
@@ -84,7 +84,7 @@ export default function AdminControlPanel({ users, settings, onUpdateSettings, o
         {users.map((user) => (
           <li key={user.id} className="row-between">
             <span>
-              {user.name} ({user.role}) - {user.status}
+              {user.name} ({user.role}) <span className={`pill ${user.status}`}>{user.status}</span>
             </span>
             <button type="button" onClick={() => onToggleUserStatus(user.id)}>
               {user.status === "active" ? "Suspend" : "Activate"}

--- a/services/admin-panel/src/pages/AdminDashboard.jsx
+++ b/services/admin-panel/src/pages/AdminDashboard.jsx
@@ -1,11 +1,29 @@
-import React from "react"
+import React, { useMemo, useState } from "react"
 
 export default function AdminDashboard({ users, settings }) {
+  const [query, setQuery] = useState("")
+  const [statusFilter, setStatusFilter] = useState("all")
+
   const suspendedUsers = users.filter((user) => user.status === "suspended").length
+
+  const filteredUsers = useMemo(() => {
+    return users.filter((user) => {
+      const matchesQuery = [user.name, user.email, user.role]
+        .join(" ")
+        .toLowerCase()
+        .includes(query.toLowerCase())
+      const matchesStatus = statusFilter === "all" || user.status === statusFilter
+      return matchesQuery && matchesStatus
+    })
+  }, [query, statusFilter, users])
 
   return (
     <section className="panel">
-      <h3>Admin Dashboard</h3>
+      <div className="title-row">
+        <h3>Admin Dashboard</h3>
+        <p className="muted-text">Live account health and user directory controls.</p>
+      </div>
+
       <div className="grid-3">
         <article className="metric-card">
           <span>Total Accounts</span>
@@ -20,6 +38,21 @@ export default function AdminDashboard({ users, settings }) {
           <h4>{settings.maintenanceMode ? "ON" : "OFF"}</h4>
         </article>
       </div>
+
+      <div className="toolbar">
+        <input
+          type="search"
+          placeholder="Search users by name, email, or role"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="suspended">Suspended</option>
+        </select>
+      </div>
+
       <h4>User Directory</h4>
       <table>
         <thead>
@@ -32,13 +65,15 @@ export default function AdminDashboard({ users, settings }) {
           </tr>
         </thead>
         <tbody>
-          {users.map((user) => (
+          {filteredUsers.map((user) => (
             <tr key={user.id}>
               <td>{user.id}</td>
               <td>{user.name}</td>
               <td>{user.email}</td>
               <td>{user.role}</td>
-              <td>{user.status}</td>
+              <td>
+                <span className={`pill ${user.status}`}>{user.status}</span>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/services/admin-panel/src/pages/OverviewDashboard.jsx
+++ b/services/admin-panel/src/pages/OverviewDashboard.jsx
@@ -4,10 +4,15 @@ export default function OverviewDashboard({ users, rentUnits }) {
   const totalRevenue = rentUnits.reduce((sum, unit) => sum + unit.monthlyRent, 0)
   const overdueCount = rentUnits.filter((unit) => unit.status === "overdue").length
   const activeUsers = users.filter((u) => u.status === "active").length
+  const paidUnits = rentUnits.filter((unit) => unit.status === "paid").length
 
   return (
     <section className="panel">
-      <h3>Overview Dashboard</h3>
+      <div className="title-row">
+        <h3>Overview Dashboard</h3>
+        <p className="muted-text">Platform-wide operational snapshot.</p>
+      </div>
+
       <div className="grid-3">
         <article className="metric-card">
           <span>Total Users</span>
@@ -22,7 +27,19 @@ export default function OverviewDashboard({ users, rentUnits }) {
           <h4>${totalRevenue}</h4>
         </article>
       </div>
-      <p>Overdue units: {overdueCount}</p>
+
+      <div className="grid-2">
+        <article className="soft-card">
+          <h4>Collection Progress</h4>
+          <p>
+            {paidUnits} / {rentUnits.length} units marked as paid this month.
+          </p>
+        </article>
+        <article className="soft-card">
+          <h4>Risk Alert</h4>
+          <p>{overdueCount > 0 ? `${overdueCount} overdue units need follow-up.` : "No overdue units right now."}</p>
+        </article>
+      </div>
     </section>
   )
 }

--- a/services/admin-panel/src/pages/RentControlPanel.jsx
+++ b/services/admin-panel/src/pages/RentControlPanel.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react"
+import React, { useMemo, useState } from "react"
 
 export default function RentControlPanel({ rentUnits, onAddRentUnit, onUpdateRentStatus }) {
   const [form, setForm] = useState({ id: "", tenant: "", monthlyRent: 0, dueDate: "", status: "pending" })
+  const [statusFilter, setStatusFilter] = useState("all")
 
   function handleSubmit(event) {
     event.preventDefault()
@@ -9,9 +10,16 @@ export default function RentControlPanel({ rentUnits, onAddRentUnit, onUpdateRen
     setForm({ id: "", tenant: "", monthlyRent: 0, dueDate: "", status: "pending" })
   }
 
+  const visibleUnits = useMemo(() => {
+    return rentUnits.filter((unit) => statusFilter === "all" || unit.status === statusFilter)
+  }, [rentUnits, statusFilter])
+
   return (
     <section className="panel">
-      <h3>Rent Control Panel</h3>
+      <div className="title-row">
+        <h3>Rent Control Panel</h3>
+        <p className="muted-text">Create, monitor, and resolve rental payment statuses quickly.</p>
+      </div>
 
       <form onSubmit={handleSubmit} className="grid-5">
         <input
@@ -43,6 +51,15 @@ export default function RentControlPanel({ rentUnits, onAddRentUnit, onUpdateRen
         <button type="submit">Add Unit</button>
       </form>
 
+      <div className="toolbar">
+        <select value={statusFilter} onChange={(event) => setStatusFilter(event.target.value)}>
+          <option value="all">All payment statuses</option>
+          <option value="paid">Paid</option>
+          <option value="pending">Pending</option>
+          <option value="overdue">Overdue</option>
+        </select>
+      </div>
+
       <table>
         <thead>
           <tr>
@@ -55,16 +72,18 @@ export default function RentControlPanel({ rentUnits, onAddRentUnit, onUpdateRen
           </tr>
         </thead>
         <tbody>
-          {rentUnits.map((unit) => (
+          {visibleUnits.map((unit) => (
             <tr key={unit.id}>
               <td>{unit.id}</td>
               <td>{unit.tenant}</td>
               <td>${unit.monthlyRent}</td>
               <td>{unit.dueDate}</td>
-              <td>{unit.status}</td>
+              <td>
+                <span className={`pill ${unit.status}`}>{unit.status}</span>
+              </td>
               <td className="button-group">
-                {['paid', 'pending', 'overdue'].map((status) => (
-                  <button type="button" key={status} onClick={() => onUpdateRentStatus(unit.id, status)}>
+                {["paid", "pending", "overdue"].map((status) => (
+                  <button type="button" className="ghost" key={status} onClick={() => onUpdateRentStatus(unit.id, status)}>
                     {status}
                   </button>
                 ))}

--- a/services/admin-panel/src/styles.css
+++ b/services/admin-panel/src/styles.css
@@ -1,7 +1,7 @@
 :root {
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
   color: #132035;
-  background: #f3f6fb;
+  background: linear-gradient(180deg, #f5f8ff 0%, #ecf1fb 100%);
 }
 
 * {
@@ -31,30 +31,42 @@ select {
   display: grid;
   min-height: 100vh;
   place-items: center;
+  padding: 1rem;
 }
 
 .panel {
   background: #ffffff;
-  border-radius: 14px;
+  border-radius: 16px;
   padding: 1rem;
-  box-shadow: 0 8px 28px rgba(25, 40, 64, 0.08);
+  box-shadow: 0 12px 32px rgba(25, 40, 64, 0.1);
+  border: 1px solid #e5ecfa;
 }
 
 .auth-card {
-  width: min(420px, 92vw);
+  width: min(440px, 94vw);
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .top-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.8rem;
+  display: grid;
+  gap: 1rem;
   align-items: center;
-  justify-content: space-between;
 }
 
-nav {
+.brand-block h2 {
+  margin: 0;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #4f6280;
+}
+
+.tab-nav {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
@@ -67,10 +79,20 @@ button {
   border-radius: 10px;
   padding: 0.5rem 0.85rem;
   cursor: pointer;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
 }
 
 button.secondary {
   background: #5e6b84;
+}
+
+button.ghost {
+  background: #edf2ff;
+  color: #23407f;
 }
 
 button.active {
@@ -82,7 +104,8 @@ select {
   width: 100%;
   border: 1px solid #c9d2e3;
   border-radius: 9px;
-  padding: 0.5rem;
+  padding: 0.55rem;
+  background: #fff;
 }
 
 label {
@@ -103,7 +126,7 @@ label {
 }
 
 .grid-3 {
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
 .grid-5 {
@@ -112,15 +135,38 @@ label {
 }
 
 .metric-card {
-  background: #f5f8ff;
+  background: linear-gradient(160deg, #f6f9ff, #eef3ff);
   border: 1px solid #d9e3f8;
-  border-radius: 10px;
-  padding: 0.75rem;
+  border-radius: 12px;
+  padding: 0.8rem;
+}
+
+.soft-card {
+  background: #f9fbff;
+  border: 1px solid #e4ecfb;
+  border-radius: 12px;
+  padding: 0.8rem;
+}
+
+.title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: 1fr minmax(180px, 260px);
+  gap: 0.6rem;
+  margin: 0.8rem 0;
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
+  overflow: hidden;
 }
 
 th,
@@ -128,6 +174,7 @@ td {
   border-bottom: 1px solid #e8eef8;
   text-align: left;
   padding: 0.6rem;
+  vertical-align: middle;
 }
 
 .stacked-form {
@@ -153,9 +200,47 @@ td {
 .button-group {
   display: flex;
   gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.18rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  text-transform: capitalize;
+}
+
+.pill.active,
+.pill.paid {
+  background: #dff7ea;
+  color: #08693b;
+}
+
+.pill.pending {
+  background: #fff4d7;
+  color: #805800;
+}
+
+.pill.suspended,
+.pill.overdue {
+  background: #ffe3e8;
+  color: #9f1138;
+}
+
+.muted-text {
+  margin: 0;
+  color: #5d6f8d;
 }
 
 .error-text {
   color: #b10032;
   margin: 0;
+}
+
+@media (max-width: 720px) {
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
### Motivation
- Improve the admin-panel's clarity and usability by refreshing branding, layout, and visual hierarchy for operational users.
- Make user and rent management faster to scan and act on by introducing status badges and client-side filtering/search.
- Provide a consistent visual system (cards, toolbars, ghost buttons, responsive rules) so dashboards communicate important signals at a glance.

### Description
- Updated authentication and navigation presentation in `services/admin-panel/src/components/AuthView.jsx` and `services/admin-panel/src/components/Navigation.jsx` to use clearer product framing and simplified tab labels with a structured signed-in header.
- Enhanced Admin Dashboard in `services/admin-panel/src/pages/AdminDashboard.jsx` with a client-side search input, status filter, `useMemo` filtering, and status `pill` indicators in the user directory.
- Improved Rent Control in `services/admin-panel/src/pages/RentControlPanel.jsx` by adding a payment `statusFilter`, `visibleUnits` memoized view, status pills, and action `ghost` buttons for consistency.
- Refined Overview in `services/admin-panel/src/pages/OverviewDashboard.jsx` with collection progress and risk alert cards to surface operational KPIs.
- Polished global styles in `services/admin-panel/src/styles.css` to introduce gradients, card/soft-card variants, toolbar layout, pill styles, ghost buttons, responsive adjustments, and subtle elevation updates.
- Minor UX polish in `services/admin-panel/src/pages/AdminControlPanel.jsx` to replace plain status text with `pill` badges for consistency.

### Testing
- Built the admin panel with `npm run build` in `services/admin-panel` and the build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully (Vite reported ready).
- Ran an automated Playwright script to sign in and capture a UI screenshot (`artifacts/admin-panel-uiux.png`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2f8a677248321b76e79fb03c8d8b1)