### PR TITLE
Fix zttato CLI script headers and path handling

### DIFF
--- a/scripts/zttato
+++ b/scripts/zttato
@@ -1,9 +1,9 @@
-# zttato
 #!/usr/bin/env bash
+# zttato
 
 set -e
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 case "${1:-}" in
 
@@ -39,9 +39,9 @@ logs)
 SERVICE="${2:-}"
 
 if [ -z "$SERVICE" ]; then
-ls logs
+ls "$ROOT/logs"
 else
-tail -f logs/"$SERVICE".log
+tail -f "$ROOT/logs/$SERVICE.log"
 fi
 ;;
 

--- a/zttato
+++ b/zttato
@@ -1,5 +1,5 @@
-# zttato
 #!/usr/bin/env bash
+# zttato
 
 set -Eeuo pipefail
 
@@ -72,7 +72,7 @@ bash "$ROOT/scripts/zttato-doctor.sh"
 ;;
 
 node-install)
-bash scripts/node-install.sh
+bash "$ROOT/scripts/node-install.sh"
 ;;
 
 node-status)


### PR DESCRIPTION
### Motivation
- Ensure the `zttato` CLI scripts are directly executable by placing the shebang on the first line. 
- Make sub-script lookups robust by resolving `ROOT` to the repository root so helper scripts are found reliably. 
- Normalize log and helper script paths so commands always reference files under `$ROOT` instead of relative locations.

### Description
- Move the shebang to line 1 in `zttato` and `scripts/zttato` so the scripts execute correctly as shell scripts. 
- Update `ROOT` calculation in `scripts/zttato` to `$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)` so repository root is used for sub-script invocations. 
- Replace relative log and node-install invocations with explicit `$ROOT` paths, e.g. `ls "$ROOT/logs"`, `tail -f "$ROOT/logs/$SERVICE.log"`, and `bash "$ROOT/scripts/node-install.sh"`.

### Testing
- Ran `bash -n zttato` to validate the root CLI script syntax and it succeeded. 
- Ran `bash -n scripts/zttato` to validate the helper script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fafee53083219ec2bba205b5a71c)