### PR TITLE
Fix worker launcher to use service venv and PYTHONPATH

### DIFF
--- a/infrastructure/start/workers.sh
+++ b/infrastructure/start/workers.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 
-echo "Starting crawler workers..."
-python services/market-crawler/src/workers/worker.py &
+set -Eeuo pipefail
 
-echo "Starting arbitrage workers..."
-python services/arbitrage-engine/src/workers/worker.py &
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-echo "Starting GPU renderer workers..."
-python services/gpu-renderer/src/worker/worker.py &
+run_worker() {
+  local service_dir="$1"
+  local worker_rel_path="$2"
+  local label="$3"
+
+  local python_bin="python3"
+  if [ -x "$ROOT/$service_dir/.venv/bin/python" ]; then
+    python_bin="$ROOT/$service_dir/.venv/bin/python"
+  fi
+
+  echo "Starting $label workers..."
+  (
+    cd "$ROOT/$service_dir"
+    PYTHONPATH="$ROOT/$service_dir/src${PYTHONPATH:+:$PYTHONPATH}" "$python_bin" "$worker_rel_path"
+  ) &
+}
+
+run_worker "services/market-crawler" "src/workers/worker.py" "crawler"
+run_worker "services/arbitrage-engine" "src/workers/worker.py" "arbitrage"
+run_worker "services/gpu-renderer" "src/worker/worker.py" "GPU renderer"


### PR DESCRIPTION
### Motivation

- The original worker bootstrap invoked `python` directly which caused `python: command not found` on some hosts. 
- Workers were started without ensuring the service `src` directory was on `PYTHONPATH`, causing `ModuleNotFoundError: No module named 'core'`. 
- The launcher should be robust regardless of the caller CWD and prefer per-service virtualenvs when present.

### Description

- Replace the simple one-line `python ... &` invocations with a reusable `run_worker` helper in `infrastructure/start/workers.sh` that centralizes launcher behavior. 
- Resolve repository root from the script location using `ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)` so worker startup does not depend on the caller CWD. 
- Prefer each service's virtualenv interpreter at `.venv/bin/python` and fall back to `python3` when the venv interpreter is not available. 
- Start each worker from its service directory and set `PYTHONPATH` to the service `src` folder so imports like `from core...` resolve correctly.

### Testing

- Ran `bash infrastructure/start/workers.sh` to validate the launcher no longer fails with `python: command not found` and observed workers progress past the interpreter/import stage. 
- Observed runtime traces showing application-level environment failures (`KeyError: 'DB_URL'` and `redis.exceptions.ConnectionError: Error 111 connecting to localhost:6379`) which are unrelated to the launcher change and indicate missing service environment/config or unavailable Redis for the local test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40905f0c88321812572fa1775406c)