### PR TITLE
Fix startup DB connectivity defaults and migration target

### DIFF
--- a/infrastructure/start/env.sh
+++ b/infrastructure/start/env.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 export DB_URL=postgresql://zttato:zttato@localhost:5432/zttato
+export CONTAINER_DB_URL=postgresql://zttato:zttato@postgres:5432/zttato
 export REDIS_URL=redis://localhost:6379
+export CONTAINER_REDIS_URL=redis://redis:6379
 export GPU_RENDER=true

--- a/start-zttato.sh
+++ b/start-zttato.sh
@@ -90,6 +90,10 @@ echo ""
 echo "Starting infrastructure..."
 docker compose up -d postgres redis
 
+# Ensure compose services get container-resolvable URLs
+export DB_URL="${CONTAINER_DB_URL:-postgresql://zttato:zttato@postgres:5432/zttato}"
+export REDIS_URL="${CONTAINER_REDIS_URL:-redis://redis:6379}"
+
 sleep 6
 
 ################################
@@ -121,7 +125,7 @@ if [ -f "$MIG" ]; then
   CONTAINER=$(docker ps -qf name=postgres | head -n1 || true)
 
   if [ -n "$CONTAINER" ]; then
-    docker exec -i "$CONTAINER" psql -U postgres -f /dev/stdin < "$MIG" || true
+    docker exec -i "$CONTAINER" psql -U zttato -d zttato -f /dev/stdin < "$MIG" || true
   fi
 fi
 
@@ -147,7 +151,7 @@ sleep 5
 
 curl -fs http://localhost:9100/docs || true
 curl -fs http://localhost:9400/docs || true
-curl -fs http://localhost:9500/arbitrage || true
+curl -fs http://localhost:9500/docs || true
 
 ################################
 # Status


### PR DESCRIPTION
### Motivation
- Services started via Docker were inheriting `DB_URL`/`REDIS_URL` that point to `localhost`, causing container-internal services to try connecting to `127.0.0.1` and fail. 
- The migration command used the wrong default connection arguments which could target the wrong user/database and fail to apply schema. 
- The arbitrage health check endpoint differed from other services and could produce false negatives during startup checks.

### Description
- Added container-scoped defaults `CONTAINER_DB_URL` and `CONTAINER_REDIS_URL` to `infrastructure/start/env.sh` so compose-network hostnames (`postgres`, `redis`) are available. 
- Updated `start-zttato.sh` to export container-safe `DB_URL` and `REDIS_URL` (falling back to the `CONTAINER_*` values) immediately after bringing up infra so services inside containers use service DNS names. 
- Fixed the migration invocation to run `psql -U zttato -d zttato -f /dev/stdin` against the `postgres` container so the migration targets the configured user and database. 
- Aligned the arbitrage service health check to use `/docs` like other services to avoid endpoint mismatches.

### Testing
- Performed a shell syntax check with `bash -n start-zttato.sh infrastructure/start/env.sh infrastructure/start/workers.sh` which completed successfully. 
- Verified the changes were committed to the repository (`Fix startup DB connectivity defaults and migration target`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40f264d9883219523a7ee057d794b)