### PR TITLE
Improve repo validator to run real syntax and manifest checks

### DIFF
--- a/infrastructure/scripts/validate-repo.sh
+++ b/infrastructure/scripts/validate-repo.sh
@@ -7,25 +7,56 @@ echo "--------------------------------"
 echo "Repository Validation"
 echo "--------------------------------"
 
-echo ""
-echo "Dockerfiles:"
-find "$ROOT" -name Dockerfile
+mapfile -t dockerfiles < <(find "$ROOT" -type f -name Dockerfile -not -path '*/node_modules/*' | sort)
+mapfile -t package_jsons < <(find "$ROOT/services" -type f -name package.json -not -path '*/node_modules/*' | sort)
+mapfile -t requirements_files < <(find "$ROOT/services" -type f -name requirements.txt | sort)
+mapfile -t shell_scripts < <(find "$ROOT" -type f -name '*.sh' -not -path '*/node_modules/*' | sort)
+mapfile -t python_files < <(find "$ROOT/services" -type f -name '*.py' -not -path '*/__pycache__/*' | sort)
+mapfile -t kubernetes_manifests < <(find "$ROOT/infrastructure/k8s" -type f -name '*.yaml' | sort)
 
 echo ""
-echo "Node services:"
-find "$ROOT/services" -name package.json
+echo "Dockerfiles (${#dockerfiles[@]}):"
+printf '%s\n' "${dockerfiles[@]}"
 
 echo ""
-echo "Python services:"
-find "$ROOT/services" -name requirements.txt
+echo "Node services (${#package_jsons[@]}):"
+printf '%s\n' "${package_jsons[@]}"
 
 echo ""
-echo "Shell scripts:"
-find "$ROOT" -name "*.sh"
+echo "Python services (${#requirements_files[@]}):"
+printf '%s\n' "${requirements_files[@]}"
 
 echo ""
-echo "Kubernetes manifests:"
-find "$ROOT/infrastructure/k8s" -name "*.yaml"
+echo "Shell scripts (${#shell_scripts[@]}):"
+printf '%s\n' "${shell_scripts[@]}"
 
 echo ""
-echo "Validation completed."
+echo "Kubernetes manifests (${#kubernetes_manifests[@]}):"
+printf '%s\n' "${kubernetes_manifests[@]}"
+
+echo ""
+echo "Running checks..."
+
+if ((${#shell_scripts[@]} > 0)); then
+  while IFS= read -r script; do
+    bash -n "$script"
+  done < <(printf '%s\n' "${shell_scripts[@]}")
+  echo "✅ Shell syntax check passed (${#shell_scripts[@]} files)"
+fi
+
+if ((${#python_files[@]} > 0)); then
+  while IFS= read -r pyfile; do
+    python -m py_compile "$pyfile"
+  done < <(printf '%s\n' "${python_files[@]}")
+  echo "✅ Python syntax check passed (${#python_files[@]} files)"
+fi
+
+if ((${#package_jsons[@]} > 0)); then
+  while IFS= read -r package_json; do
+    python -m json.tool "$package_json" >/dev/null
+  done < <(printf '%s\n' "${package_jsons[@]}")
+  echo "✅ package.json validation passed (${#package_jsons[@]} files)"
+fi
+
+echo ""
+echo "Validation completed successfully."


### PR DESCRIPTION
### Motivation
- Provide a real validation step that fails fast for broken scripts/files instead of only listing files.  
- Reduce noise by excluding `node_modules` and `__pycache__` and show concise inventories with counts.  
- Catch common repository issues early (shell syntax, Python syntax, invalid `package.json`) for CI and local checks.

### Description
- Replace passive file-listing behavior in `infrastructure/scripts/validate-repo.sh` with scoped discovery using `find` and `mapfile`, excluding noisy paths.  
- Emit inventories with counts for Dockerfiles, Node `package.json`, Python `requirements.txt`, shell scripts, Python files, and k8s manifests.  
- Add automated checks: run `bash -n` for shell scripts, `python -m py_compile` for Python files, and `python -m json.tool` for each `package.json`.  
- Preserve strict failure behavior via `set -Eeuo pipefail` and update the final status message to indicate successful validation.

### Testing
- Ran `bash infrastructure/scripts/validate-repo.sh` and it completed successfully reporting inventories and passing all checks.  
- Ran `python -m compileall` across Python services and compilation completed without errors.  
- Ran `node --check` against JS sources and the checked files returned `OK`.  
- Ran `bash -n` style checks across discovered shell scripts and they passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41664c3d48321aae964e7c1fa5836)