### PR TITLE
Add production-ready Docker Compose stack, nginx proxy, env and lifecycle scripts

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,11 @@
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=zttato
+DB_USER=zttato
+DB_PASSWORD=zttato
+
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+API_HOST=0.0.0.0
+ENV=production

--- a/README.md
+++ b/README.md
@@ -1,157 +1,79 @@
-# zTTato Platform
+# zTTato Platform — Production Layout
 
-A multi-service growth/automation platform with Node.js and Python services, Docker-based infrastructure, Kubernetes manifests, and Cloudflare edge automation scripts.
+This repository includes a production-ready Docker Compose deployment with isolated services, worker containers, reverse proxy routing, persistent state, and health checks.
 
-## Repository Overview
+## Production layout
 
 ```text
-.
-├── docker-compose.yml                # Core local stack (postgres, redis, core python APIs)
-├── start-zttato.sh                   # Unified bootstrap script
-├── env.edge                          # Edge-related env sample
-├── cloudflare-devops/                # Cloudflare tunnel + DNS helper toolkit
-├── infrastructure/
-│   ├── ci/                           # Build/deploy helper scripts
-│   ├── k8s/                          # Kubernetes deployments/services/ingress/config
-│   ├── postgres/                     # Postgres config + migrations
-│   ├── scripts/                      # Platform operations scripts
-│   └── start/                        # Env and worker startup scripts
-├── scripts/                          # Additional operational/fix/deploy scripts
-└── services/
-    ├── account-farm/                 # Account automation service (Node)
-    ├── admin-panel/                  # Frontend dashboard (React)
-    ├── ai-video-generator/           # AI video generation pipeline (Node)
-    ├── analytics/                    # Analytics API/metrics (Node)
-    ├── arbitrage-engine/             # Arbitrage API/worker (Python)
-    ├── click-tracker/                # Click/fingerprint tracking (Node)
-    ├── gpu-renderer/                 # Render queue + API (Python)
-    ├── market-crawler/               # Market crawler API/workers (Python)
-    ├── shopee-crawler/               # Shopee crawler (Node)
-    ├── tiktok-farm/                  # TikTok farm scheduler/uploader (Node)
-    ├── tiktok-shop-miner/            # TikTok shop mining service (Node)
-    └── viral-predictor/              # ML prediction API/training (Python)
+zttato-platform
+│
+├─ docker
+│   ├─ postgres
+│   └─ nginx
+│
+├─ services
+│   ├─ viral-predictor
+│   ├─ market-crawler
+│   ├─ gpu-renderer
+│   ├─ arbitrage-engine
+│   ├─ analytics
+│   ├─ click-tracker
+│   └─ admin-panel
+│
+├─ workers
+│   ├─ crawler-worker
+│   ├─ arbitrage-worker
+│   └─ renderer-worker
+│
+├─ infrastructure
+│   ├─ postgres
+│   │   └─ migrations
+│   ├─ monitoring
+│   └─ scripts
+│
+├─ configs
+│   ├─ nginx.conf
+│   └─ env
+│
+├─ docker-compose.yml
+├─ .env
+├─ start.sh
+├─ stop.sh
+└─ README.md
 ```
 
-## Current Validation Status
-
-Validation checks performed in this repository:
-
-- Shell syntax check across all `*.sh` scripts.
-- Python syntax byte-compile for all `*.py` files.
-- JSON parse check for all `package.json` files.
-
-### Result
-
-- ✅ Repository is now syntactically valid for shell/python/json checks.
-- 🔧 Fixed one blocking shell syntax issue in:
-  - `scripts/generate-cloudflare-devops-toolkit-v2.sh`
-  - Missing closing quote in `chmod +x "$TOOLKIT/install.sh"`.
-
-## Local Run (quick start)
-
-### 1) Prerequisites
-
-- Docker + Docker Compose
-- Node.js + npm
-- Python 3 + venv
-
-### 2) Bootstrap
+## Usage
 
 ```bash
-bash start-zttato.sh
+./start.sh
 ```
 
-This script:
-- makes scripts executable,
-- installs service dependencies,
-- starts postgres/redis,
-- builds/starts compose services,
-- applies SQL migrations,
-- starts worker scripts,
-- runs basic health checks.
-
-## Manual Checks
+Health status:
 
 ```bash
-# Shell syntax
-while IFS= read -r f; do bash -n "$f"; done < <(rg --files -g '*.sh')
-
-# Python syntax
-python -m compileall services
-
-# package.json validity
-while IFS= read -r f; do python -m json.tool "$f" >/dev/null; done < <(rg --files -g 'package.json')
+docker compose ps
 ```
 
-## Notes
-
-- Docker runtime checks (such as `docker compose config`) require Docker CLI in the environment.
-- Cloudflare scripts require a valid API token/account/zone configuration.
-AI-powered Affiliate Automation Platform for product discovery, AI content generation, campaign automation, and analytics.
-
-## Features
-
-- AI viral video prediction
-- Automated AI video generation
-- Distributed GPU rendering
-- Multi-marketplace product crawling
-- Affiliate arbitrage detection
-- Click tracking and campaign analytics
-- Automation farm scheduling
-- Admin dashboard
-- Docker and Kubernetes deployment support
-
-## Architecture
-
-Crawler → AI → Video → Automation → Analytics
-
-For details, see:
-
-- [docs/system-overview.md](docs/system-overview.md)
-- [docs/architecture.md](docs/architecture.md)
-
-## Quick Start
+Stop the stack:
 
 ```bash
-./start-zttato.sh
+./stop.sh
 ```
 
-## Web Dashboard
+## Endpoints
 
-- Admin panel: http://localhost:5173
+- `http://SERVER/predict`
+- `http://SERVER/crawl`
+- `http://SERVER/arbitrage`
 
-## Documentation Index
-
-- [CHANGELOG.md](CHANGELOG.md)
-- [docs/project-structure.md](docs/project-structure.md)
-- [docs/installation.md](docs/installation.md)
-- [docs/quick-start.md](docs/quick-start.md)
-- [docs/configuration.md](docs/configuration.md)
-- [docs/services/](docs/services)
-- [docs/api/](docs/api)
-- [docs/database/](docs/database)
-- [docs/infrastructure/](docs/infrastructure)
-- [docs/development/](docs/development)
-- [docs/operations/](docs/operations)
-
-## Import to GitHub
-
-1. Create an empty GitHub repository.
-2. Add remote:
+## Scale workers
 
 ```bash
-git remote add origin git@github.com:<org-or-user>/zttato-platform.git
+docker compose up -d --scale crawler-worker=5
 ```
 
-3. Push current branch:
+## Backup
 
 ```bash
-git push -u origin "$(git branch --show-current)"
-```
-
-If `origin` already exists, update it:
-
-```bash
-git remote set-url origin git@github.com:<org-or-user>/zttato-platform.git
-git push -u origin "$(git branch --show-current)"
+pg_dump -U zttato zttato > backup.sql
 ```

--- a/configs/env/production.env
+++ b/configs/env/production.env
@@ -1,0 +1,11 @@
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=zttato
+DB_USER=zttato
+DB_PASSWORD=zttato
+
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+API_HOST=0.0.0.0
+ENV=production

--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -1,0 +1,48 @@
+events {}
+
+http {
+  upstream predictor {
+    server viral-predictor:9100;
+  }
+
+  upstream crawler {
+    server market-crawler:9400;
+  }
+
+  upstream arbitrage {
+    server arbitrage-engine:9500;
+  }
+
+  server {
+    listen 80;
+
+    location = / {
+      return 200 'zTTato platform proxy is healthy';
+      add_header Content-Type text/plain;
+    }
+
+    location /predict {
+      proxy_pass http://predictor;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /crawl {
+      proxy_pass http://crawler;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /arbitrage {
+      proxy_pass http://arbitrage;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,46 +1,212 @@
+version: "3.9"
+
+name: zttato-platform
 
 services:
-
   postgres:
-    image: postgres:17
+    image: postgres:15.8
+    container_name: zttato-postgres
+    restart: always
     environment:
-      POSTGRES_DB: zttato
-      POSTGRES_USER: zttato
-      POSTGRES_PASSWORD: zttato
-    ports:
-      - "5432:5432"
+      POSTGRES_DB: ${DB_NAME:-zttato}
+      POSTGRES_USER: ${DB_USER:-zttato}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-zttato}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./infrastructure/postgres/migrations:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-zttato} -d ${DB_NAME:-zttato}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - zttato-net
 
   redis:
-    image: redis:7.4
-    ports:
-      - "6379:6379"
+    image: redis:7.4.0
+    container_name: zttato-redis
+    restart: always
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - zttato-net
 
   viral-predictor:
-    build: services/viral-predictor
+    build:
+      context: ./services/viral-predictor
+      dockerfile: Dockerfile
+    container_name: zttato-viral-predictor
+    restart: always
+    env_file: .env
     environment:
-      DB_URL: ${DB_URL}
-    ports:
-      - "9100:9100"
-
-  gpu-renderer:
-    build: services/gpu-renderer
-    environment:
-      REDIS_URL: ${REDIS_URL}
-    ports:
-      - "9300:9300"
+      DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9100),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
 
   market-crawler:
-    build: services/market-crawler
+    build:
+      context: ./services/market-crawler
+      dockerfile: Dockerfile
+    container_name: zttato-market-crawler
+    restart: always
+    env_file: .env
     environment:
-      DB_URL: ${DB_URL}
-      REDIS_URL: ${REDIS_URL}
-    ports:
-      - "9400:9400"
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+      DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9400),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
 
   arbitrage-engine:
-    build: services/arbitrage-engine
+    build:
+      context: ./services/arbitrage-engine
+      dockerfile: Dockerfile
+    container_name: zttato-arbitrage-engine
+    restart: always
+    env_file: .env
     environment:
-      DB_URL: ${DB_URL}
-    ports:
-      - "9500:9500"
+      DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9500),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
 
+  gpu-renderer:
+    build:
+      context: ./services/gpu-renderer
+      dockerfile: Dockerfile
+    container_name: zttato-gpu-renderer
+    restart: always
+    env_file: .env
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9300),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  crawler-worker:
+    build:
+      context: ./services/market-crawler
+      dockerfile: Dockerfile
+    container_name: zttato-crawler-worker
+    restart: always
+    env_file: .env
+    command: ["python", "src/workers/worker.py"]
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+      DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - zttato-net
+
+  arbitrage-worker:
+    build:
+      context: ./services/arbitrage-engine
+      dockerfile: Dockerfile
+    container_name: zttato-arbitrage-worker
+    restart: always
+    env_file: .env
+    command: ["python", "src/workers/worker.py"]
+    environment:
+      DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - zttato-net
+
+  renderer-worker:
+    build:
+      context: ./services/gpu-renderer
+      dockerfile: Dockerfile
+    container_name: zttato-renderer-worker
+    restart: always
+    env_file: .env
+    command: ["python", "src/worker/worker.py"]
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - zttato-net
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: zttato-nginx
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - ./configs/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      viral-predictor:
+        condition: service_healthy
+      market-crawler:
+        condition: service_healthy
+      arbitrage-engine:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1/ || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - zttato-net
+
+networks:
+  zttato-net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker/nginx/.gitkeep
+++ b/docker/nginx/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder

--- a/docker/postgres/.gitkeep
+++ b/docker/postgres/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder

--- a/services/arbitrage-engine/Dockerfile
+++ b/services/arbitrage-engine/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.12-slim
+FROM python:3.12.8-slim
 
 WORKDIR /app
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt || true
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src ./src
 

--- a/services/gpu-renderer/Dockerfile
+++ b/services/gpu-renderer/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.12-slim
+FROM python:3.12.8-slim
 
 WORKDIR /app
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt || true
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src ./src
 

--- a/services/market-crawler/Dockerfile
+++ b/services/market-crawler/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.12-slim
+FROM python:3.12.8-slim
 
 WORKDIR /app
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt || true
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src ./src
 

--- a/services/viral-predictor/Dockerfile
+++ b/services/viral-predictor/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.12-slim
+FROM python:3.12.8-slim
 
 WORKDIR /app
 
 COPY requirements.txt .
 
-RUN pip install --no-cache-dir -r requirements.txt || true
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src ./src
 

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Starting zTTato Platform (production profile)..."
+docker compose pull
+docker compose build --pull
+docker compose up -d --remove-orphans
+
+echo "Platform started."
+docker compose ps

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker compose down

--- a/workers/arbitrage-worker/.gitkeep
+++ b/workers/arbitrage-worker/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder

--- a/workers/crawler-worker/.gitkeep
+++ b/workers/crawler-worker/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder

--- a/workers/renderer-worker/.gitkeep
+++ b/workers/renderer-worker/.gitkeep
@@ -1,0 +1,1 @@
+# placeholder


### PR DESCRIPTION
### Motivation
- Provide a deterministic, production-ready layout to run the platform with isolated containers, persistent DB/Redis volumes, containerized workers, reverse-proxy routing, and health checks.
- Replace ad-hoc local-compose settings with a curated orchestration manifest and lifecycle scripts to make deploys repeatable and observable.

### Description
- Replaced/rewrote `docker-compose.yml` to a production profile with a dedicated `zttato-net` bridge network, persistent volumes, service healthchecks, `depends_on` gating, and dedicated worker services for crawler/arbitrage/renderer.
- Added `configs/nginx.conf` implementing upstreams for `viral-predictor`, `market-crawler`, and `arbitrage-engine` plus a root health response and proxy headers for `/predict`, `/crawl`, and `/arbitrage`.
- Added environment templates (`.env` and `configs/env/production.env`) and lifecycle scripts `start.sh` and `stop.sh` that run `docker compose pull`, `docker compose build`, `docker compose up -d` and `docker compose down` respectively.
- Updated service Dockerfiles for `viral-predictor`, `market-crawler`, `arbitrage-engine`, and `gpu-renderer` to pin the Python base image to `python:3.12.8-slim` and remove permissive `|| true` pip fallbacks, and added placeholder directories under `docker/` and `workers/` plus README updates documenting the layout and endpoints.

### Testing
- Ran shell syntax checks for the lifecycle scripts with `bash -n start.sh && bash -n stop.sh`, which succeeded. 
- Attempted `docker compose config` to validate the compose manifest but the Docker CLI is not available in this environment so the check could not be executed. 
- Attempted `nginx -t -c $(pwd)/configs/nginx.conf` to validate the Nginx config but the `nginx` binary is not available in this environment so the check could not be executed. 
- Attempted to parse the Compose YAML with a small Python snippet but `PyYAML` is not installed in the environment, so that check could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b455584dc08321bfb0a63e76cf60c6)