### PR TITLE
Add /healthz endpoints, integration smoke test, and docs/roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ zttato-platform
 └─ README.md
 ```
 
+
+## Project status and recommended next additions
+
+- Thai summary and implementation-ready roadmap: `docs/development/current-status-and-next-steps.md`
+- Health endpoint catalog: `docs/operations/health-checks.md`
+- Integration smoke test script: `scripts/test-integration.sh`
+
 ## Usage
 
 ```bash

--- a/docs/development/current-status-and-next-steps.md
+++ b/docs/development/current-status-and-next-steps.md
@@ -1,0 +1,124 @@
+# สรุปสถานะปัจจุบันและสิ่งที่ควรเพิ่มต่อ (Current Status & Next Steps)
+
+เอกสารนี้สรุปว่า **ตอนนี้ระบบมีอะไรแล้ว** และเสนอว่า **ควรเพิ่มอะไรต่อเป็นลำดับถัดไป** พร้อมตัวอย่างงานที่เริ่มทำได้ทันที
+
+## 0) สิ่งที่เพิ่มเข้ามาแล้วในรอบนี้
+
+เพื่อให้เริ่มใช้งานได้ทันที มีการเพิ่มพื้นฐานชุดแรกแล้ว:
+
+- เพิ่มเอกสาร health checks: `docs/operations/health-checks.md`
+- เพิ่มสคริปต์ integration smoke test: `scripts/test-integration.sh`
+- เพิ่ม `/healthz` endpoint ใน API services หลัก: `viral-predictor`, `market-crawler`, `arbitrage-engine`, `gpu-renderer`
+
+## 1) ตอนนี้เราเขียนอะไรไปแล้วบ้าง
+
+จากโครงสร้างโปรเจกต์และเอกสารปัจจุบัน แพลตฟอร์มมีองค์ประกอบหลักครบระดับ Foundation แล้ว:
+
+- โครงสร้างเป็น Microservices หลายตัว เช่น `viral-predictor`, `market-crawler`, `gpu-renderer`, `arbitrage-engine`, `analytics`, `account-farm`, `tiktok-uploader` และ `ai-video-generator`
+- มี Infrastructure ระดับใช้งานจริง: Docker Compose, PostgreSQL migrations, Kubernetes manifests, CI/deploy scripts
+- มีเอกสารครอบคลุมหลายมุม: สถาปัตยกรรม, การติดตั้ง, การปฏิบัติการ (logging/monitoring/backup), และ API overview
+- มีสคริปต์ช่วย run/repair/deploy จำนวนมากใน `scripts/` และ `infrastructure/scripts/`
+
+> สรุปสั้น: สถานะตอนนี้คือ “ระบบฐานพร้อมใช้งานและขยายต่อได้” แต่ยังขาดส่วน “การบูรณาการและคุณภาพการผลิต (production quality gates)” บางส่วน
+
+## 2) ควรเพิ่มอะไรต่อ (เรียงตามความคุ้มค่า)
+
+## Priority 1: ทำให้ระบบตรวจสอบสุขภาพได้ครบทุก service
+
+**เป้าหมาย:** ทุก service ควรมี endpoint เช่น `/healthz` และมีมาตรฐาน response เดียวกัน
+
+สิ่งที่ต้องเพิ่ม:
+
+1. เพิ่ม health endpoint ที่ตอบสถานะ dependency สำคัญ (DB/queue/external API)
+2. รวม health check เข้ากับ `docker-compose.yml` และถ้ามี k8s ให้ใส่ readiness/liveness probes
+3. สร้างหน้าเอกสารกลางที่บอกว่า endpoint สุขภาพของแต่ละ service คืออะไร
+
+ผลลัพธ์ที่ได้ทันที:
+- ลดเวลาหาสาเหตุตอนระบบล่ม
+- Auto-restart ทำงานได้แม่นยำขึ้น
+
+## Priority 2: เพิ่ม “Integration Test แบบเส้นทางหลัก”
+
+**เป้าหมาย:** ทดสอบ flow สำคัญตั้งแต่รับ request จนถึงบันทึกผลลัพธ์
+
+สิ่งที่ต้องเพิ่ม:
+
+1. เลือก 2-3 เส้นทางหลัก เช่น
+   - `market-crawler -> analytics`
+   - `tiktok-uploader -> analytics`
+   - `ai-video-generator -> gpu-renderer`
+2. ทำ test harness ที่รันด้วย Docker Compose profile test
+3. เพิ่มคำสั่งทดสอบกลาง เช่น `./scripts/test-integration.sh`
+
+ผลลัพธ์ที่ได้ทันที:
+- มั่นใจขึ้นเวลา merge/upgrade dependency
+- ลด incident จาก service contract ที่เปลี่ยนโดยไม่ตั้งใจ
+
+## Priority 3: เพิ่ม API contract และ schema validation
+
+**เป้าหมาย:** ลด bug จาก payload ไม่ตรงรูปแบบ
+
+สิ่งที่ต้องเพิ่ม:
+
+1. กำหนด JSON schema/OpenAPI สำหรับ endpoint หลัก
+2. Validate request/response ฝั่ง API
+3. เพิ่ม contract tests ระหว่าง service ที่คุยกันบ่อย
+
+ผลลัพธ์ที่ได้ทันที:
+- ทีมพัฒนาเชื่อม service กันง่ายขึ้น
+- เอกสาร API อัปเดตตามโค้ดได้จริง
+
+## Priority 4: ทำ Observability ให้ครบ trace + metrics + structured logs
+
+**เป้าหมาย:** รู้ให้ได้ว่า request หนึ่งวิ่งผ่าน service ไหนบ้างและช้าเพราะอะไร
+
+สิ่งที่ต้องเพิ่ม:
+
+1. Correlation ID กลางในทุก service
+2. Structured logging รูปแบบเดียวกัน (JSON + fields มาตรฐาน)
+3. Metrics dashboard ชุดเดียวสำหรับ latency/error rate/throughput
+
+## Priority 5: Security baseline ที่ enforce ได้จริง
+
+**เป้าหมาย:** ลดความเสี่ยงเชิงระบบก่อนโต
+
+สิ่งที่ต้องเพิ่ม:
+
+1. Secrets management (ย้ายค่าลับออกจากไฟล์ plain env)
+2. Dependency scanning ใน CI
+3. Image scanning + minimum base image hardening
+4. Rate limiting และ auth policy สำหรับ endpoint ที่เสี่ยง
+
+## 3) ตัวอย่างแผน 2 สัปดาห์ (เริ่มได้เลย)
+
+### Week 1
+- สร้างมาตรฐาน `/healthz` ทุก service
+- ต่อ health check เข้า compose/k8s
+- เขียนเอกสาร endpoint สุขภาพรวม
+
+### Week 2
+- ทำ integration test เส้นทางหลักอย่างน้อย 2 flow
+- เพิ่ม schema validation ให้ endpoint สำคัญ 3 จุด
+- ใส่ CI gate: ถ้า integration test fail ให้ block merge
+
+## 4) Definition of Done (DoD) ที่แนะนำ
+
+งานแต่ละ service ถือว่าเสร็จเมื่อ:
+
+- มี health endpoint และผ่าน check อัตโนมัติ
+- มี integration test อย่างน้อย 1 เคสต่อเส้นทางหลัก
+- มี schema validation สำหรับ request สำคัญ
+- มี structured logs พร้อม correlation id
+- มีเอกสารอัปเดตใน `docs/services/*.md`
+
+## 5) Backlog พร้อมหยิบทำ (Ready-to-implement)
+
+1. สร้างไฟล์ `docs/operations/health-checks.md` รวบรวม endpoint สุขภาพทั้งหมด
+2. เพิ่มสคริปต์ `scripts/test-integration.sh` สำหรับรัน smoke/integration test
+3. เพิ่ม CI job `integration-test` ใน pipeline
+4. อัปเดต `docs/api/api-overview.md` ให้มีตัวอย่าง payload ที่ตรวจ schema แล้ว
+5. เพิ่มเอกสาร runbook incident สั้น ๆ ต่อ service ใน `docs/operations/`
+
+---
+
+หากต้องการต่อยอดทันที แนะนำเริ่มจาก **Priority 1 + Priority 2** ก่อน เพราะได้ผลด้านเสถียรภาพเร็วที่สุดและลดปัญหาตอน deploy จริงอย่างชัดเจน

--- a/docs/operations/health-checks.md
+++ b/docs/operations/health-checks.md
@@ -1,0 +1,44 @@
+# Health Checks
+
+เอกสารนี้รวบรวม health endpoints มาตรฐานของบริการหลักใน stack และวิธีตรวจสอบแบบเร็ว
+
+## Service health endpoints
+
+| Service | Container Port | Endpoint | Dependency check |
+|---|---:|---|---|
+| viral-predictor | 9100 | `/healthz` | PostgreSQL (`select 1`) |
+| market-crawler | 9400 | `/healthz` | Redis (`PING`) |
+| arbitrage-engine | 9500 | `/healthz` | PostgreSQL (`select 1`) |
+| gpu-renderer | 9300 | `/healthz` | Redis (`PING`) |
+| nginx (edge proxy) | 80 | `/` | Proxy process alive |
+
+## Quick checks
+
+เมื่อ stack รันด้วย `docker compose up -d`:
+
+```bash
+docker compose ps
+```
+
+ตรวจ endpoint ผ่านเครือข่ายภายใน compose:
+
+```bash
+docker compose exec -T nginx wget -qO- http://viral-predictor:9100/healthz
+docker compose exec -T nginx wget -qO- http://market-crawler:9400/healthz
+docker compose exec -T nginx wget -qO- http://arbitrage-engine:9500/healthz
+docker compose exec -T nginx wget -qO- http://gpu-renderer:9300/healthz
+```
+
+## Integration smoke test
+
+ใช้สคริปต์กลาง:
+
+```bash
+./scripts/test-integration.sh
+```
+
+สคริปต์นี้จะ:
+
+1. รัน `docker compose up -d` (เฉพาะบริการหลัก)
+2. ตรวจว่า services สำคัญอยู่ในสถานะ `running`
+3. ยิง smoke tests ที่ endpoint proxy (`/`, `/predict`, `/crawl`, `/arbitrage`)

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_CMD=(docker compose)
+BASE_URL="${BASE_URL:-http://127.0.0.1:80}"
+SERVICES=(postgres redis viral-predictor market-crawler arbitrage-engine gpu-renderer nginx)
+
+log() {
+  printf '[integration] %s\n' "$*"
+}
+
+assert_running() {
+  local svc="$1"
+  local state
+  state="$(${COMPOSE_CMD[@]} ps --format json "$svc" | python -c 'import json,sys; data=json.load(sys.stdin); print(data[0]["State"] if data else "missing")')"
+
+  if [[ "$state" != "running" ]]; then
+    log "service '$svc' is not running (state=$state)"
+    return 1
+  fi
+
+  log "service '$svc' is running"
+}
+
+assert_http_2xx() {
+  local method="$1"
+  local url="$2"
+  local body="${3:-}"
+  local code
+
+  if [[ -n "$body" ]]; then
+    code="$(curl -sS -o /dev/null -w '%{http_code}' -X "$method" -H 'content-type: application/json' -d "$body" "$url")"
+  else
+    code="$(curl -sS -o /dev/null -w '%{http_code}' -X "$method" "$url")"
+  fi
+
+  if [[ "$code" -lt 200 || "$code" -ge 300 ]]; then
+    log "request failed: $method $url (http=$code)"
+    return 1
+  fi
+
+  log "request ok: $method $url (http=$code)"
+}
+
+log "starting compose stack"
+${COMPOSE_CMD[@]} up -d
+
+log "checking service process state"
+for svc in "${SERVICES[@]}"; do
+  assert_running "$svc"
+done
+
+log "running HTTP smoke tests via nginx"
+assert_http_2xx GET "$BASE_URL/"
+assert_http_2xx POST "$BASE_URL/predict" '{"views":1000,"likes":100,"comments":10,"shares":5}'
+assert_http_2xx POST "$BASE_URL/crawl" '{"keyword":"wireless earbud"}'
+assert_http_2xx GET "$BASE_URL/arbitrage"
+
+log "integration smoke test passed"

--- a/services/arbitrage-engine/src/api/server.py
+++ b/services/arbitrage-engine/src/api/server.py
@@ -7,20 +7,42 @@ app = FastAPI()
 
 
 def get_db():
-    return psycopg2.connect(os.environ["DB_URL"])
+    return psycopg2.connect(os.environ['DB_URL'])
 
 
-@app.get("/arbitrage")
+@app.get('/healthz')
+def healthz():
+    db_ok = False
+
+    try:
+        with get_db() as db:
+            with db.cursor() as cur:
+                cur.execute('select 1')
+                cur.fetchone()
+        db_ok = True
+    except Exception:
+        db_ok = False
+
+    return {
+        'status': 'ok' if db_ok else 'degraded',
+        'service': 'arbitrage-engine',
+        'checks': {
+            'db': db_ok,
+        },
+    }
+
+
+@app.get('/arbitrage')
 def list_events():
     with get_db() as db:
         with db.cursor() as cur:
             cur.execute(
-                """
+                '''
                 select product_name,buy_source,sell_source,profit
                 from arbitrage_events
                 order by profit desc
                 limit 50
-                """
+                '''
             )
             rows = cur.fetchall()
 
@@ -28,10 +50,10 @@ def list_events():
     for r in rows:
         result.append(
             {
-                "product": r[0],
-                "buy": r[1],
-                "sell": r[2],
-                "profit": float(r[3]),
+                'product': r[0],
+                'buy': r[1],
+                'sell': r[2],
+                'profit': float(r[3]),
             }
         )
 

--- a/services/gpu-renderer/src/api/server.py
+++ b/services/gpu-renderer/src/api/server.py
@@ -1,17 +1,39 @@
+import os
+
+import redis
 from fastapi import FastAPI
 from pydantic import BaseModel
+
 from core.queue import enqueue
 
 app = FastAPI()
 
+
 class Job(BaseModel):
-    input:str
-    output:str
+    input: str
+    output: str
 
-@app.post("/render")
 
-def render_video(job:Job):
+@app.get('/healthz')
+def healthz():
+    redis_ok = False
 
+    try:
+        redis_client = redis.Redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379'))
+        redis_ok = bool(redis_client.ping())
+    except Exception:
+        redis_ok = False
+
+    return {
+        'status': 'ok' if redis_ok else 'degraded',
+        'service': 'gpu-renderer',
+        'checks': {
+            'redis': redis_ok,
+        },
+    }
+
+
+@app.post('/render')
+def render_video(job: Job):
     enqueue(job.dict())
-
-    return {"status":"queued"}
+    return {'status': 'queued'}

--- a/services/market-crawler/src/api/server.py
+++ b/services/market-crawler/src/api/server.py
@@ -1,3 +1,6 @@
+import os
+
+import redis
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -5,13 +8,31 @@ from core.queue import enqueue
 
 app = FastAPI()
 
+
 class CrawlJob(BaseModel):
-    keyword:str
+    keyword: str
 
-@app.post("/crawl")
 
-def crawl(job:CrawlJob):
+@app.get('/healthz')
+def healthz():
+    redis_ok = False
 
+    try:
+        redis_client = redis.Redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379'))
+        redis_ok = bool(redis_client.ping())
+    except Exception:
+        redis_ok = False
+
+    return {
+        'status': 'ok' if redis_ok else 'degraded',
+        'service': 'market-crawler',
+        'checks': {
+            'redis': redis_ok,
+        },
+    }
+
+
+@app.post('/crawl')
+def crawl(job: CrawlJob):
     enqueue(job.dict())
-
-    return {"status":"queued"}
+    return {'status': 'queued'}

--- a/services/viral-predictor/src/api/server.py
+++ b/services/viral-predictor/src/api/server.py
@@ -1,3 +1,6 @@
+import os
+
+import psycopg2
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -8,21 +11,41 @@ app = FastAPI()
 
 
 class Video(BaseModel):
+    views: int
+    likes: int
+    comments: int
+    shares: int
 
-    views:int
-    likes:int
-    comments:int
-    shares:int
+
+@app.get('/healthz')
+def healthz():
+    db_url = os.environ.get('DB_URL')
+    db_ok = False
+
+    if db_url:
+        try:
+            with psycopg2.connect(db_url) as db:
+                with db.cursor() as cur:
+                    cur.execute('select 1')
+                    cur.fetchone()
+            db_ok = True
+        except Exception:
+            db_ok = False
+
+    return {
+        'status': 'ok',
+        'service': 'viral-predictor',
+        'checks': {
+            'db': db_ok,
+        },
+    }
 
 
-@app.post("/predict")
-
-def predict_viral(video:Video):
-
+@app.post('/predict')
+def predict_viral(video: Video):
     features = extract_features(video.dict())
-
     score = predict(features)
 
     return {
-        "viral_score":score
+        'viral_score': score,
     }


### PR DESCRIPTION
### Motivation

- Provide standard health checks for core services so orchestration (compose/k8s) and operators can detect degraded dependencies.
- Add a lightweight integration smoke test to verify the main HTTP flows and service liveness after stack bring-up.
- Capture current status and next implementation steps in project docs to guide short-term priorities.

### Description

- Added `/healthz` endpoints to `viral-predictor`, `market-crawler`, `arbitrage-engine`, and `gpu-renderer` that perform dependency checks (Postgres `select 1` or Redis `PING`) and return a structured status payload.
- Introduced `scripts/test-integration.sh`, an executable smoke test that brings up the compose stack, checks container states, and exercises `/, /predict, /crawl, /arbitrage` through the proxy.
- Added operational and planning documentation: `docs/operations/health-checks.md` (service endpoints and quick checks) and `docs/development/current-status-and-next-steps.md` (Thai roadmap and prioritized backlog), and updated `README.md` to surface the new docs and test script.
- Minor code cleanups and formatting in service server files (consistent string quoting, Pydantic model spacing, reordering imports) and ensured the new health checks import required clients (`psycopg2`, `redis`) where needed.

### Testing

- No automated CI tests were executed as part of this change; this PR adds the smoke test script `scripts/test-integration.sh` to be wired into CI as an `integration-test` job in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b45e2e7b1c8321b40f910f07c33bfe)