### PR TITLE
Fix worker DNS failures by scoping compose DB/REDIS URLs

### DIFF
--- a/start-zttato.sh
+++ b/start-zttato.sh
@@ -90,9 +90,10 @@ echo ""
 echo "Starting infrastructure..."
 docker compose up -d postgres redis
 
-# Ensure compose services get container-resolvable URLs
-export DB_URL="${CONTAINER_DB_URL:-postgresql://zttato:zttato@postgres:5432/zttato}"
-export REDIS_URL="${CONTAINER_REDIS_URL:-redis://redis:6379}"
+# Ensure compose services get container-resolvable URLs without leaking
+# container-only hostnames into locally executed workers.
+COMPOSE_DB_URL="${CONTAINER_DB_URL:-postgresql://zttato:zttato@postgres:5432/zttato}"
+COMPOSE_REDIS_URL="${CONTAINER_REDIS_URL:-redis://redis:6379}"
 
 sleep 6
 
@@ -102,7 +103,7 @@ sleep 6
 
 echo ""
 echo "Building services..."
-docker compose build
+DB_URL="$COMPOSE_DB_URL" REDIS_URL="$COMPOSE_REDIS_URL" docker compose build
 
 ################################
 # Start services
@@ -110,7 +111,7 @@ docker compose build
 
 echo ""
 echo "Starting services..."
-docker compose up -d
+DB_URL="$COMPOSE_DB_URL" REDIS_URL="$COMPOSE_REDIS_URL" docker compose up -d
 
 ################################
 # Run DB migrations


### PR DESCRIPTION
### Motivation
- Local Python workers were inheriting container-only hostnames (`postgres`, `redis`) via exported `DB_URL`/`REDIS_URL`, causing DNS resolution errors when run outside the Docker network.

### Description
- Stop exporting container-only `DB_URL`/`REDIS_URL` from `start-zttato.sh` and introduce `COMPOSE_DB_URL` and `COMPOSE_REDIS_URL` to hold compose-specific values.
- Pass the compose URLs inline to `docker compose build` and `docker compose up -d` so only compose processes see container DNS names.
- This prevents locally started workers (via `infrastructure/start/workers.sh`) from inheriting `postgres`/`redis` hostnames that are not resolvable from the host.
- Modified file: `start-zttato.sh`.

### Testing
- Ran `bash -n start-zttato.sh` to validate script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b52cbb14708321b2332c452e2134cc)