### PR TITLE
Make migrations idempotent and skip host workers by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: zttato-platform
 
 services:

--- a/infrastructure/postgres/migrations/001_schema.sql
+++ b/infrastructure/postgres/migrations/001_schema.sql
@@ -3,7 +3,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 
 
-CREATE TABLE accounts (
+CREATE TABLE IF NOT EXISTS accounts (
 
 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
 
@@ -21,7 +21,7 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE TABLE proxies (
+CREATE TABLE IF NOT EXISTS proxies (
 
 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
 
@@ -39,7 +39,7 @@ active BOOLEAN DEFAULT TRUE
 
 
 
-CREATE TABLE products (
+CREATE TABLE IF NOT EXISTS products (
 
 id BIGINT PRIMARY KEY,
 
@@ -59,7 +59,7 @@ created_at TIMESTAMP DEFAULT NOW()
 
 );
 
-create table arbitrage_events (
+CREATE TABLE IF NOT EXISTS arbitrage_events (
 
 id serial primary key,
 
@@ -80,7 +80,7 @@ created_at timestamp default now()
 );
 
 
-CREATE TABLE tiktok_products (
+CREATE TABLE IF NOT EXISTS tiktok_products (
 
 id BIGINT PRIMARY KEY,
 
@@ -100,7 +100,7 @@ updated_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE TABLE campaigns (
+CREATE TABLE IF NOT EXISTS campaigns (
 
 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
 
@@ -114,7 +114,7 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE TABLE videos (
+CREATE TABLE IF NOT EXISTS videos (
 
 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
 
@@ -132,7 +132,7 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE TABLE jobs (
+CREATE TABLE IF NOT EXISTS jobs (
 
 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
 
@@ -146,7 +146,7 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE TABLE clicks (
+CREATE TABLE IF NOT EXISTS clicks (
 
 id BIGSERIAL PRIMARY KEY,
 
@@ -166,7 +166,7 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE TABLE orders (
+CREATE TABLE IF NOT EXISTS orders (
 
 id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
 
@@ -182,19 +182,19 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
-CREATE INDEX idx_click_campaign
+CREATE INDEX IF NOT EXISTS idx_click_campaign
 
 ON clicks(campaign_id);
 
 
 
-CREATE INDEX idx_orders_campaign
+CREATE INDEX IF NOT EXISTS idx_orders_campaign
 
 ON orders(campaign_id);
 
 
 
-CREATE INDEX idx_products_sales
+CREATE INDEX IF NOT EXISTS idx_products_sales
 
 ON products(sold);
 

--- a/start-zttato.sh
+++ b/start-zttato.sh
@@ -137,8 +137,13 @@ fi
 echo ""
 echo "Starting background workers..."
 
-if [ -f "$ROOT/infrastructure/start/workers.sh" ]; then
-  bash "$ROOT/infrastructure/start/workers.sh"
+if [ "${START_LOCAL_WORKERS:-false}" = "true" ]; then
+  if [ -f "$ROOT/infrastructure/start/workers.sh" ]; then
+    bash "$ROOT/infrastructure/start/workers.sh"
+  fi
+else
+  echo "Skipping local worker processes (containers already run worker services)."
+  echo "Set START_LOCAL_WORKERS=true to run host-based workers."
 fi
 
 ################################


### PR DESCRIPTION
### Motivation
- Startup logs showed repeated migration errors (`relation "..." already exists`) when the bootstrap ran multiple times.
- Host-launched Python workers crashed trying to connect to `localhost` services while the stack ran in Docker containers, producing noisy `Connection refused` traces.
- Docker Compose emitted an obsolete `version` key warning that could confuse users.

### Description
- Made all `CREATE TABLE` and `CREATE INDEX` statements in `infrastructure/postgres/migrations/001_schema.sql` idempotent by adding `IF NOT EXISTS` so re-running migrations no longer errors.
- Updated `start-zttato.sh` to skip launching host-based workers by default and added an opt-in `START_LOCAL_WORKERS=true` flag to run host workers when intentionally desired.
- Removed the obsolete `version` key from `docker-compose.yml` to eliminate the Compose warning.

### Testing
- Ran `bash -n start-zttato.sh` to verify the startup script parses correctly, which succeeded.
- Verified there are no remaining non-idempotent `CREATE TABLE`/`CREATE INDEX` statements using a `rg` check against `infrastructure/postgres/migrations/001_schema.sql`, which reported no matches.
- Attempted to run `docker compose config` to validate the compose file but the Docker CLI was unavailable in the execution environment, so full compose validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58825b7d08321b29c6971a95f582a)