### PR TITLE
Fix worker PYTHONPATH to stop restart loops and add wildcard *.zeaz.dev tunnel routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,7 @@ services:
     env_file: .env
     command: ["python", "src/workers/worker.py"]
     environment:
+      PYTHONPATH: /app/src
       REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
       DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
     depends_on:
@@ -151,6 +152,7 @@ services:
     env_file: .env
     command: ["python", "src/workers/worker.py"]
     environment:
+      PYTHONPATH: /app/src
       DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
       REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
     depends_on:
@@ -170,6 +172,7 @@ services:
     env_file: .env
     command: ["python", "src/worker/worker.py"]
     environment:
+      PYTHONPATH: /app/src
       REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
     depends_on:
       redis:

--- a/scripts/install-zeaz-edge-stack.sh
+++ b/scripts/install-zeaz-edge-stack.sh
@@ -138,6 +138,10 @@ cat > /tmp/tunnel-config.json <<EOF
         "service": "http://viral-predictor:9100"
       },
       {
+        "hostname": "*.zeaz.dev",
+        "service": "http://nginx:80"
+      },
+      {
         "service": "http_status:404"
       }
     ]
@@ -190,6 +194,7 @@ create_dns "zttato.zeaz.dev"
 create_dns "api.zeaz.dev"
 create_dns "gpu.zeaz.dev"
 create_dns "predict.zeaz.dev"
+create_dns "*.zeaz.dev"
 
 # ------------------------------------------------
 # Deploy Docker platform


### PR DESCRIPTION
### Motivation
- Worker containers were repeatedly restarting due to Python import resolution failures when launching `python src/...`, so the workers need a proper module search path.
- The Cloudflare Tunnel/ingress automation did not create a wildcard route/DNS for `*.zeaz.dev`, which prevents wildcard subdomains from reaching the local `nginx` service.

### Description
- Added `PYTHONPATH: /app/src` to the `environment` section of `crawler-worker`, `arbitrage-worker`, and `renderer-worker` in `docker-compose.yml` to allow `from core...` imports to resolve when workers run `python src/...`.
- Updated `scripts/install-zeaz-edge-stack.sh` to add an ingress rule routing `"*.zeaz.dev"` to `http://nginx:80` in the tunnel configuration JSON.
- Updated `scripts/install-zeaz-edge-stack.sh` to create a DNS record for `*.zeaz.dev` as a proxied CNAME to the tunnel (`$TUNNEL_ID.cfargotunnel.com`).

### Testing
- Ran shell syntax check `bash -n start-zttato.sh scripts/install-zeaz-edge-stack.sh`, which completed with no syntax errors.
- Byte-compiled worker Python files with `python -m py_compile services/market-crawler/src/workers/worker.py services/arbitrage-engine/src/workers/worker.py services/gpu-renderer/src/worker/worker.py`, which passed.
- Attempted external HTTPS checks with `curl -I https://{zeaz.dev,api.zeaz.dev,gpu.zeaz.dev,predict.zeaz.dev,test.zeaz.dev}`, which returned `403 CONNECT tunnel failed` due to this runner's network/egress/proxy limitations and therefore cannot be used to verify external Cloudflare edge behavior here.
- `docker` CLI was not available in this execution environment, so `docker ps`, `docker logs`, and `docker compose` validations could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58d16c7008321b6350912452737b0)