### PR TITLE
Fix edge scripts to use compose network and reliable service probes

### DIFF
--- a/scripts/deploy-zttato-production.sh
+++ b/scripts/deploy-zttato-production.sh
@@ -80,7 +80,11 @@ sleep 5
 echo
 echo "Checking docker network"
 
-NETWORK="zttato-platform_default"
+NETWORK="zttato-platform_zttato-net"
+
+if ! docker network inspect "$NETWORK" >/dev/null 2>&1; then
+    NETWORK="zttato-platform_default"
+fi
 
 if ! docker network inspect "$NETWORK" >/dev/null 2>&1; then
     echo "Creating docker network"

--- a/scripts/install-zeaz-edge-stack.sh
+++ b/scripts/install-zeaz-edge-stack.sh
@@ -220,9 +220,19 @@ echo "Starting cloudflared"
 
 docker rm -f zttato-cloudflared >/dev/null 2>&1 || true
 
+NETWORK="zttato-platform_zttato-net"
+if ! docker network inspect "$NETWORK" >/dev/null 2>&1; then
+    NETWORK="zttato-platform_default"
+fi
+
+if ! docker network inspect "$NETWORK" >/dev/null 2>&1; then
+    echo "ERROR: Could not find docker network for stack (checked zttato-platform_zttato-net and zttato-platform_default)"
+    exit 1
+fi
+
 docker run -d \
 --name zttato-cloudflared \
---network zttato-platform_default \
+--network "$NETWORK" \
 --restart unless-stopped \
 cloudflare/cloudflared:latest \
 tunnel --no-autoupdate run --token "$CF_TUNNEL_TOKEN"

--- a/scripts/zttato-edge-doctor.sh
+++ b/scripts/zttato-edge-doctor.sh
@@ -177,9 +177,16 @@ echo ""
 echo "Docker Network"
 echo "--------------------------------------"
 
-docker network inspect zttato-platform_default >/dev/null 2>&1 \
-  && echo "[OK] zttato-platform_default exists" \
-  || echo "[WARN] docker network missing"
+DOCKER_NETWORK="zttato-platform_zttato-net"
+if ! docker network inspect "$DOCKER_NETWORK" >/dev/null 2>&1; then
+  DOCKER_NETWORK="zttato-platform_default"
+fi
+
+if docker network inspect "$DOCKER_NETWORK" >/dev/null 2>&1; then
+  echo "[OK] $DOCKER_NETWORK exists"
+else
+  echo "[WARN] docker network missing (checked zttato-platform_zttato-net and zttato-platform_default)"
+fi
 
 ########################################
 # Internal Connectivity
@@ -196,11 +203,19 @@ SERVICES=(
 "viral-predictor:9100"
 )
 
+PROBE_CONTAINER="zttato-market-crawler"
+if ! docker ps --format '{{.Names}}' | grep -qx "$PROBE_CONTAINER"; then
+  PROBE_CONTAINER="zttato-arbitrage-engine"
+fi
+
 for s in "${SERVICES[@]}"; do
-  docker exec zttato-platform-market-crawler-1 \
-    wget -qO- "http://$s" >/dev/null 2>&1 \
-    && echo "[OK] $s reachable" \
-    || echo "[FAIL] $s unreachable"
+  host="${s%:*}"
+  port="${s#*:}"
+  if docker exec "$PROBE_CONTAINER" python -c "import socket; s=socket.create_connection(('$host',$port),3); s.close()" >/dev/null 2>&1; then
+    echo "[OK] $s reachable"
+  else
+    echo "[FAIL] $s unreachable"
+  fi
 done
 
 ########################################


### PR DESCRIPTION
### Motivation

- The edge installer and deploy logs showed Cloudflare Tunnel active but endpoints returning HTTP 530 and the edge doctor reporting internal services unreachable.
- Root causes identified: `zttato-cloudflared` was being attached to a hardcoded network name and the diagnostic probe used a stale container name plus an HTTP root fetch that can produce false negatives.
- The change ensures the tunnel runs on the actual Compose network and that internal connectivity checks are robust so the edge stack can be validated reliably.

### Description

- Update `scripts/install-zeaz-edge-stack.sh` to detect the Compose network by preferring `zttato-platform_zttato-net` and falling back to `zttato-platform_default`, and fail with a clear error if neither exists, then attach `zttato-cloudflared` to the selected network via `--network "$NETWORK"` instead of a hardcoded name.
- Update `scripts/deploy-zttato-production.sh` to use the same preferred network/fallback logic before connecting or starting the cloudflared container, keeping existing create/connect behavior.
- Update `scripts/zttato-edge-doctor.sh` to detect the active Docker network dynamically and replace the stale probe logic; the doctor now picks a real probe container (`zttato-market-crawler` with fallback `zttato-arbitrage-engine`) and performs direct TCP socket connectivity checks (via a short Python socket connect) against service ports to avoid false negatives from HTTP status responses.
- Commit message: `Fix edge scripts to use compose network and reliable service probes` (changes applied to the three scripts listed above).

### Testing

- Performed shell syntax validation with `bash -n` on `scripts/install-zeaz-edge-stack.sh`, `scripts/deploy-zttato-production.sh`, and `scripts/zttato-edge-doctor.sh`, which completed without syntax errors.
- Changes were committed locally (`git commit`) with the above message; further live end-to-end verification (running the installer/deploy and cloudflared runtime checks) requires the target host environment and Cloudflare credentials and was not executed as part of these automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b599e150a48321af6c950c0d4d8a10)