### PR TITLE
Fix Pydantic v1/v2 payload serialization in API handlers

### DIFF
--- a/services/gpu-renderer/src/api/server.py
+++ b/services/gpu-renderer/src/api/server.py
@@ -35,5 +35,6 @@ def healthz():
 
 @app.post('/render')
 def render_video(job: Job):
-    enqueue(job.dict())
+    payload = job.model_dump() if hasattr(job, "model_dump") else job.dict()
+    enqueue(payload)
     return {'status': 'queued'}

--- a/services/market-crawler/src/api/server.py
+++ b/services/market-crawler/src/api/server.py
@@ -34,5 +34,6 @@ def healthz():
 
 @app.post('/crawl')
 def crawl(job: CrawlJob):
-    enqueue(job.dict())
+    payload = job.model_dump() if hasattr(job, "model_dump") else job.dict()
+    enqueue(payload)
     return {'status': 'queued'}

--- a/services/viral-predictor/src/api/server.py
+++ b/services/viral-predictor/src/api/server.py
@@ -43,7 +43,8 @@ def healthz():
 
 @app.post('/predict')
 def predict_viral(video: Video):
-    features = extract_features(video.dict())
+    video_payload = video.model_dump() if hasattr(video, "model_dump") else video.dict()
+    features = extract_features(video_payload)
     score = predict(features)
 
     return {


### PR DESCRIPTION
### Motivation
- Ensure FastAPI request handlers remain compatible when running under Pydantic v2 by using `model_dump()` where available and falling back to `dict()` for older Pydantic versions to avoid serialization breaking changes before enqueueing or feature extraction.

### Description
- Update handlers to serialize request models via `job.model_dump() if hasattr(job, "model_dump") else job.dict()` (or `video.model_dump()` fallback) in `services/gpu-renderer/src/api/server.py`, `services/market-crawler/src/api/server.py`, and `services/viral-predictor/src/api/server.py`.

### Testing
- Ran `pytest -q` (no tests collected), `python -m compileall -q` for the modified files (succeeded), `node --check` across JS files (succeeded), and `bash -n` for shell scripts (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d8d3575c8321bcd029e7b2f7d2f9)