### PR TITLE
docs: add full operation manuals for user, admin, devops, and godmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ psql -U zttato zttato < backup.sql
 docs/development/current-status-and-next-steps.md
 docs/operations/health-checks.md
 scripts/test-integration.sh
+docs/manuals/user-manual.md
+docs/manuals/admin-manual.md
+docs/manuals/devops-manual.md
+docs/manuals/godmode-manual.md
 
 ---
 

--- a/docs/manuals/admin-manual.md
+++ b/docs/manuals/admin-manual.md
@@ -1,0 +1,150 @@
+# Admin Manual
+
+## 1. Purpose
+
+This manual is for platform administrators responsible for account access, operational control, and business-level governance.
+
+---
+
+## 2. Admin Responsibilities
+
+- Manage access to dashboard and role-scoped pages.
+- Coordinate campaign execution and review operational metrics.
+- Verify that core services and workers remain healthy.
+- Route incidents to DevOps when infrastructure intervention is required.
+
+---
+
+## 3. Environment Startup and Shutdown
+
+### Start platform
+
+```bash
+docker compose up -d
+```
+
+### Stop platform
+
+```bash
+docker compose down
+```
+
+### Check service state
+
+```bash
+docker compose ps
+```
+
+---
+
+## 4. Service Inventory to Monitor
+
+Administrators should recognize the core runtime set:
+
+- `postgres`
+- `redis`
+- `viral-predictor`
+- `market-crawler`
+- `arbitrage-engine`
+- `gpu-renderer`
+- `crawler-worker`
+- `arbitrage-worker`
+- `renderer-worker`
+- `nginx`
+
+---
+
+## 5. Operational Checks
+
+### 5.1 Health Snapshot
+
+```bash
+docker compose ps
+```
+
+Confirm each critical service is `running` and healthy where health checks exist.
+
+### 5.2 Logs
+
+```bash
+docker compose logs --tail=200 <service-name>
+```
+
+Use this to verify startup errors, queue stalls, or connectivity failures.
+
+### 5.3 API Reachability
+
+```bash
+curl -i http://localhost/predict
+curl -i http://localhost/crawl
+curl -i http://localhost/arbitrage
+```
+
+A non-network error response still confirms routing works.
+
+---
+
+## 6. Worker Operations
+
+Workers process background jobs and should be watched for throughput:
+
+- `crawler-worker`
+- `renderer-worker`
+- `arbitrage-worker`
+
+To scale workers when load increases:
+
+```bash
+docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale arbitrage-worker=2
+```
+
+Adjust based on queue depth and resource limits.
+
+---
+
+## 7. Data Protection and Recovery
+
+### Backup
+
+```bash
+pg_dump -U zttato zttato > backup.sql
+```
+
+### Restore
+
+```bash
+psql -U zttato zttato < backup.sql
+```
+
+Store backups securely with retention policy and access control.
+
+---
+
+## 8. Security Administration
+
+- Enforce least privilege for platform users.
+- Rotate credentials periodically (DB, app secrets, dashboard auth).
+- Keep `.env` and secret files outside public sharing channels.
+- Review unusual automation activity and account lockout patterns.
+
+---
+
+## 9. Incident Runbook (Admin Layer)
+
+1. Detect issue from dashboard/API/alerts.
+2. Confirm scope (single service or platform-wide).
+3. Gather evidence (`docker compose ps`, logs, affected endpoints).
+4. Apply safe restart if incident is transient.
+5. Escalate with collected artifacts to DevOps for infra-level fixes.
+
+---
+
+## 10. Change Governance
+
+- Document every production-affecting change.
+- Prefer staged rollout for significant behavior updates.
+- Validate critical flows after each deploy:
+  - prediction
+  - crawl
+  - arbitrage
+  - dashboard access

--- a/docs/manuals/admin-manual.md
+++ b/docs/manuals/admin-manual.md
@@ -107,7 +107,7 @@ Adjust based on queue depth and resource limits.
 ### Backup
 
 ```bash
-pg_dump -U zttato zttato > backup.sql
+pg_dump -U zttato zttato > backup-$(date +%Y%m%d%H%M%S).sql
 ```
 
 ### Restore

--- a/docs/manuals/devops-manual.md
+++ b/docs/manuals/devops-manual.md
@@ -152,7 +152,7 @@ docker compose up -d
 ### Backup data
 
 ```bash
-pg_dump -U zttato zttato > backup.sql
+pg_dump -U zttato zttato > backup.sql-$(date +%Y%m%d%H%M%S)
 ```
 
 ### Restore data

--- a/docs/manuals/devops-manual.md
+++ b/docs/manuals/devops-manual.md
@@ -1,0 +1,180 @@
+# DevOps Manual
+
+## 1. Purpose
+
+This manual is for DevOps engineers owning deployment, reliability, scaling, and recovery of zTTato Platform.
+
+---
+
+## 2. Stack Summary
+
+- Container orchestration: Docker Compose
+- Services: Node.js + Python microservices
+- Data stores: PostgreSQL + Redis
+- Entry gateway: Nginx
+- Optional edge automation: Cloudflare scripts/tooling
+
+---
+
+## 3. Build, Boot, and Validate
+
+### Build images
+
+```bash
+docker compose build
+```
+
+### Start full stack
+
+```bash
+docker compose up -d
+```
+
+### Validate running services
+
+```bash
+docker compose ps
+```
+
+### Run repository tests
+
+```bash
+pytest
+```
+
+---
+
+## 4. Runtime Topology
+
+Core compose services:
+
+- data: `postgres`, `redis`
+- APIs: `viral-predictor`, `market-crawler`, `arbitrage-engine`, `gpu-renderer`
+- workers: `crawler-worker`, `arbitrage-worker`, `renderer-worker`
+- edge/gateway: `nginx`
+
+Network: `zttato-net`
+
+Persistent volumes:
+
+- `postgres_data`
+- `redis_data`
+
+---
+
+## 5. Environment and Configuration
+
+### Required config artifacts
+
+- `.env` (runtime configuration)
+- `configs/nginx.conf` (reverse proxy config)
+- `configs/env/production.env` (production-oriented defaults)
+
+### Key dependencies between services
+
+- DB-backed services depend on healthy `postgres`.
+- Queue-based services/workers depend on healthy `redis`.
+- `nginx` depends on predictor/crawler/arbitrage health checks.
+
+---
+
+## 6. Operational Playbook
+
+### Service logs
+
+```bash
+docker compose logs --tail=200 <service>
+```
+
+### Restart single service
+
+```bash
+docker compose restart <service>
+```
+
+### Recreate one service
+
+```bash
+docker compose up -d --force-recreate <service>
+```
+
+### Scale workers
+
+```bash
+docker compose up -d --scale crawler-worker=5
+```
+
+---
+
+## 7. Verification and Diagnostics
+
+### API checks
+
+```bash
+curl -fS http://localhost/predict || true
+curl -fS http://localhost/crawl || true
+curl -fS http://localhost/arbitrage || true
+```
+
+### Container health perspective
+
+```bash
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+```
+
+### Scripted diagnostics
+
+Repository includes operational scripts under `scripts/` (doctor, monitor, repair, deploy, restart).
+Use them for standardized troubleshooting and environment repair.
+
+---
+
+## 8. Deployment Guidance
+
+### Standard deploy
+
+```bash
+docker compose up -d
+```
+
+### Safer deploy sequence
+
+1. Pull latest code and review config diffs.
+2. Build images.
+3. Apply deployment.
+4. Validate health checks and endpoints.
+5. Monitor logs for at least one processing window.
+
+---
+
+## 9. Backup and Recovery
+
+### Backup data
+
+```bash
+pg_dump -U zttato zttato > backup.sql
+```
+
+### Restore data
+
+```bash
+psql -U zttato zttato < backup.sql
+```
+
+### Recovery priorities
+
+1. Restore database availability.
+2. Restore queue/cache path.
+3. Restore API services.
+4. Restore workers.
+5. Validate ingress and external routing.
+
+---
+
+## 10. Hardening and Reliability Recommendations
+
+- Add centralized logs and metrics (e.g., ELK, Loki, Prometheus).
+- Set explicit alerting on health checks and queue lag.
+- Automate backup retention and periodic restore drills.
+- Use staged environments before production rollouts.
+- Pin dependencies and image tags for reproducible deployments.

--- a/docs/manuals/devops-manual.md
+++ b/docs/manuals/devops-manual.md
@@ -111,9 +111,9 @@ docker compose up -d --scale crawler-worker=5
 ### API checks
 
 ```bash
-curl -fS http://localhost/predict || true
-curl -fS http://localhost/crawl || true
-curl -fS http://localhost/arbitrage || true
+curl -fS http://localhost/predict
+curl -fS http://localhost/crawl
+curl -fS http://localhost/arbitrage
 ```
 
 ### Container health perspective

--- a/docs/manuals/godmode-manual.md
+++ b/docs/manuals/godmode-manual.md
@@ -90,7 +90,7 @@ When possible, use scripted pathways instead of ad-hoc commands to keep operatio
 ### Manual database backup
 
 ```bash
-pg_dump -U zttato zttato > backup.sql
+pg_dump -U zttato zttato > backup-$(date +%Y%m%d%H%M%S).sql
 ```
 
 ### Manual restore

--- a/docs/manuals/godmode-manual.md
+++ b/docs/manuals/godmode-manual.md
@@ -1,0 +1,136 @@
+# Godmode Manual
+
+## 1. Purpose and Scope
+
+This manual defines high-authority operational control for trusted operators with full-platform permissions ("godmode").
+
+Godmode access should be tightly limited, audited, and used only for emergency intervention, platform-wide migrations, or deep maintenance.
+
+---
+
+## 2. Godmode Capabilities
+
+A godmode operator can:
+
+- perform full-stack restart/rebuild
+- scale workers and service replicas
+- run repair and diagnostic scripts
+- apply infrastructure and edge networking changes
+- execute backup/restore procedures
+- supervise incident response end-to-end
+
+---
+
+## 3. Preconditions Before Godmode Actions
+
+1. Confirm incident severity and blast radius.
+2. Snapshot current state (`docker compose ps`, key logs, active alerts).
+3. Announce maintenance/incident handling to stakeholders.
+4. Confirm rollback plan and data safety approach.
+
+---
+
+## 4. Full-Stack Control Commands
+
+### Build and deploy
+
+```bash
+docker compose build
+docker compose up -d
+```
+
+### Controlled restart
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+### Emergency stop
+
+```bash
+docker compose down
+```
+
+### Validate post-action health
+
+```bash
+docker compose ps
+```
+
+---
+
+## 5. Worker and Throughput Control
+
+Adjust worker capacity according to queue pressure and latency targets.
+
+```bash
+docker compose up -d --scale crawler-worker=5 --scale renderer-worker=3 --scale arbitrage-worker=3
+```
+
+Observe CPU/memory saturation and avoid over-scaling beyond host capacity.
+
+---
+
+## 6. Deep Diagnostics and Repair
+
+Use repository scripts under `scripts/` for advanced troubleshooting, including:
+
+- doctor and monitor scripts
+- restart/supervisor scripts
+- docker recovery and stack repair scripts
+- cloudflare provisioning and tunnel recovery scripts
+
+When possible, use scripted pathways instead of ad-hoc commands to keep operations repeatable.
+
+---
+
+## 7. Data and State Control
+
+### Manual database backup
+
+```bash
+pg_dump -U zttato zttato > backup.sql
+```
+
+### Manual restore
+
+```bash
+psql -U zttato zttato < backup.sql
+```
+
+Before restore, ensure write operations are quiesced to prevent data divergence.
+
+---
+
+## 8. Edge and Network Override
+
+Godmode may include control of Cloudflare and ingress automation:
+
+- provisioning scripts
+- DNS/tunnel creation scripts
+- migration and heal scripts
+
+Apply network changes incrementally and confirm service reachability after each step.
+
+---
+
+## 9. Incident Command Mode
+
+During severe outages:
+
+1. Stabilize data stores (`postgres`, `redis`).
+2. Restore API baseline (`viral-predictor`, `market-crawler`, `arbitrage-engine`).
+3. Restore workers and confirm queue movement.
+4. Validate Nginx ingress and external routes.
+5. Announce recovery status and residual risks.
+
+---
+
+## 10. Governance and Security Requirements
+
+- Use godmode only with explicit approval in your organization.
+- Maintain action logs and timestamps for postmortem.
+- Separate personal and break-glass credentials.
+- Rotate high-privilege secrets after major incidents.
+- Perform post-incident review and convert ad-hoc fixes into documented runbooks.

--- a/docs/manuals/user-manual.md
+++ b/docs/manuals/user-manual.md
@@ -1,0 +1,129 @@
+# User Manual
+
+## 1. Purpose
+
+This manual is for operators and business users who need to use zTTato Platform features without changing infrastructure or source code.
+
+zTTato Platform is an automation and growth stack for social commerce and affiliate operations with API-driven workflows and a web dashboard.
+
+---
+
+## 2. Access Paths
+
+### Dashboard
+
+- Open the admin panel at `http://localhost:5173` in local environments.
+- Use credentials provided by your organization.
+- The dashboard includes campaign, products, and performance-oriented views.
+
+### API Gateway
+
+- Open API routes through the reverse proxy (default `http://localhost`).
+- Key public paths:
+  - `/predict`
+  - `/crawl`
+  - `/arbitrage`
+
+---
+
+## 3. Core User Workflows
+
+### 3.1 Product Discovery Workflow
+
+1. Trigger or request crawler activity (via admin workflows or platform automation).
+2. Wait for crawler workers to collect marketplace data.
+3. Review discovered products and profitability hints in product-facing dashboards.
+4. Promote selected products to campaign pipelines.
+
+### 3.2 Prediction Workflow
+
+1. Submit product/content payloads to prediction endpoints.
+2. Collect score outputs and ranking indicators.
+3. Use scores to prioritize media generation and campaign budgets.
+
+### 3.3 Campaign Optimization Workflow
+
+1. Monitor click and conversion analytics.
+2. Compare predicted performance with observed outcomes.
+3. Pause low-performing campaigns.
+4. Reallocate budget to higher-conversion products.
+
+---
+
+## 4. Dashboard Areas (High-Level)
+
+Depending on your role and enabled modules, the platform frontend contains views such as:
+
+- Overview dashboards
+- Campaigns pages
+- Products pages
+- User/admin control panel pages
+- Rent/admin operational views
+
+If a page is missing, request role access from an administrator.
+
+---
+
+## 5. Data Interpretation Guidance
+
+- **Conversion metrics**: prioritize stable trend lines over single spikes.
+- **Prediction metrics**: treat model outputs as ranking signals, not guarantees.
+- **Arbitrage outputs**: validate availability and logistics before execution.
+- **Crawler freshness**: use recent crawl timestamps when selecting products.
+
+---
+
+## 6. User Safety and Account Hygiene
+
+- Do not share dashboard credentials.
+- Do not upload sensitive secrets into campaign notes or free-text fields.
+- Avoid repeatedly submitting duplicate jobs; use existing queue status first.
+- Report suspicious account behavior to administrators immediately.
+
+---
+
+## 7. Common User Issues
+
+### Dashboard not loading
+
+- Confirm containers are running.
+- Confirm the frontend port (`5173`) is reachable.
+- Ask admin to verify reverse proxy and service health.
+
+### API returns 5xx
+
+- Retry once after 30–60 seconds.
+- If persistent, provide timestamp + endpoint + payload shape to support/admin.
+
+### Missing recent analytics
+
+- Data pipelines may be delayed.
+- Ask admin to check worker and database health.
+
+---
+
+## 8. Expected Service Availability
+
+A healthy platform should have these components running:
+
+- PostgreSQL
+- Redis
+- Predictor service
+- Crawler service
+- Arbitrage service
+- Renderer service
+- Worker set (crawler, arbitrage, renderer)
+- Nginx gateway
+
+---
+
+## 9. Escalation
+
+Escalate issues to admins/devops with:
+
+- Action attempted
+- Exact time (UTC preferred)
+- Endpoint/page used
+- Error message and screenshot (if available)
+
+This allows faster triage and recovery.

--- a/docs/manuals/user-manual.md
+++ b/docs/manuals/user-manual.md
@@ -58,7 +58,7 @@ Depending on your role and enabled modules, the platform frontend contains views
 - Campaigns pages
 - Products pages
 - User/admin control panel pages
-- Rent/admin operational views
+- Rent management operational views
 
 If a page is missing, request role access from an administrator.
 


### PR DESCRIPTION
### Motivation

- Provide comprehensive, role-focused operational documentation to improve onboarding and reduce time-to-recovery for users, administrators, DevOps, and emergency operators.
- Centralize runbooks, health checks, backup/restore steps, and escalation paths so teams can follow consistent procedures during normal operations and incidents.
- Capture deployment, scaling, and edge/network guidance to reduce ad-hoc interventions and encourage repeatable, auditable actions.

### Description

- Added four new manuals under `docs/manuals/`: `user-manual.md`, `admin-manual.md`, `devops-manual.md`, and `godmode-manual.md`, each covering role-specific workflows and runbooks.
- Updated `README.md` documentation references to include the new manuals so they are discoverable from the repo root.
- Manuals include concrete commands and checks such as `docker compose up -d`, `docker compose ps`, `pg_dump`, scaling examples, and scripted diagnostics references under `scripts/`.
- This is documentation-only and does not modify runtime application logic or service code.

### Testing

- Ran `pytest`, which discovered no tests in the repository (no automated tests were executed by `pytest`).
- Ran `python -m compileall services`, which completed successfully to validate Python sources compile without syntax errors.
- No runtime behavior was changed, so no service-level integration tests were required for this documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61b8626ec8321a925c2ce75a1dad1)