### PR TITLE
Potential fix for code scanning alert no. 1: Server-side URL redirect

### DIFF
--- a/services/click-tracker/src/server/server.js
+++ b/services/click-tracker/src/server/server.js
@@ -1,6 +1,18 @@
 import http from "http"
 import { trackClick } from "../core/tracker.js"
 
+function isLocalUrl(path) {
+
+try{
+  const base = "http://localhost"
+  const parsed = new URL(path, base)
+  return parsed.origin === base && parsed.pathname.startsWith("/")
+}catch(e){
+  return false
+}
+
+}
+
 const server = http.createServer(async (req,res)=>{
 
 try{
@@ -15,8 +27,10 @@ const target = url.searchParams.get("to")
 
 const redirect = await trackClick(req,campaign,target)
 
+const location = isLocalUrl(redirect) ? redirect : "/"
+
 res.writeHead(302,{
-Location: redirect
+Location: location
 })
 
 res.end()


### PR DESCRIPTION
Potential fix for [https://github.com/ZeaZDev/zttato-platform/security/code-scanning/1](https://github.com/ZeaZDev/zttato-platform/security/code-scanning/1)

In general, to fix untrusted URL redirection you must not use arbitrary user input directly as the redirect target. Instead, either (a) select a redirect destination from a server-side whitelist based on a user-provided key, or (b) at least validate that the redirect is local/same-origin (for example, a relative path or same host) before performing the redirect, and fall back to a safe default when validation fails.

For this codebase, the minimal change without altering core behavior is to validate `redirect` just before using it in the `Location` header. A good approach here is to accept only “local” URLs: those that resolve to the same origin as the server and/or are relative paths (starting with `/` and not containing a scheme like `http:`). We can implement a small helper `isLocalRedirect` in `server.js` that uses the standard `URL` class with a known base (here `http://localhost:8080` or just `http://localhost`) to check that the origin stays the same and that no dangerous schemes are used. Then, in the redirect handler, we only use the `redirect` value if it passes this check; otherwise we redirect to a safe default (for example `/`).

Concretely:
- In `services/click-tracker/src/server/server.js`, define a function such as `isLocalUrl(target)` (or `isSafeRedirect`) near the top of the file, using `new URL(target, "http://localhost")` and comparing `origin` (and maybe only allowing paths starting with `/`).
- In the block where `redirect` is set (`const redirect = await trackClick(...)`), add a validation step before `res.writeHead`, e.g.:

  ```js
  const location = isLocalUrl(redirect) ? redirect : "/";
  res.writeHead(302, { Location: location });
  ```

- `tracker.js` does not need to change logic-wise; it can keep returning the raw `target`, because the actual security decision is now enforced at the sink in `server.js`.

No external libraries are needed; Node’s built-in `URL` class suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
