### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,5 +1,8 @@
 name: Codex Automation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ZeaZDev/zttato-platform/security/code-scanning/8](https://github.com/ZeaZDev/zttato-platform/security/code-scanning/8)

In general, the problem is fixed by explicitly setting a `permissions` block to restrict the default `GITHUB_TOKEN` privileges to the minimum required for the workflow. This can be defined at the top (root) of the workflow to apply to all jobs, or inside a specific job. Since this workflow has a single job and does not appear to need any token-based write operations, setting `contents: read` at the workflow level is sufficient and clearly documents the intent.

The best fix here without changing existing functionality is to add a top-level `permissions` block immediately after the `name` field. Based on the current steps, the workflow only checks out the repository and runs local commands; `actions/checkout` with default settings only requires `contents: read`. There is no use of PR metadata writes, issues, or other write operations. Therefore we can safely set `permissions: contents: read`. Concretely, in `.github/workflows/codex.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: Codex Automation`) and line 3 (`on:`). No additional imports or methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
