### PR TITLE
Add start/stop scripts for Node services (install deps, background start, per-service logs)

### DIFF
--- a/scripts/start-node-services.sh
+++ b/scripts/start-node-services.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/services"
+LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/logs/node"
+
+mkdir -p "$LOG_DIR"
+
+SERVICES=(
+  shopee-crawler
+  tiktok-uploader
+  tiktok-shop-miner
+  tiktok-farm
+  account-farm
+  analytics
+  admin-panel
+  ai-video-generator
+  click-tracker
+)
+
+echo "================================="
+echo "Starting Node Services"
+echo "Root: $ROOT"
+echo "================================="
+
+for SERVICE in "${SERVICES[@]}"; do
+  SERVICE_DIR="$ROOT/$SERVICE"
+
+  if [ ! -d "$SERVICE_DIR" ]; then
+    echo "SKIP: $SERVICE_DIR not found"
+    continue
+  fi
+
+  if [ ! -f "$SERVICE_DIR/package.json" ]; then
+    echo "SKIP: $SERVICE_DIR missing package.json"
+    continue
+  fi
+
+  echo "Installing dependencies -> $SERVICE"
+
+  pushd "$SERVICE_DIR" >/dev/null
+
+  if [ -f package-lock.json ]; then
+    npm ci
+  else
+    npm install
+  fi
+
+  LOG_FILE="$LOG_DIR/$SERVICE.log"
+
+  echo "Starting service -> $SERVICE"
+
+  if npm run | grep -q "start"; then
+    nohup npm run start >"$LOG_FILE" 2>&1 &
+  elif npm run | grep -q "dev"; then
+    nohup npm run dev >"$LOG_FILE" 2>&1 &
+  else
+    echo "WARN: $SERVICE has no start/dev script"
+  fi
+
+  popd >/dev/null
+done
+
+echo ""
+echo "================================="
+echo "Node Services Started"
+echo "Logs: $LOG_DIR"
+echo "================================="

--- a/scripts/stop-node-services.sh
+++ b/scripts/stop-node-services.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "Stopping Node services..."
+
+pkill -f "npm run start" || true
+pkill -f "npm run dev" || true
+pkill -f "node" || true
+
+echo "Done."


### PR DESCRIPTION
### Motivation

- Provide simple, repository-relative helper scripts to bootstrap all Node automation services by installing dependencies, starting them in background, and collecting per-service logs for local/dev usage.

### Description

- Added `scripts/start-node-services.sh` which resolves repo-relative `services` and `logs/node` paths, creates the log directory, verifies each service directory and `package.json`, installs dependencies using `npm ci` when `package-lock.json` is present or `npm install` otherwise, and starts each service with `npm run start` or `npm run dev` via `nohup` redirecting output to `logs/node/<service>.log`.
- Added `scripts/stop-node-services.sh` which stops running Node services by matching `npm run start`, `npm run dev`, and `node` processes using `pkill`.
- Both scripts are executable (`100755`) and the set of services is defined in the `SERVICES` array inside the start script.

### Testing

- Ran syntax checks `bash -n scripts/start-node-services.sh` which succeeded.
- Ran syntax checks `bash -n scripts/stop-node-services.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b635d5d5288321bfb06005ebefa4ca)