### PR TITLE
Add PM2 ecosystem and migrate Node service scripts to PM2

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+
+const servicesRoot = path.join(__dirname, 'services');
+
+const nodeServices = [
+  'shopee-crawler',
+  'tiktok-uploader',
+  'tiktok-shop-miner',
+  'tiktok-farm',
+  'account-farm',
+  'analytics',
+  'admin-panel',
+  'ai-video-generator',
+  'click-tracker',
+];
+
+module.exports = {
+  apps: nodeServices.map((service) => ({
+    name: `zttato-${service}`,
+    cwd: path.join(servicesRoot, service),
+    script: 'npm',
+    args: 'run start',
+    autorestart: true,
+    watch: false,
+    max_memory_restart: '500M',
+    env: {
+      NODE_ENV: 'production',
+    },
+  })),
+};

--- a/scripts/start-node-services.sh
+++ b/scripts/start-node-services.sh
@@ -2,44 +2,32 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/services"
-LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/logs/node"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ECOSYSTEM_CONFIG="$REPO_ROOT/ecosystem.config.js"
+LOG_DIR="$REPO_ROOT/logs/node"
 
 mkdir -p "$LOG_DIR"
 
-SERVICES=(
-  shopee-crawler
-  tiktok-uploader
-  tiktok-shop-miner
-  tiktok-farm
-  account-farm
-  analytics
-  admin-panel
-  ai-video-generator
-  click-tracker
-)
-
 echo "================================="
-echo "Starting Node Services"
-echo "Root: $ROOT"
+echo "Starting Node Services with PM2"
+echo "Repo: $REPO_ROOT"
 echo "================================="
 
-for SERVICE in "${SERVICES[@]}"; do
-  SERVICE_DIR="$ROOT/$SERVICE"
+if [ ! -f "$ECOSYSTEM_CONFIG" ]; then
+  echo "ERROR: ecosystem config not found at $ECOSYSTEM_CONFIG"
+  exit 1
+fi
 
-  if [ ! -d "$SERVICE_DIR" ]; then
-    echo "SKIP: $SERVICE_DIR not found"
-    continue
-  fi
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo "PM2 not found. Installing globally..."
+  npm install -g pm2
+fi
 
-  if [ ! -f "$SERVICE_DIR/package.json" ]; then
-    echo "SKIP: $SERVICE_DIR missing package.json"
-    continue
-  fi
-
-  echo "Installing dependencies -> $SERVICE"
-
-  pushd "$SERVICE_DIR" >/dev/null
+echo "Installing npm dependencies for Node services..."
+while IFS= read -r package_file; do
+  service_dir="$(dirname "$package_file")"
+  echo "Installing dependencies -> $(basename "$service_dir")"
+  pushd "$service_dir" >/dev/null
 
   if [ -f package-lock.json ]; then
     npm ci
@@ -47,23 +35,16 @@ for SERVICE in "${SERVICES[@]}"; do
     npm install
   fi
 
-  LOG_FILE="$LOG_DIR/$SERVICE.log"
-
-  echo "Starting service -> $SERVICE"
-
-  if npm run | grep -q "start"; then
-    nohup npm run start >"$LOG_FILE" 2>&1 &
-  elif npm run | grep -q "dev"; then
-    nohup npm run dev >"$LOG_FILE" 2>&1 &
-  else
-    echo "WARN: $SERVICE has no start/dev script"
-  fi
-
   popd >/dev/null
-done
+done < <(find "$REPO_ROOT/services" -mindepth 2 -maxdepth 2 -name package.json | sort)
+
+echo "Starting PM2 processes from $ECOSYSTEM_CONFIG"
+pm2 start "$ECOSYSTEM_CONFIG"
+pm2 save
+pm2 list
 
 echo ""
 echo "================================="
-echo "Node Services Started"
-echo "Logs: $LOG_DIR"
+echo "Node Services Started via PM2"
+echo "PM2 logs: pm2 logs"
 echo "================================="

--- a/scripts/stop-node-services.sh
+++ b/scripts/stop-node-services.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
-echo "Stopping Node services..."
+set -euo pipefail
 
-pkill -f "npm run start" || true
-pkill -f "npm run dev" || true
-pkill -f "node" || true
+echo "Stopping Node services managed by PM2..."
+
+if command -v pm2 >/dev/null 2>&1; then
+  pm2 delete all || true
+  pm2 save || true
+else
+  echo "PM2 is not installed; nothing to stop via PM2."
+fi
 
 echo "Done."


### PR DESCRIPTION
### Motivation
- Standardize Node service lifecycle using PM2 for reliable process management and memory-based restarts.
- Ensure dependencies are installed for each Node service before launch and replace ad-hoc `nohup` starts with a single orchestrated PM2 launch.
- Provide a safe stop mechanism that uses PM2 instead of broad `pkill` calls.

### Description
- Added a root `ecosystem.config.js` that defines a PM2 app entry for each Node service under `services/*` running `npm run start` with `NODE_ENV=production` and memory restart limits.
- Reworked `scripts/start-node-services.sh` to validate the ecosystem file, install `pm2` globally when missing via `npm install -g pm2`, iterate service `package.json` files to run `npm ci`/`npm install`, and launch all apps with `pm2 start` / `pm2 save` / `pm2 list`.
- Removed the previous per-service `nohup npm run start`/`dev` logic and single-folder `SERVICES` list in favor of a dynamic `find`-based discovery of `services/*/package.json`.
- Replaced the previous `pkill`-based `scripts/stop-node-services.sh` with a PM2-aware stop script that runs `pm2 delete all` and `pm2 save`, and prints a message if `pm2` is not installed.

### Testing
- Ran syntax checks with `bash -n scripts/start-node-services.sh` and `bash -n scripts/stop-node-services.sh`, which succeeded.
- Verified the new ecosystem file by running `node -e "require('./ecosystem.config.js')"`, which loaded successfully.
- Attempted `npm install -g pm2` in this environment and it failed due to `npm` registry `403 Forbidden`, so global PM2 installation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6388154708321bcf3719e478e518f)