### PR TITLE
docs: refresh core documentation and manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,228 +1,85 @@
-
 # zTTato Platform
 
-zTTato Platform is a modular automation and growth infrastructure designed for large-scale social commerce and affiliate operations.
-It combines Node.js services, Python compute services, AI pipelines, and data crawlers with containerized infrastructure,
-orchestration tooling, and edge networking integration.
+zTTato Platform is a multi-service automation stack for social-commerce operations, combining product discovery, AI scoring, rendering, campaign automation, and analytics in one deployable platform.
 
-The platform is designed for:
-- TikTok automation pipelines
-- Social commerce intelligence
-- AI-generated media production
-- Market arbitrage detection
-- Large-scale crawler operations
-- Growth analytics and prediction
+## What is in this repository
 
-Architecture: microservice-oriented with independent services communicating through APIs, queues, and shared infrastructure.
+- **Microservices** in Node.js and Python under `services/`
+- **Infrastructure** and orchestration assets under `infrastructure/`
+- **Operational scripts** under `scripts/`
+- **Platform documentation** under `docs/`
 
----
+## Quick start
 
-## Architecture Overview
+### 1) Build images
 
-Layer | Technology | Purpose
------ | ---------- | -------
-API Services | Node.js | REST APIs and automation logic
-Compute Services | Python | ML, crawling, arbitrage engines
-Queue & Cache | Redis | Worker communication and job queues
-Database | PostgreSQL | Persistent data storage
-Infrastructure | Docker / Kubernetes | Container orchestration
-Edge | Cloudflare | DNS, tunnels, and edge networking
-UI | React | Admin control panel
+```bash
+docker compose build
+```
 
----
+### 2) Start the stack
 
-## Repository Structure
+```bash
+docker compose up -d
+```
 
-.
-├── docker-compose.yml
-├── start-zttato.sh
-├── env.edge
-├── cloudflare-devops/
-├── infrastructure/
-│   ├── ci/
-│   ├── k8s/
-│   ├── postgres/
-│   ├── scripts/
-│   └── start/
-├── scripts/
-└── services/
-    ├── account-farm
-    ├── admin-panel
-    ├── ai-video-generator
-    ├── analytics
-    ├── arbitrage-engine
-    ├── click-tracker
-    ├── gpu-renderer
-    ├── market-crawler
-    ├── shopee-crawler
-    ├── tiktok-farm
-    ├── tiktok-shop-miner
-    └── viral-predictor
+### 3) Verify runtime health
 
----
-
-## Quick Start
-
-Prerequisites
-- Docker
-- Docker Compose
-- Node.js
-- Python 3
-- Git
-
-Bootstrap:
-
-bash start-zttato.sh
-
-The bootstrap script:
-- fixes script permissions
-- installs dependencies
-- starts postgres/redis
-- builds containers
-- runs migrations
-- starts workers
-- performs health checks
-
----
-
-## Manual Validation
-
-Shell syntax check
-
-while IFS= read -r f; do bash -n "$f"; done < <(rg --files -g '*.sh')
-
-Python syntax
-
-python -m compileall services
-
-JSON validation
-
-while IFS= read -r f; do python -m json.tool "$f" >/dev/null; done < <(rg --files -g 'package.json')
-
----
-
-## Running the Platform
-
-Start
-
-./start.sh
-
-Check services
-
+```bash
 docker compose ps
+```
 
-Stop
+### 4) Run tests
 
-./stop.sh
+```bash
+pytest
+```
 
----
+## Core workers
 
-## API Endpoints
+- `crawler-worker`
+- `renderer-worker`
+- `arbitrage-worker`
 
-/predict
-/crawl
-/arbitrage
+## Public API routes (via nginx)
 
-Example:
+- `http://localhost/predict`
+- `http://localhost/crawl`
+- `http://localhost/arbitrage`
 
-http://SERVER/predict
-http://SERVER/crawl
-http://SERVER/arbitrage
+## Common operations
 
----
+### View logs
 
-## Worker Scaling
+```bash
+docker compose logs --tail=200 <service-name>
+```
 
-docker compose up -d --scale crawler-worker=5
+### Restart one service
 
----
+```bash
+docker compose restart <service-name>
+```
 
-## Backup
+### Scale workers
 
-pg_dump -U zttato zttato > backup.sql
+```bash
+docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale arbitrage-worker=2
+```
 
-Restore
+## Documentation map
 
-psql -U zttato zttato < backup.sql
+- Platform overview: `docs/system-overview.md`
+- Installation: `docs/installation.md`
+- Configuration: `docs/configuration.md`
+- Project structure: `docs/project-structure.md`
+- Quick start: `docs/quick-start.md`
+- Manuals:
+  - `docs/manuals/user-manual.md`
+  - `docs/manuals/admin-manual.md`
+  - `docs/manuals/devops-manual.md`
+  - `docs/manuals/godmode-manual.md`
 
----
+## License
 
-## Documentation
-
-docs/development/current-status-and-next-steps.md
-docs/operations/health-checks.md
-scripts/test-integration.sh
-docs/manuals/user-manual.md
-docs/manuals/admin-manual.md
-docs/manuals/devops-manual.md
-docs/manuals/godmode-manual.md
-
----
-
-## Roadmap
-
-- distributed queue architecture
-- service discovery
-- GPU cluster orchestration
-- CI/CD automation
-- Kubernetes multi-node support
-- observability stack
-
----
-
-## Enterprise Production Advancement Backlog
-
-Use this list to prioritize what should be added next for enterprise-grade production maturity.
-
-### Security & Compliance
-
-- [ ] Centralized secrets management (Vault / cloud secret manager), replacing plain env files in runtime.
-- [ ] SSO + RBAC for admin panel and internal APIs (OIDC/SAML).
-- [ ] Audit log pipeline for privileged actions (who did what, when, from where).
-- [ ] Automated SAST/DAST and container image scanning in CI.
-- [ ] Data retention + PII controls (encryption at rest, field-level masking, policy docs).
-
-### Reliability & Resilience
-
-- [ ] Define and track SLOs (availability, latency, data freshness) per service.
-- [ ] Add circuit breakers, retries with backoff, and idempotency keys for external calls.
-- [ ] Multi-AZ database and Redis HA setup with tested failover playbooks.
-- [ ] Blue/green or canary deploy strategy for zero-downtime upgrades.
-- [ ] Disaster recovery plan with RPO/RTO targets and regular restore drills.
-
-### Observability & Operations
-
-- [ ] Unified logs, metrics, and tracing (OpenTelemetry + centralized dashboard).
-- [ ] Service-level runbooks for every production service and worker.
-- [ ] Alert routing with severity policy and on-call ownership.
-- [ ] Capacity dashboards (queue depth, worker throughput, DB saturation, error budgets).
-- [ ] Synthetic checks for public endpoints and key internal worker paths.
-
-### Delivery & Governance
-
-- [ ] CI/CD gates: unit/integration/security checks required before deploy.
-- [ ] Environment promotion workflow (dev -> staging -> production) with approvals.
-- [ ] Infrastructure-as-Code policy checks for k8s and docker changes.
-- [ ] Versioned API contracts with backward-compatibility verification.
-- [ ] Change management template for high-risk rollouts.
-
-### Performance & Cost Control
-
-- [ ] Autoscaling policy tuning using real workload metrics.
-- [ ] Workload profiling for Python/Node hot paths and crawler throughput.
-- [ ] Cost allocation tags per service and dashboard for cloud spend visibility.
-- [ ] Queue prioritization and admission control for burst traffic.
-- [ ] Periodic rightsizing review for compute-heavy services (GPU/ML/rendering).
-
-## Already Implemented in This Project (Current Baseline)
-
-- [x] Containerized microservices architecture with Docker Compose and service isolation.
-- [x] Kubernetes deployment artifacts (deployments, services, ingress, autoscaling manifests).
-- [x] Automated platform scripts for bootstrap, rollback, repair, and diagnostics.
-- [x] Worker model separated by domain (crawler-worker, renderer-worker, arbitrage-worker).
-- [x] PostgreSQL + Redis split for persistence and queue/cache responsibilities.
-- [x] Cloudflare edge/devops helper tooling for DNS and tunnel operations.
-
----
-
-License: Private internal infrastructure project
+Private internal infrastructure project.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,21 +1,34 @@
 # Configuration
 
-## Environment variables
+This file summarizes configuration sources and environment conventions.
 
-Common runtime variables:
+## Configuration sources
 
-- `DB_URL`
-- `REDIS_URL`
-- `NODE_ENV`
-- `PYTHON_ENV`
-- `GPU_RENDER_ENABLED`
+- Runtime environment files (for example `configs/env/production.env`)
+- Docker Compose service environment declarations
+- Reverse-proxy routing in `configs/nginx.conf`
+
+## Common environment variables
+
+- `DB_URL`: PostgreSQL connection string
+- `REDIS_URL`: Redis connection string
+- `NODE_ENV`: Node.js runtime mode
+- `PYTHON_ENV`: Python runtime mode
+- `GPU_RENDER_ENABLED`: feature toggle for GPU rendering paths
 
 ## Example
 
 ```env
 DB_URL=postgresql://user:pass@localhost:5432/zttato
 REDIS_URL=redis://localhost:6379
+NODE_ENV=production
+PYTHON_ENV=production
 GPU_RENDER_ENABLED=true
 ```
 
-Store sensitive values in secret stores for production deployments.
+## Configuration practices
+
+- Keep secrets out of source control.
+- Use per-environment `.env` variants with explicit ownership.
+- Validate critical values (DB/Redis URLs, service credentials) before deploy.
+- Rotate sensitive values after incident response or credential exposure.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,24 +1,52 @@
 # Installation
 
+This document covers local setup for development and operational testing.
+
 ## Requirements
 
-- Docker and Docker Compose
-- Node.js and npm
-- Python 3
-- PostgreSQL client tools (optional)
-- Redis client tools (optional)
+- Docker + Docker Compose
+- Python 3 and `pip`
+- Git
+- Optional: `psql`/`pg_dump` client tools for backup/restore workflows
 
-## Setup
-
-1. Clone repository:
+## Clone
 
 ```bash
-git clone https://github.com/your-org/zttato-platform
+git clone <your-repository-url>
 cd zttato-platform
 ```
 
-2. Start platform bootstrap:
+## Build and start
 
 ```bash
-./start-zttato.sh
+docker compose build
+docker compose up -d
 ```
+
+## Verify stack
+
+```bash
+docker compose ps
+```
+
+## Run tests
+
+```bash
+pytest
+```
+
+## First health checks
+
+```bash
+curl -i http://localhost/predict
+curl -i http://localhost/crawl
+curl -i http://localhost/arbitrage
+```
+
+## Stop and clean down
+
+```bash
+docker compose down
+```
+
+Use `docker compose down -v` only when you intentionally want to remove persisted volumes.

--- a/docs/manuals/admin-manual.md
+++ b/docs/manuals/admin-manual.md
@@ -2,77 +2,51 @@
 
 ## 1. Purpose
 
-This manual is for platform administrators responsible for account access, operational control, and business-level governance.
+This manual is for platform administrators managing access, service health, and operational coordination.
 
----
+## 2. Core responsibilities
 
-## 2. Admin Responsibilities
+- Maintain dashboard/user access controls.
+- Monitor API and worker health.
+- Coordinate incident triage and escalation.
+- Validate post-deploy platform integrity.
 
-- Manage access to dashboard and role-scoped pages.
-- Coordinate campaign execution and review operational metrics.
-- Verify that core services and workers remain healthy.
-- Route incidents to DevOps when infrastructure intervention is required.
+## 3. Start, stop, and status
 
----
-
-## 3. Environment Startup and Shutdown
-
-### Start platform
+### Start
 
 ```bash
 docker compose up -d
 ```
 
-### Stop platform
+### Stop
 
 ```bash
 docker compose down
 ```
 
-### Check service state
+### Status
 
 ```bash
 docker compose ps
 ```
 
----
+## 4. Service inventory to watch
 
-## 4. Service Inventory to Monitor
-
-Administrators should recognize the core runtime set:
-
-- `postgres`
-- `redis`
-- `viral-predictor`
-- `market-crawler`
-- `arbitrage-engine`
-- `gpu-renderer`
-- `crawler-worker`
-- `arbitrage-worker`
-- `renderer-worker`
+- `postgres`, `redis`
+- `viral-predictor`, `market-crawler`, `arbitrage-engine`, `gpu-renderer`
+- `crawler-worker`, `renderer-worker`, `arbitrage-worker`
 - `nginx`
 
----
+## 5. Operational checks
 
-## 5. Operational Checks
-
-### 5.1 Health Snapshot
-
-```bash
-docker compose ps
-```
-
-Confirm each critical service is `running` and healthy where health checks exist.
-
-### 5.2 Logs
+### Logs
 
 ```bash
 docker compose logs --tail=200 <service-name>
 ```
 
-Use this to verify startup errors, queue stalls, or connectivity failures.
-
-### 5.3 API Reachability
+### API route reachability
 
 ```bash
 curl -i http://localhost/predict
@@ -80,29 +54,15 @@ curl -i http://localhost/crawl
 curl -i http://localhost/arbitrage
 ```
 
-A non-network error response still confirms routing works.
-
----
-
-## 6. Worker Operations
-
-Workers process background jobs and should be watched for throughput:
-
-- `crawler-worker`
-- `renderer-worker`
-- `arbitrage-worker`
-
-To scale workers when load increases:
+## 6. Worker scaling
 
 ```bash
 docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale arbitrage-worker=2
 ```
 
-Adjust based on queue depth and resource limits.
+Adjust replicas according to queue depth, SLA pressure, and host capacity.
 
----
-
-## 7. Data Protection and Recovery
+## 7. Data protection
 
 ### Backup
 
@@ -116,35 +76,9 @@ pg_dump -U zttato zttato > backup-$(date +%Y%m%d%H%M%S).sql
 psql -U zttato zttato < backup.sql
 ```
 
-Store backups securely with retention policy and access control.
+## 8. Incident response (admin layer)
 
----
-
-## 8. Security Administration
-
-- Enforce least privilege for platform users.
-- Rotate credentials periodically (DB, app secrets, dashboard auth).
-- Keep `.env` and secret files outside public sharing channels.
-- Review unusual automation activity and account lockout patterns.
-
----
-
-## 9. Incident Runbook (Admin Layer)
-
-1. Detect issue from dashboard/API/alerts.
-2. Confirm scope (single service or platform-wide).
-3. Gather evidence (`docker compose ps`, logs, affected endpoints).
-4. Apply safe restart if incident is transient.
-5. Escalate with collected artifacts to DevOps for infra-level fixes.
-
----
-
-## 10. Change Governance
-
-- Document every production-affecting change.
-- Prefer staged rollout for significant behavior updates.
-- Validate critical flows after each deploy:
-  - prediction
-  - crawl
-  - arbitrage
-  - dashboard access
+1. Detect and scope the issue.
+2. Gather evidence (`docker compose ps`, logs, endpoint status).
+3. Apply safe restarts if low risk.
+4. Escalate infra-level issues to DevOps with artifacts.

--- a/docs/manuals/devops-manual.md
+++ b/docs/manuals/devops-manual.md
@@ -2,91 +2,50 @@
 
 ## 1. Purpose
 
-This manual is for DevOps engineers owning deployment, reliability, scaling, and recovery of zTTato Platform.
+This manual is for infrastructure operators responsible for platform reliability, deployment, and recovery.
 
----
+## 2. Baseline commands
 
-## 2. Stack Summary
-
-- Container orchestration: Docker Compose
-- Services: Node.js + Python microservices
-- Data stores: PostgreSQL + Redis
-- Entry gateway: Nginx
-- Optional edge automation: Cloudflare scripts/tooling
-
----
-
-## 3. Build, Boot, and Validate
-
-### Build images
+### Build
 
 ```bash
 docker compose build
 ```
 
-### Start full stack
+### Start
 
 ```bash
 docker compose up -d
 ```
 
-### Validate running services
+### Validate runtime
 
 ```bash
 docker compose ps
 ```
 
-### Run repository tests
+### Test
 
 ```bash
 pytest
 ```
 
----
+## 3. Runtime topology
 
-## 4. Runtime Topology
+- Data: `postgres`, `redis`
+- API/compute: predictor, crawler, arbitrage, renderer
+- Workers: `crawler-worker`, `renderer-worker`, `arbitrage-worker`
+- Gateway: `nginx`
 
-Core compose services:
+## 4. Operational playbook
 
-- data: `postgres`, `redis`
-- APIs: `viral-predictor`, `market-crawler`, `arbitrage-engine`, `gpu-renderer`
-- workers: `crawler-worker`, `arbitrage-worker`, `renderer-worker`
-- edge/gateway: `nginx`
-
-Network: `zttato-net`
-
-Persistent volumes:
-
-- `postgres_data`
-- `redis_data`
-
----
-
-## 5. Environment and Configuration
-
-### Required config artifacts
-
-- `.env` (runtime configuration)
-- `configs/nginx.conf` (reverse proxy config)
-- `configs/env/production.env` (production-oriented defaults)
-
-### Key dependencies between services
-
-- DB-backed services depend on healthy `postgres`.
-- Queue-based services/workers depend on healthy `redis`.
-- `nginx` depends on predictor/crawler/arbitrage health checks.
-
----
-
-## 6. Operational Playbook
-
-### Service logs
+### Logs
 
 ```bash
 docker compose logs --tail=200 <service>
 ```
 
-### Restart single service
+### Restart one service
 
 ```bash
 docker compose restart <service>
@@ -104,11 +63,7 @@ docker compose up -d --force-recreate <service>
 docker compose up -d --scale crawler-worker=5
 ```
 
----
-
-## 7. Verification and Diagnostics
-
-### API checks
+## 5. Health diagnostics
 
 ```bash
 curl -fS http://localhost/predict
@@ -116,65 +71,34 @@ curl -fS http://localhost/crawl
 curl -fS http://localhost/arbitrage
 ```
 
-### Container health perspective
-
 ```bash
 docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
 ```
 
-### Scripted diagnostics
+## 6. Backup and recovery
 
-Repository includes operational scripts under `scripts/` (doctor, monitor, repair, deploy, restart).
-Use them for standardized troubleshooting and environment repair.
-
----
-
-## 8. Deployment Guidance
-
-### Standard deploy
+### Backup
 
 ```bash
-docker compose up -d
+pg_dump -U zttato zttato > backup-$(date +%Y%m%d%H%M%S).sql
 ```
 
-### Safer deploy sequence
-
-1. Pull latest code and review config diffs.
-2. Build images.
-3. Apply deployment.
-4. Validate health checks and endpoints.
-5. Monitor logs for at least one processing window.
-
----
-
-## 9. Backup and Recovery
-
-### Backup data
-
-```bash
-pg_dump -U zttato zttato > backup.sql-$(date +%Y%m%d%H%M%S)
-```
-
-### Restore data
+### Restore
 
 ```bash
 psql -U zttato zttato < backup.sql
 ```
 
-### Recovery priorities
+Recovery order:
 
-1. Restore database availability.
-2. Restore queue/cache path.
-3. Restore API services.
-4. Restore workers.
-5. Validate ingress and external routing.
+1. Restore `postgres` and `redis`
+2. Restore API services
+3. Restore workers
+4. Validate ingress and external routing
 
----
+## 7. Reliability recommendations
 
-## 10. Hardening and Reliability Recommendations
-
-- Add centralized logs and metrics (e.g., ELK, Loki, Prometheus).
-- Set explicit alerting on health checks and queue lag.
-- Automate backup retention and periodic restore drills.
-- Use staged environments before production rollouts.
-- Pin dependencies and image tags for reproducible deployments.
+- Enforce alerting on service health and queue lag.
+- Run periodic restore drills.
+- Use staged rollout for high-risk changes.
+- Keep runbooks and ownership maps current.

--- a/docs/manuals/godmode-manual.md
+++ b/docs/manuals/godmode-manual.md
@@ -1,36 +1,27 @@
 # Godmode Manual
 
-## 1. Purpose and Scope
+## 1. Purpose and restrictions
 
-This manual defines high-authority operational control for trusted operators with full-platform permissions ("godmode").
+Godmode access is break-glass operational control for severe incidents, platform-wide maintenance, or recovery scenarios. Access must be tightly restricted and auditable.
 
-Godmode access should be tightly limited, audited, and used only for emergency intervention, platform-wide migrations, or deep maintenance.
+## 2. Capabilities
 
----
+A godmode operator may:
 
-## 2. Godmode Capabilities
+- run full stack restart/rebuild actions
+- scale workers and service capacity
+- execute repair, recovery, and infrastructure scripts
+- perform backup and restore operations
+- lead incident command from detection to recovery
 
-A godmode operator can:
+## 3. Preconditions before action
 
-- perform full-stack restart/rebuild
-- scale workers and service replicas
-- run repair and diagnostic scripts
-- apply infrastructure and edge networking changes
-- execute backup/restore procedures
-- supervise incident response end-to-end
+1. Confirm severity and blast radius.
+2. Capture initial state (`docker compose ps`, key logs, active alerts).
+3. Communicate maintenance/incident window.
+4. Confirm rollback and data-protection plan.
 
----
-
-## 3. Preconditions Before Godmode Actions
-
-1. Confirm incident severity and blast radius.
-2. Snapshot current state (`docker compose ps`, key logs, active alerts).
-3. Announce maintenance/incident handling to stakeholders.
-4. Confirm rollback plan and data safety approach.
-
----
-
-## 4. Full-Stack Control Commands
+## 4. Full-stack control
 
 ### Build and deploy
 
@@ -52,85 +43,44 @@ docker compose up -d
 docker compose down
 ```
 
-### Validate post-action health
+### Post-action verification
 
 ```bash
 docker compose ps
 ```
 
----
-
-## 5. Worker and Throughput Control
-
-Adjust worker capacity according to queue pressure and latency targets.
+## 5. Throughput control
 
 ```bash
 docker compose up -d --scale crawler-worker=5 --scale renderer-worker=3 --scale arbitrage-worker=3
 ```
 
-Observe CPU/memory saturation and avoid over-scaling beyond host capacity.
+Scale incrementally and monitor host saturation.
 
----
+## 6. Recovery and diagnostics
 
-## 6. Deep Diagnostics and Repair
+Prefer standard scripts in `scripts/` and `infrastructure/scripts/` for repeatability (doctor, monitor, repair, rollback, deploy).
 
-Use repository scripts under `scripts/` for advanced troubleshooting, including:
+## 7. Data state operations
 
-- doctor and monitor scripts
-- restart/supervisor scripts
-- docker recovery and stack repair scripts
-- cloudflare provisioning and tunnel recovery scripts
-
-When possible, use scripted pathways instead of ad-hoc commands to keep operations repeatable.
-
----
-
-## 7. Data and State Control
-
-### Manual database backup
+### Backup
 
 ```bash
 pg_dump -U zttato zttato > backup-$(date +%Y%m%d%H%M%S).sql
 ```
 
-### Manual restore
+### Restore
 
 ```bash
 psql -U zttato zttato < backup.sql
 ```
 
-Before restore, ensure write operations are quiesced to prevent data divergence.
+Quiesce write-heavy operations before restore.
 
----
+## 8. Incident command sequence
 
-## 8. Edge and Network Override
-
-Godmode may include control of Cloudflare and ingress automation:
-
-- provisioning scripts
-- DNS/tunnel creation scripts
-- migration and heal scripts
-
-Apply network changes incrementally and confirm service reachability after each step.
-
----
-
-## 9. Incident Command Mode
-
-During severe outages:
-
-1. Stabilize data stores (`postgres`, `redis`).
-2. Restore API baseline (`viral-predictor`, `market-crawler`, `arbitrage-engine`).
-3. Restore workers and confirm queue movement.
-4. Validate Nginx ingress and external routes.
-5. Announce recovery status and residual risks.
-
----
-
-## 10. Governance and Security Requirements
-
-- Use godmode only with explicit approval in your organization.
-- Maintain action logs and timestamps for postmortem.
-- Separate personal and break-glass credentials.
-- Rotate high-privilege secrets after major incidents.
-- Perform post-incident review and convert ad-hoc fixes into documented runbooks.
+1. Stabilize data stores.
+2. Restore API baseline.
+3. Restore workers and queue movement.
+4. Validate ingress and external routes.
+5. Publish recovery state and residual risks.

--- a/docs/manuals/user-manual.md
+++ b/docs/manuals/user-manual.md
@@ -2,128 +2,58 @@
 
 ## 1. Purpose
 
-This manual is for operators and business users who need to use zTTato Platform features without changing infrastructure or source code.
+This manual is for business operators using zTTato workflows through the dashboard and API-facing features.
 
-zTTato Platform is an automation and growth stack for social commerce and affiliate operations with API-driven workflows and a web dashboard.
+## 2. Access
 
----
-
-## 2. Access Paths
-
-### Dashboard
-
-- Open the admin panel at `http://localhost:5173` in local environments.
-- Use credentials provided by your organization.
-- The dashboard includes campaign, products, and performance-oriented views.
-
-### API Gateway
-
-- Open API routes through the reverse proxy (default `http://localhost`).
-- Key public paths:
+- Dashboard (local): `http://localhost:5173`
+- API gateway (local): `http://localhost`
   - `/predict`
   - `/crawl`
   - `/arbitrage`
 
----
+If access fails, contact an administrator for role or environment validation.
 
-## 3. Core User Workflows
+## 3. Typical workflows
 
-### 3.1 Product Discovery Workflow
+### Product discovery
 
-1. Trigger or request crawler activity (via admin workflows or platform automation).
-2. Wait for crawler workers to collect marketplace data.
-3. Review discovered products and profitability hints in product-facing dashboards.
-4. Promote selected products to campaign pipelines.
+1. Trigger or wait for crawler pipelines.
+2. Review discovered products and freshness metadata.
+3. Move promising candidates into campaign planning.
 
-### 3.2 Prediction Workflow
+### Prediction and ranking
 
-1. Submit product/content payloads to prediction endpoints.
-2. Collect score outputs and ranking indicators.
-3. Use scores to prioritize media generation and campaign budgets.
+1. Submit payloads for prediction.
+2. Compare relative scores rather than treating a single score as certainty.
+3. Prioritize assets with strong score + market viability.
 
-### 3.3 Campaign Optimization Workflow
+### Campaign optimization
 
-1. Monitor click and conversion analytics.
-2. Compare predicted performance with observed outcomes.
-3. Pause low-performing campaigns.
-4. Reallocate budget to higher-conversion products.
+1. Monitor click and conversion trends.
+2. Pause low-performing campaigns.
+3. Reallocate budget to stronger products/content.
 
----
+## 4. User safety rules
 
-## 4. Dashboard Areas (High-Level)
+- Keep credentials private.
+- Do not paste secrets into free-text dashboard fields.
+- Avoid duplicate submissions when jobs are already queued.
+- Report suspicious behavior immediately.
 
-Depending on your role and enabled modules, the platform frontend contains views such as:
+## 5. Common issues
 
-- Overview dashboards
-- Campaigns pages
-- Products pages
-- User/admin control panel pages
-- Rent management operational views
+### Dashboard unavailable
 
-If a page is missing, request role access from an administrator.
+- Check with admin that core services are running.
+- Validate `http://localhost:5173` connectivity.
 
----
+### API 5xx responses
 
-## 5. Data Interpretation Guidance
-
-- **Conversion metrics**: prioritize stable trend lines over single spikes.
-- **Prediction metrics**: treat model outputs as ranking signals, not guarantees.
-- **Arbitrage outputs**: validate availability and logistics before execution.
-- **Crawler freshness**: use recent crawl timestamps when selecting products.
-
----
-
-## 6. User Safety and Account Hygiene
-
-- Do not share dashboard credentials.
-- Do not upload sensitive secrets into campaign notes or free-text fields.
-- Avoid repeatedly submitting duplicate jobs; use existing queue status first.
-- Report suspicious account behavior to administrators immediately.
-
----
-
-## 7. Common User Issues
-
-### Dashboard not loading
-
-- Confirm containers are running.
-- Confirm the frontend port (`5173`) is reachable.
-- Ask admin to verify reverse proxy and service health.
-
-### API returns 5xx
-
-- Retry once after 30–60 seconds.
-- If persistent, provide timestamp + endpoint + payload shape to support/admin.
+- Retry once after a short delay.
+- Provide timestamp + endpoint + payload shape to support/admin.
 
 ### Missing recent analytics
 
 - Data pipelines may be delayed.
-- Ask admin to check worker and database health.
-
----
-
-## 8. Expected Service Availability
-
-A healthy platform should have these components running:
-
-- PostgreSQL
-- Redis
-- Predictor service
-- Crawler service
-- Arbitrage service
-- Renderer service
-- Worker set (crawler, arbitrage, renderer)
-- Nginx gateway
-
----
-
-## 9. Escalation
-
-Escalate issues to admins/devops with:
-
-- Action attempted
-- Exact time (UTC preferred)
-- Endpoint/page used
-- Error message and screenshot (if available)
-
-This allows faster triage and recovery.
+- Ask admins to check worker health and queue lag.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -2,24 +2,29 @@
 
 ```text
 zttato-platform/
-├── services/
-│   ├── viral-predictor/
-│   ├── ai-video-generator/
-│   ├── gpu-renderer/
-│   ├── market-crawler/
+├── docs/                    # Documentation, runbooks, manuals, architecture
+├── services/                # Business services (Node.js/Python)
+│   ├── admin-panel/
+│   ├── analytics/
 │   ├── arbitrage-engine/
 │   ├── click-tracker/
-│   ├── analytics/
-│   ├── account-farm/
-│   ├── tiktok-uploader/
-│   └── admin-panel/
-├── infrastructure/
-│   ├── postgres/
-│   ├── ci/
-│   ├── scripts/
-│   └── start/
-├── scripts/
-├── cloudflare-devops/
-├── docker-compose.yml
-└── start-zttato.sh
+│   ├── gpu-renderer/
+│   ├── market-crawler/
+│   ├── viral-predictor/
+│   └── ...
+├── infrastructure/          # k8s manifests, CI scripts, startup tooling, postgres assets
+├── scripts/                 # Operations helpers (deploy, repair, monitor, doctor)
+├── contracts/               # Service API/data contracts
+├── configs/                 # Shared env and gateway configuration
+├── tests/                   # Python test suite
+├── docker-compose.yml       # Default orchestration baseline
+└── README.md
 ```
+
+## Directory intent
+
+- **`docs/`**: authoritative operational and developer documentation.
+- **`services/`**: independently deployable components with per-service dependencies.
+- **`infrastructure/`**: platform orchestration and production-oriented artifacts.
+- **`scripts/`**: repeatable command wrappers for diagnostics, deploy, and recovery.
+- **`tests/`**: baseline validation for core Python modules.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,17 +1,49 @@
 # Quick Start
 
-## Local startup
+This guide gets a local zTTato environment running with the default Docker Compose stack.
+
+## Prerequisites
+
+- Docker Engine + Docker Compose
+- Python 3 (for `pytest`)
+- Git
+
+## 1. Build
 
 ```bash
-./start-zttato.sh
+docker compose build
 ```
 
-## Verify services
+## 2. Start
+
+```bash
+docker compose up -d
+```
+
+## 3. Validate
 
 ```bash
 docker compose ps
 ```
 
-## Open dashboard
+Expected critical runtime services include `postgres`, `redis`, API services, and workers (`crawler-worker`, `renderer-worker`, `arbitrage-worker`).
 
-- http://localhost:5173
+## 4. Run tests
+
+```bash
+pytest
+```
+
+## 5. Use the platform
+
+- Dashboard (local): `http://localhost:5173`
+- API routes (via nginx):
+  - `http://localhost/predict`
+  - `http://localhost/crawl`
+  - `http://localhost/arbitrage`
+
+## 6. Stop
+
+```bash
+docker compose down
+```

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,20 +1,49 @@
 # System Overview
 
-zTTato-platform is an AI-powered affiliate automation system for high-volume product discovery, content creation, campaign execution, and performance analytics.
+zTTato Platform is an AI-assisted affiliate automation system for product discovery, campaign acceleration, and conversion optimization.
 
-## Primary Goals
+## Platform objectives
 
-- Discover profitable products from multiple marketplaces.
-- Predict and generate high-performing marketing content.
-- Automate publishing and account operations.
-- Track user engagement and campaign conversion.
-- Provide analytics for optimization loops.
+- Discover profitable products from marketplaces.
+- Score opportunities using ML/prediction services.
+- Automate campaign publishing workflows.
+- Track click/conversion performance and optimize outcomes.
 
-## Major Components
+## High-level architecture
 
-- Crawlers and data ingestion workers
-- AI predictor and generation services
-- Rendering and media processing workers
-- Automation farm and uploader services
-- Click tracking and analytics services
-- Admin dashboard frontend
+### Data layer
+
+- `postgres`: persistent relational storage
+- `redis`: queue/cache and worker coordination
+
+### API and compute services
+
+- `viral-predictor`
+- `market-crawler`
+- `arbitrage-engine`
+- `gpu-renderer`
+- analytics/click-tracking services
+
+### Worker layer
+
+- `crawler-worker`
+- `renderer-worker`
+- `arbitrage-worker`
+
+### Access layer
+
+- `nginx`: reverse-proxy and route gateway
+- `admin-panel`: web UI for operators/admins
+
+## Core request and processing flow
+
+1. Ingestion/crawl discovers product candidates.
+2. Predictor and analytics services score opportunities.
+3. Workers process long-running jobs asynchronously.
+4. Dashboard and API consumers observe results and operate campaigns.
+
+## Operations model
+
+- Container orchestration: Docker Compose (local/ops baseline)
+- Optional deployment manifests: Kubernetes assets in `infrastructure/k8s/`
+- Operational automation: shell scripts in `scripts/` and `infrastructure/scripts/`


### PR DESCRIPTION
### Motivation
- Bring all user and operator documentation up-to-date with the current Docker Compose based workflow and runtime commands.
- Standardize onboarding and operational runbooks so developers, admins, and DevOps share a consistent set of procedures and commands.

### Description
- Rewrote `README.md` to provide a concise quick-start, clear build/start/test commands, and a documentation map to the manuals.
- Updated core docs: `docs/quick-start.md`, `docs/installation.md`, `docs/system-overview.md`, `docs/project-structure.md`, and `docs/configuration.md` to match the current platform baseline and environment conventions.
- Rewrote all manuals under `docs/manuals/` (`user-manual.md`, `admin-manual.md`, `devops-manual.md`, `godmode-manual.md`) to align runbook steps, startup/stop/status commands, worker scaling, backup/restore, and incident playbooks (using `docker compose build`, `docker compose up -d`, `docker compose ps`, `pytest`, etc.).
- This change set is documentation-only and does not modify application source code or runtime behavior.

### Testing
- Ran the repository test suite with `pytest`, which discovered and ran 7 tests and returned `7 passed`.
- No additional automated runtime or deployment tests were executed as this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63b127b0c83219e97d6a6c2566b3d)