### PR TITLE
Add full-source-scan script and 2026-03-15 scan report

### DIFF
--- a/docs/development/full-source-scan-report-2026-03-15.md
+++ b/docs/development/full-source-scan-report-2026-03-15.md
@@ -1,0 +1,40 @@
+# Full Source Scan Report (2026-03-15)
+
+## Scope
+Scanned the repository source tree with available non-interactive checks:
+
+- Python syntax validation across all `*.py` files.
+- JavaScript syntax validation across all `*.js` files.
+- JSX file inventory (`*.jsx`) with parser limitation note.
+- Existing Python test suite (`pytest`).
+- Repository validation script (`infrastructure/scripts/validate-repo.sh`).
+
+## Commands Run
+
+```bash
+bash infrastructure/scripts/full-source-scan.sh
+bash infrastructure/scripts/validate-repo.sh
+npm -C services/admin-panel run build
+```
+
+## Findings
+
+1. **No Python syntax errors** were detected.
+2. **No JavaScript syntax errors** were detected for `.js` files.
+3. **12 JSX files** were detected. Direct `node --check` does not parse JSX; these files should be validated through their framework build tooling.
+4. **Pytest passed**: `7 passed`.
+5. **Repository validation passed** (shell syntax, Python syntax, package.json validation).
+6. Attempting to build `services/admin-panel` failed in this environment because `next` is not installed in the current runtime (`sh: 1: next: not found`).
+
+## Fixes Applied
+
+To make full-scan workflow repeatable and explicit, added:
+
+- `infrastructure/scripts/full-source-scan.sh` — a consolidated scan script that performs Python checks, JavaScript checks, JSX inventory, and `pytest`.
+
+No source-code logic errors were detected during this pass, so no application code changes were required.
+
+## Recommended Follow-ups
+
+- Run frontend service-level builds in environments where dependencies are installed (e.g., `npm ci` inside each Node service before build checks).
+- If desired, add framework-specific lint/build steps for JSX/TSX services to CI.

--- a/infrastructure/scripts/full-source-scan.sh
+++ b/infrastructure/scripts/full-source-scan.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "=== ZTTATO Full Source Scan ==="
+echo "Repository: $ROOT_DIR"
+
+echo
+printf "[1/4] Python syntax scan... "
+PY_FILES="$(rg --files -g '*.py')"
+if [[ -n "$PY_FILES" ]]; then
+  python -m py_compile $PY_FILES
+fi
+echo "OK"
+
+echo
+printf "[2/4] JavaScript syntax scan (.js)... "
+JS_FILES="$(rg --files -g '*.js')"
+if [[ -n "$JS_FILES" ]]; then
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    node --check "$f" >/dev/null
+  done <<< "$JS_FILES"
+fi
+echo "OK"
+
+echo
+printf "[3/4] JSX inventory... "
+JSX_COUNT="$(rg --files -g '*.jsx' | wc -l | tr -d ' ')"
+echo "$JSX_COUNT file(s) detected"
+if [[ "$JSX_COUNT" -gt 0 ]]; then
+  echo "      Note: JSX syntax requires a JSX-aware parser (e.g., Vite/Next/Babel build) and is validated in service-level build/test pipelines."
+fi
+
+echo
+printf "[4/4] Pytest suite...\n"
+pytest -q
+
+echo
+echo "All configured checks completed."


### PR DESCRIPTION
### Motivation

- Provide a single, repeatable entrypoint to perform repository-wide sanity checks and make scans easy to run locally or in CI.
- Consolidate Python and JavaScript syntax checks, a JSX inventory note, and the existing Python test suite into one script for consistent validation.

### Description

- Add `infrastructure/scripts/full-source-scan.sh` which runs: Python syntax checks (`python -m py_compile`), JavaScript `.js` syntax checks (`node --check`), a `*.jsx` inventory/count, and `pytest -q`.
- Add `docs/development/full-source-scan-report-2026-03-15.md` containing the scope, commands run, findings, and follow-up recommendations from the scan run.
- The change does not modify application logic; it only adds tooling and documentation to standardize repository scans.

### Testing

- Ran the new script with `bash infrastructure/scripts/full-source-scan.sh`, which completed all configured checks successfully in this environment.
- Verified `pytest` passed (`7 passed`), `python -m compileall` completed, and the `.js` `node --check` loop passed for `.js` files, and `infrastructure/scripts/validate-repo.sh` passed.
- Attempted `npm -C services/admin-panel run build` which failed here due to missing `next` (`sh: 1: next: not found`); frontend service builds should be validated in an environment with Node dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ddc49fbc83219867146ac3d219d6)