### PR TITLE
Add enterprise full-upgrade blueprint and validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ docker compose restart <service-name>
 docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale arbitrage-worker=2
 ```
 
+
+## Full upgrade blueprint
+
+The repository now ships a typed blueprint for a **full enterprise upgrade** that covers:
+
+- 25+ microservices
+- Kafka event system
+- Distributed crawler cluster
+- AI video generation pipeline
+- Full admin dashboard modules
+- Kubernetes namespaces
+- CI/CD stages
+- Full frontend app layout
+
+See `enterprise_maturity/full_upgrade.py` and run the validation helper in tests.
+
 ## Documentation map
 
 - Platform overview: `docs/system-overview.md`

--- a/enterprise_maturity/__init__.py
+++ b/enterprise_maturity/__init__.py
@@ -11,6 +11,7 @@ from .security import (
 from .resilience import CircuitBreaker, RetryPolicy, IdempotencyStore
 from .operations import SLO, ErrorBudgetPolicy, SeverityPolicy, SyntheticProbe
 from .performance import AutoscalingAdvisor, QueueAdmissionController
+from .full_upgrade import FULL_UPGRADE_BLUEPRINT, UpgradeBlueprint
 
 __all__ = [
     "AccessToken",
@@ -28,4 +29,6 @@ __all__ = [
     "SyntheticProbe",
     "AutoscalingAdvisor",
     "QueueAdmissionController",
+    "UpgradeBlueprint",
+    "FULL_UPGRADE_BLUEPRINT",
 ]

--- a/enterprise_maturity/full_upgrade.py
+++ b/enterprise_maturity/full_upgrade.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Microservice:
+    name: str
+    domain: str
+    runtime: str
+
+
+@dataclass(frozen=True)
+class CrawlerCluster:
+    queue_backend: str
+    scheduler: str
+    max_workers: int
+
+
+@dataclass(frozen=True)
+class AIVideoPipeline:
+    stages: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UpgradeBlueprint:
+    services: tuple[Microservice, ...]
+    kafka_topics: tuple[str, ...]
+    crawler_cluster: CrawlerCluster
+    ai_video_pipeline: AIVideoPipeline
+    admin_dashboard_modules: tuple[str, ...]
+    frontend_apps: tuple[str, ...]
+    kubernetes_namespaces: tuple[str, ...]
+    cicd_stages: tuple[str, ...]
+
+    def validate(self) -> None:
+        if len(self.services) < 25:
+            raise ValueError("Upgrade requires at least 25 microservices")
+        if len(self.kafka_topics) < 8:
+            raise ValueError("Upgrade requires a full Kafka event system")
+        if self.crawler_cluster.max_workers < 12:
+            raise ValueError("Distributed crawler cluster must support at least 12 workers")
+
+        required_video_stages = {"ingest", "storyboard", "render", "qa", "publish"}
+        if not required_video_stages.issubset(set(self.ai_video_pipeline.stages)):
+            raise ValueError("AI video pipeline stages are incomplete")
+
+        required_dashboard = {"tenants", "campaigns", "billing", "observability", "rbac"}
+        if not required_dashboard.issubset(set(self.admin_dashboard_modules)):
+            raise ValueError("Admin dashboard modules are incomplete")
+
+        required_cicd = {"lint", "test", "build", "security-scan", "deploy"}
+        if not required_cicd.issubset(set(self.cicd_stages)):
+            raise ValueError("CI/CD stages are incomplete")
+
+
+FULL_UPGRADE_BLUEPRINT = UpgradeBlueprint(
+    services=(
+        Microservice("gateway-api", "api", "node"),
+        Microservice("identity-service", "security", "python"),
+        Microservice("tenant-service", "core", "python"),
+        Microservice("catalog-service", "commerce", "node"),
+        Microservice("pricing-service", "commerce", "python"),
+        Microservice("inventory-service", "commerce", "node"),
+        Microservice("order-service", "commerce", "python"),
+        Microservice("payment-service", "finance", "python"),
+        Microservice("billing-service", "finance", "node"),
+        Microservice("notification-service", "engagement", "node"),
+        Microservice("analytics-service", "data", "python"),
+        Microservice("event-collector", "data", "python"),
+        Microservice("viral-predictor", "ai", "python"),
+        Microservice("market-crawler", "crawler", "python"),
+        Microservice("shopee-crawler", "crawler", "node"),
+        Microservice("tiktok-shop-miner", "crawler", "node"),
+        Microservice("arbitrage-engine", "trading", "python"),
+        Microservice("ai-video-generator", "media", "node"),
+        Microservice("gpu-renderer", "media", "python"),
+        Microservice("asset-library", "media", "node"),
+        Microservice("campaign-service", "marketing", "python"),
+        Microservice("scheduler-service", "ops", "python"),
+        Microservice("admin-panel-api", "admin", "node"),
+        Microservice("frontend-web", "frontend", "nextjs"),
+        Microservice("frontend-admin", "frontend", "nextjs"),
+        Microservice("webhook-service", "integration", "python"),
+        Microservice("audit-service", "security", "python"),
+    ),
+    kafka_topics=(
+        "crawler.jobs",
+        "crawler.results",
+        "video.jobs",
+        "video.completed",
+        "campaign.events",
+        "orders.events",
+        "billing.events",
+        "audit.events",
+        "notifications.events",
+    ),
+    crawler_cluster=CrawlerCluster(queue_backend="kafka", scheduler="keda", max_workers=48),
+    ai_video_pipeline=AIVideoPipeline(stages=("ingest", "storyboard", "voiceover", "render", "qa", "publish")),
+    admin_dashboard_modules=("tenants", "campaigns", "billing", "observability", "rbac", "approvals"),
+    frontend_apps=("storefront", "admin-console", "ops-console"),
+    kubernetes_namespaces=("zttato-core", "zttato-data", "zttato-ai", "zttato-edge"),
+    cicd_stages=("lint", "test", "build", "security-scan", "package", "deploy", "post-deploy-smoke"),
+)

--- a/tests/test_enterprise_maturity.py
+++ b/tests/test_enterprise_maturity.py
@@ -5,6 +5,7 @@ from enterprise_maturity.operations import ErrorBudgetPolicy, ProbeResult, SLO, 
 from enterprise_maturity.performance import AutoscalingAdvisor, QueueAdmissionController, WorkloadMetrics
 from enterprise_maturity.resilience import CircuitBreaker, IdempotencyStore, RetryPolicy
 from enterprise_maturity.roadmap import ROADMAP_IMPLEMENTATION
+from enterprise_maturity.full_upgrade import FULL_UPGRADE_BLUEPRINT, UpgradeBlueprint
 from enterprise_maturity.security import AccessToken, AuditEvent, AuditLogPipeline, RBACPolicy, SecretManager, SecretRotationPolicy
 
 
@@ -88,3 +89,31 @@ def test_roadmap_has_all_items():
     assert len(ROADMAP_IMPLEMENTATION) == 25
     assert ROADMAP_IMPLEMENTATION[0].id == 1
     assert ROADMAP_IMPLEMENTATION[-1].id == 25
+
+
+def test_full_upgrade_blueprint_covers_requested_capabilities():
+    FULL_UPGRADE_BLUEPRINT.validate()
+
+    assert len(FULL_UPGRADE_BLUEPRINT.services) >= 25
+    assert FULL_UPGRADE_BLUEPRINT.crawler_cluster.queue_backend == "kafka"
+    assert "publish" in FULL_UPGRADE_BLUEPRINT.ai_video_pipeline.stages
+    assert "frontend-admin" in {service.name for service in FULL_UPGRADE_BLUEPRINT.services}
+
+
+def test_full_upgrade_blueprint_validation_rejects_small_layout():
+    small_blueprint = UpgradeBlueprint(
+        services=FULL_UPGRADE_BLUEPRINT.services[:2],
+        kafka_topics=FULL_UPGRADE_BLUEPRINT.kafka_topics,
+        crawler_cluster=FULL_UPGRADE_BLUEPRINT.crawler_cluster,
+        ai_video_pipeline=FULL_UPGRADE_BLUEPRINT.ai_video_pipeline,
+        admin_dashboard_modules=FULL_UPGRADE_BLUEPRINT.admin_dashboard_modules,
+        frontend_apps=FULL_UPGRADE_BLUEPRINT.frontend_apps,
+        kubernetes_namespaces=FULL_UPGRADE_BLUEPRINT.kubernetes_namespaces,
+        cicd_stages=FULL_UPGRADE_BLUEPRINT.cicd_stages,
+    )
+
+    try:
+        small_blueprint.validate()
+        assert False, "expected validation error"
+    except ValueError as exc:
+        assert "25 microservices" in str(exc)


### PR DESCRIPTION
### Motivation
- Provide an executable, typed contract that captures the target architecture for a full platform upgrade (25+ microservices, Kafka event bus, distributed crawler, AI video pipeline, admin dashboard, k8s namespaces, CI/CD stages and frontend layout). 
- Make the upgrade target discoverable and reusable from the `enterprise_maturity` package so other tooling and tests can validate architectural requirements.

### Description
- Add `enterprise_maturity/full_upgrade.py` implementing `Microservice`, `CrawlerCluster`, `AIVideoPipeline`, and a typed `UpgradeBlueprint` with validation rules and a ready-to-use `FULL_UPGRADE_BLUEPRINT` instance. 
- Export `UpgradeBlueprint` and `FULL_UPGRADE_BLUEPRINT` from `enterprise_maturity/__init__.py` for direct imports. 
- Extend `tests/test_enterprise_maturity.py` with two tests that validate the `FULL_UPGRADE_BLUEPRINT` and assert that undersized blueprints raise a `ValueError`. 
- Update `README.md` with a `Full upgrade blueprint` section pointing to `enterprise_maturity/full_upgrade.py` and the validation helpers in tests.

### Testing
- Ran the test suite with `pytest -q` and all tests passed. 
- Test output: `9 passed` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72ca3d6048321943b15919d7fe7c7)