### PR TITLE
Harden Node service start/stop scripts for PM2-less environments

### DIFF
--- a/scripts/start-node-services.sh
+++ b/scripts/start-node-services.sh
@@ -5,11 +5,91 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ECOSYSTEM_CONFIG="$REPO_ROOT/ecosystem.config.js"
 LOG_DIR="$REPO_ROOT/logs/node"
+PID_DIR="$LOG_DIR/pids"
 
-mkdir -p "$LOG_DIR"
+mkdir -p "$LOG_DIR" "$PID_DIR"
+
+PM2_CMD=""
+
+run_npm() {
+  npm "$@" || (
+    unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY npm_config_http_proxy npm_config_https_proxy
+    npm "$@"
+  )
+}
+
+start_with_nohup() {
+  echo "PM2 unavailable. Falling back to nohup background processes."
+  local failures=0
+
+  while IFS= read -r package_file; do
+    service_dir="$(dirname "$package_file")"
+    service_name="$(basename "$service_dir")"
+    pid_file="$PID_DIR/$service_name.pid"
+    out_log="$LOG_DIR/$service_name.out.log"
+
+    if [ -f "$pid_file" ]; then
+      existing_pid="$(cat "$pid_file")"
+      if kill -0 "$existing_pid" >/dev/null 2>&1; then
+        echo "Service $service_name is already running with PID $existing_pid"
+        continue
+      fi
+      rm -f "$pid_file"
+    fi
+
+    echo "Starting $service_name with nohup..."
+    nohup bash -lc "cd '$service_dir' && env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u npm_config_http_proxy -u npm_config_https_proxy npm run start" >"$out_log" 2>&1 &
+    new_pid=$!
+
+    sleep 2
+
+    if kill -0 "$new_pid" >/dev/null 2>&1; then
+      echo "$new_pid" >"$pid_file"
+      echo "Started $service_name (PID $new_pid, log: $out_log)"
+    else
+      failures=$((failures + 1))
+      echo "ERROR: $service_name failed to stay running. Recent log output:"
+      tail -n 20 "$out_log" || true
+    fi
+  done < <(find "$REPO_ROOT/services" -mindepth 2 -maxdepth 2 -name package.json | sort)
+
+  echo ""
+  echo "================================="
+  echo "Node Services Started via nohup"
+  echo "PID files: $PID_DIR"
+  echo "Logs: $LOG_DIR"
+  echo "================================="
+
+  if [ "$failures" -gt 0 ]; then
+    echo "ERROR: $failures service(s) failed to start via nohup."
+    exit 1
+  fi
+}
+
+resolve_pm2() {
+  if command -v pm2 >/dev/null 2>&1; then
+    PM2_CMD="pm2"
+    return
+  fi
+
+  if [ -x "$REPO_ROOT/node_modules/.bin/pm2" ]; then
+    PM2_CMD="$REPO_ROOT/node_modules/.bin/pm2"
+    return
+  fi
+
+  echo "PM2 not found. Attempting global install..."
+  if run_npm install -g pm2; then
+    if command -v pm2 >/dev/null 2>&1; then
+      PM2_CMD="pm2"
+      return
+    fi
+  fi
+
+  PM2_CMD=""
+}
 
 echo "================================="
-echo "Starting Node Services with PM2"
+echo "Starting Node Services"
 echo "Repo: $REPO_ROOT"
 echo "================================="
 
@@ -18,33 +98,38 @@ if [ ! -f "$ECOSYSTEM_CONFIG" ]; then
   exit 1
 fi
 
-if ! command -v pm2 >/dev/null 2>&1; then
-  echo "PM2 not found. Installing globally..."
-  npm install -g pm2
+if [ "${SKIP_DEP_INSTALL:-0}" = "1" ]; then
+  echo "Skipping dependency installation (SKIP_DEP_INSTALL=1)."
+else
+  echo "Installing npm dependencies for Node services..."
+  while IFS= read -r package_file; do
+    service_dir="$(dirname "$package_file")"
+    echo "Installing dependencies -> $(basename "$service_dir")"
+    pushd "$service_dir" >/dev/null
+
+    if [ -f package-lock.json ]; then
+      run_npm ci
+    else
+      run_npm install
+    fi
+
+    popd >/dev/null
+  done < <(find "$REPO_ROOT/services" -mindepth 2 -maxdepth 2 -name package.json | sort)
 fi
 
-echo "Installing npm dependencies for Node services..."
-while IFS= read -r package_file; do
-  service_dir="$(dirname "$package_file")"
-  echo "Installing dependencies -> $(basename "$service_dir")"
-  pushd "$service_dir" >/dev/null
+resolve_pm2
 
-  if [ -f package-lock.json ]; then
-    npm ci
-  else
-    npm install
-  fi
+if [ -n "$PM2_CMD" ]; then
+  echo "Starting PM2 processes from $ECOSYSTEM_CONFIG"
+  "$PM2_CMD" start "$ECOSYSTEM_CONFIG"
+  "$PM2_CMD" save
+  "$PM2_CMD" list
 
-  popd >/dev/null
-done < <(find "$REPO_ROOT/services" -mindepth 2 -maxdepth 2 -name package.json | sort)
-
-echo "Starting PM2 processes from $ECOSYSTEM_CONFIG"
-pm2 start "$ECOSYSTEM_CONFIG"
-pm2 save
-pm2 list
-
-echo ""
-echo "================================="
-echo "Node Services Started via PM2"
-echo "PM2 logs: pm2 logs"
-echo "================================="
+  echo ""
+  echo "================================="
+  echo "Node Services Started via PM2"
+  echo "PM2 logs: $PM2_CMD logs"
+  echo "================================="
+else
+  start_with_nohup
+fi

--- a/scripts/stop-node-services.sh
+++ b/scripts/stop-node-services.sh
@@ -2,13 +2,33 @@
 
 set -euo pipefail
 
-echo "Stopping Node services managed by PM2..."
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PID_DIR="$REPO_ROOT/logs/node/pids"
+
+echo "Stopping Node services..."
 
 if command -v pm2 >/dev/null 2>&1; then
+  echo "Stopping PM2-managed processes..."
   pm2 delete all || true
   pm2 save || true
 else
-  echo "PM2 is not installed; nothing to stop via PM2."
+  echo "PM2 is not installed; checking nohup PID files."
+fi
+
+if [ -d "$PID_DIR" ]; then
+  while IFS= read -r pid_file; do
+    service_name="$(basename "$pid_file" .pid)"
+    pid="$(cat "$pid_file")"
+
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      echo "Stopping $service_name (PID $pid)"
+      kill "$pid" || true
+    else
+      echo "$service_name is not running (stale PID $pid)"
+    fi
+
+    rm -f "$pid_file"
+  done < <(find "$PID_DIR" -type f -name '*.pid' | sort)
 fi
 
 echo "Done."


### PR DESCRIPTION
### Motivation
- Make node service startup resilient in network-constrained or PM2-unavailable environments where global `pm2` install may fail or the npm registry is unreachable.
- Ensure services can be started/stopped reliably for development and CI workflows even when dependency installation or global tools are blocked.

### Description
- Updated `scripts/start-node-services.sh` to add `PID_DIR` management, a `run_npm` wrapper that clears proxy env vars on npm failure, and `SKIP_DEP_INSTALL` support to skip dependency installation when needed.
- Added `resolve_pm2()` to detect global or local `pm2` and attempt a guarded global install, falling back to a `nohup`-based `start_with_nohup()` launcher when `pm2` is unavailable.
- Implemented nohup startup health checks with a 2-second liveness probe, per-service PID files and logs, and clear failure reporting (tail of recent logs) that exits non-zero if any service fails to stay running.
- Updated `scripts/stop-node-services.sh` to stop both PM2-managed processes and nohup-launched services by reading and cleaning up PID files under `logs/node/pids`.

### Testing
- Ran `pytest -q` which passed (`9 passed`).
- Ran shell syntax checks with `bash -n scripts/start-node-services.sh` and `bash -n scripts/stop-node-services.sh` which succeeded.
- Executed the repository validation script `infrastructure/scripts/validate-repo.sh` which completed successfully.
- Performed automated runs of `SKIP_DEP_INSTALL=1 bash scripts/start-node-services.sh` and `bash scripts/stop-node-services.sh` to validate fallback behavior; the start run surfaced expected runtime failures (e.g. `admin-panel` failed due to missing `next`), demonstrating clearer failure reporting.
- Attempted `docker compose build`, which failed in this environment because the `docker` CLI is not available (environment constraint, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73113c43c8321a7aa82b9a06cf637)