### PR TITLE
Refactor renderer for no-cost CPU-first local stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale 
 ```
 
 
+
+## No-cost local stack (full source code)
+
+This repository is fully source-available and can run end-to-end on a single machine with only open-source components (Docker, Postgres, Redis, Nginx, Python, Node).
+
+- No paid cloud services are required for the default `docker compose` flow.
+- GPU is optional: renderer now defaults to CPU encoding so you can run without NVIDIA hardware.
+- If you have a GPU, set `FFMPEG_HWACCEL=cuda` in `.env` to enable NVENC.
+
+Example `.env` overrides for free local mode:
+
+```bash
+FFMPEG_HWACCEL=none
+FFMPEG_CPU_PRESET=veryfast
+FFMPEG_CPU_CRF=23
+```
+
 ## Full upgrade blueprint
 
 The repository now ships a typed blueprint for a **full enterprise upgrade** that covers:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
     env_file: .env
     environment:
       REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+      FFMPEG_HWACCEL: ${FFMPEG_HWACCEL:-none}
+      FFMPEG_CPU_PRESET: ${FFMPEG_CPU_PRESET:-veryfast}
+      FFMPEG_CPU_CRF: ${FFMPEG_CPU_CRF:-23}
       DB_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
     depends_on:
       postgres:
@@ -111,6 +114,9 @@ services:
     env_file: .env
     environment:
       REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+      FFMPEG_HWACCEL: ${FFMPEG_HWACCEL:-none}
+      FFMPEG_CPU_PRESET: ${FFMPEG_CPU_PRESET:-veryfast}
+      FFMPEG_CPU_CRF: ${FFMPEG_CPU_CRF:-23}
     depends_on:
       redis:
         condition: service_healthy
@@ -174,6 +180,9 @@ services:
     environment:
       PYTHONPATH: /app/src
       REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}
+      FFMPEG_HWACCEL: ${FFMPEG_HWACCEL:-none}
+      FFMPEG_CPU_PRESET: ${FFMPEG_CPU_PRESET:-veryfast}
+      FFMPEG_CPU_CRF: ${FFMPEG_CPU_CRF:-23}
     depends_on:
       redis:
         condition: service_healthy

--- a/services/gpu-renderer/src/core/render.py
+++ b/services/gpu-renderer/src/core/render.py
@@ -1,19 +1,57 @@
+import os
+import shutil
 import subprocess
 
-def render(job):
 
+def _should_use_cuda() -> bool:
+    """Enable CUDA only when explicitly requested or when nvidia-smi exists."""
+    hwaccel_mode = os.environ.get("FFMPEG_HWACCEL", "auto").strip().lower()
+
+    if hwaccel_mode in {"none", "cpu", "off", "false", "0"}:
+        return False
+
+    if hwaccel_mode in {"cuda", "nvidia", "gpu", "on", "true", "1"}:
+        return True
+
+    # auto mode
+    return shutil.which("nvidia-smi") is not None
+
+
+def build_ffmpeg_command(job):
     input_file = job["input"]
     output_file = job["output"]
 
-    cmd = [
-        "ffmpeg",
-        "-y",
-        "-hwaccel","cuda",
-        "-i",input_file,
-        "-c:v","h264_nvenc",
-        "-preset","p4",
-        "-b:v","5M",
-        output_file
+    base_cmd = ["ffmpeg", "-y", "-i", input_file]
+
+    if _should_use_cuda():
+        return [
+            "ffmpeg",
+            "-y",
+            "-hwaccel",
+            "cuda",
+            "-i",
+            input_file,
+            "-c:v",
+            "h264_nvenc",
+            "-preset",
+            "p4",
+            "-b:v",
+            "5M",
+            output_file,
+        ]
+
+    return [
+        *base_cmd,
+        "-c:v",
+        "libx264",
+        "-preset",
+        os.environ.get("FFMPEG_CPU_PRESET", "veryfast"),
+        "-crf",
+        os.environ.get("FFMPEG_CPU_CRF", "23"),
+        output_file,
     ]
 
+
+def render(job):
+    cmd = build_ffmpeg_command(job)
     subprocess.run(cmd, check=True)

--- a/tests/test_gpu_renderer_no_cost.py
+++ b/tests/test_gpu_renderer_no_cost.py
@@ -1,0 +1,32 @@
+import importlib.util
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "services" / "gpu-renderer" / "src" / "core" / "render.py"
+
+spec = importlib.util.spec_from_file_location("gpu_render_module", MODULE_PATH)
+render_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(render_module)
+
+
+def test_build_ffmpeg_command_defaults_to_cpu_when_no_gpu():
+    job = {"input": "in.mp4", "output": "out.mp4"}
+    with patch.dict(os.environ, {"FFMPEG_HWACCEL": "auto"}, clear=False), patch.object(
+        render_module.shutil, "which", return_value=None
+    ):
+        cmd = render_module.build_ffmpeg_command(job)
+
+    assert "-hwaccel" not in cmd
+    assert "libx264" in cmd
+    assert cmd[-1] == "out.mp4"
+
+
+def test_build_ffmpeg_command_uses_cuda_when_forced():
+    job = {"input": "in.mp4", "output": "out.mp4"}
+    with patch.dict(os.environ, {"FFMPEG_HWACCEL": "cuda"}, clear=False):
+        cmd = render_module.build_ffmpeg_command(job)
+
+    assert "-hwaccel" in cmd
+    assert "cuda" in cmd
+    assert "h264_nvenc" in cmd


### PR DESCRIPTION
### Motivation
- Make the platform runnable end-to-end on a single machine without requiring NVIDIA hardware or paid cloud services by default. 
- Provide an explicit opt-in path to enable GPU/NVENC acceleration when available. 

### Description
- Replace the previous hard-coded NVENC ffmpeg call with a CPU-first command builder in `services/gpu-renderer/src/core/render.py` that selects encoding mode via `_should_use_cuda()` and `build_ffmpeg_command()`.
- Add runtime environment toggles `FFMPEG_HWACCEL`, `FFMPEG_CPU_PRESET`, and `FFMPEG_CPU_CRF` and default them in `docker-compose.yml` for the renderer services so local runs work without NVIDIA hardware. 
- Document the new “No-cost local stack (full source code)” workflow and example `.env` overrides in `README.md`.
- Add `tests/test_gpu_renderer_no_cost.py` to validate CPU-default behavior and forced-CUDA command generation.

### Testing
- Ran `pytest -q tests/test_gpu_renderer_no_cost.py` which reported `2 passed`.
- Ran the full test suite with `pytest -q` which reported `18 passed` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b74a82cb5c8321be045a14ceae841b)