### PR TITLE
Refactor Node service lifecycle: installer + PM2-managed runner

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,29 @@ A non-2xx response can still prove route reachability during initial smoke tests
 pytest
 ```
 
-## 9) Shutdown and cleanup
+
+## 9) Optional Node service lifecycle management
+
+For the standalone Node.js services listed under `services/`, use the dedicated installer and PM2-backed launcher:
+
+```bash
+bash scripts/zttato-node.sh install
+bash scripts/zttato-node.sh start
+bash scripts/zttato-node.sh status
+```
+
+Useful lifecycle commands:
+
+```bash
+bash scripts/zttato-node.sh logs
+bash scripts/zttato-node.sh logs admin-panel
+bash scripts/zttato-node.sh restart
+bash scripts/zttato-node.sh stop
+```
+
+This flow keeps dependency installation separate from service startup and writes runtime artifacts to `logs/node/` and `pids/node/`.
+
+## 10) Shutdown and cleanup
 
 Stop containers while preserving data volumes:
 
@@ -97,7 +119,7 @@ Destroy volumes only when intentionally resetting local state:
 docker compose down -v
 ```
 
-## 10) Troubleshooting quick references
+## 11) Troubleshooting quick references
 
 - Restart one service: `docker compose restart <service>`
 - Recreate one service: `docker compose up -d --force-recreate <service>`

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -42,7 +42,22 @@ curl -i http://localhost/arbitrage
 pytest
 ```
 
-## 6) Daily operations shortcuts
+## 6) Optional standalone Node service flow
+
+```bash
+bash scripts/zttato-node.sh install
+bash scripts/zttato-node.sh start
+bash scripts/zttato-node.sh status
+```
+
+Stop or restart them independently from Docker when needed:
+
+```bash
+bash scripts/zttato-node.sh stop
+bash scripts/zttato-node.sh restart
+```
+
+## 7) Daily operations shortcuts
 
 - Tail logs for one service:
   ```bash
@@ -57,7 +72,7 @@ pytest
   docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale arbitrage-worker=2
   ```
 
-## 7) Access points
+## 8) Access points
 
 - API gateway (nginx): `http://localhost`
   - Predict route: `/predict`
@@ -65,7 +80,7 @@ pytest
   - Arbitrage route: `/arbitrage`
 - Admin panel is available from the repository under `services/admin-panel` for frontend runtime workflows.
 
-## 8) Stop the environment
+## 9) Stop the environment
 
 ```bash
 docker compose down

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,112 +1,36 @@
+const path = require('path');
+
+const rootDir = __dirname;
+const logDir = path.join(rootDir, 'logs', 'node');
+const pidDir = path.join(rootDir, 'pids', 'node');
+
+const services = [
+  'shopee-crawler',
+  'tiktok-uploader',
+  'tiktok-shop-miner',
+  'tiktok-farm',
+  'account-farm',
+  'analytics',
+  'admin-panel',
+  'ai-video-generator',
+  'click-tracker',
+];
+
 module.exports = {
-  apps: [
-    {
-      name: 'node-shopee-crawler',
-      cwd: './services/shopee-crawler',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
+  apps: services.map((service) => ({
+    name: `node-${service}`,
+    cwd: path.join(rootDir, 'services', service),
+    script: 'npm',
+    args: 'run start',
+    instances: 1,
+    exec_mode: 'fork',
+    autorestart: true,
+    max_memory_restart: '500M',
+    env: {
+      NODE_ENV: 'production',
     },
-    {
-      name: 'node-tiktok-uploader',
-      cwd: './services/tiktok-uploader',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-tiktok-shop-miner',
-      cwd: './services/tiktok-shop-miner',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-tiktok-farm',
-      cwd: './services/tiktok-farm',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-account-farm',
-      cwd: './services/account-farm',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-analytics',
-      cwd: './services/analytics',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-admin-panel',
-      cwd: './services/admin-panel',
-      script: 'server.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-ai-video-generator',
-      cwd: './services/ai-video-generator',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-    {
-      name: 'node-click-tracker',
-      cwd: './services/click-tracker',
-      script: 'src/index.js',
-      instances: 1,
-      exec_mode: 'fork',
-      autorestart: true,
-      max_memory_restart: '500M',
-      env: {
-        NODE_ENV: 'production',
-      },
-    },
-  ],
+    out_file: path.join(logDir, `${service}.out.log`),
+    error_file: path.join(logDir, `${service}.error.log`),
+    pid_file: path.join(pidDir, `${service}.pid`),
+  })),
 };

--- a/scripts/install-node-services.sh
+++ b/scripts/install-node-services.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZTTATO_ROOT="$ROOT"
+# shellcheck disable=SC1091
+source "$ROOT/scripts/node-services-lib.sh"
+
+printf '=================================\n'
+printf 'Installing Node Services\n'
+printf '=================================\n'
+
+for service in "${ZTTATO_NODE_SERVICES[@]}"; do
+  dir="$(zttato_node_service_dir "$service")"
+  package_json="$(zttato_node_service_package "$service")"
+
+  if [[ ! -d "$dir" ]]; then
+    printf '[SKIP] %s (directory not found)\n' "$service"
+    continue
+  fi
+
+  if [[ ! -f "$package_json" ]]; then
+    printf '[SKIP] %s (no package.json)\n' "$service"
+    continue
+  fi
+
+  printf '[INSTALL] %s\n' "$service"
+
+  (
+    cd "$dir"
+
+    if [[ -f package-lock.json ]]; then
+      npm ci --silent
+    else
+      npm install --silent
+    fi
+  )
+done
+
+printf '✅ Node services installed\n'

--- a/scripts/node-install.sh
+++ b/scripts/node-install.sh
@@ -1,49 +1,7 @@
-# scripts/node-install.sh
 #!/usr/bin/env bash
 
 set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-############################################
-# colors
-############################################
-
-GREEN="\033[32m"
-NC="\033[0m"
-
-log(){
-echo -e "${GREEN}[zTTato]${NC} $*"
-}
-
-############################################
-# install node services
-############################################
-
-log "Installing Node services"
-
-for svc in "$ROOT/services/"*
-do
-
-if [ ! -f "$svc/package.json" ]; then
-continue
-fi
-
-NAME=$(basename "$svc")
-
-log "npm install -> $NAME"
-
-(
-cd "$svc"
-
-if [ -f package-lock.json ]; then
-npm ci --silent
-else
-npm install --silent
-fi
-
-)
-
-done
-
-log "Node dependencies installed"
+bash "$ROOT/scripts/install-node-services.sh"

--- a/scripts/node-services-lib.sh
+++ b/scripts/node-services-lib.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Shared configuration for zTTato-managed Node.js services.
+
+if [[ -z "${ZTTATO_ROOT:-}" ]]; then
+  ZTTATO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+ZTTATO_NODE_SERVICES_ROOT="$ZTTATO_ROOT/services"
+ZTTATO_NODE_LOG_DIR="$ZTTATO_ROOT/logs/node"
+ZTTATO_NODE_PID_DIR="$ZTTATO_ROOT/pids/node"
+
+ZTTATO_NODE_SERVICES=(
+  shopee-crawler
+  tiktok-uploader
+  tiktok-shop-miner
+  tiktok-farm
+  account-farm
+  analytics
+  admin-panel
+  ai-video-generator
+  click-tracker
+)
+
+zttato_node_print_service_list() {
+  printf '%s\n' "${ZTTATO_NODE_SERVICES[@]}"
+}
+
+zttato_node_service_dir() {
+  printf '%s/%s\n' "$ZTTATO_NODE_SERVICES_ROOT" "$1"
+}
+
+zttato_node_service_package() {
+  printf '%s/package.json\n' "$(zttato_node_service_dir "$1")"
+}
+
+zttato_node_prepare_runtime_dirs() {
+  mkdir -p "$ZTTATO_NODE_LOG_DIR" "$ZTTATO_NODE_PID_DIR"
+}
+
+zttato_node_has_package() {
+  [[ -f "$(zttato_node_service_package "$1")" ]]
+}

--- a/scripts/run-node-services.sh
+++ b/scripts/run-node-services.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZTTATO_ROOT="$ROOT"
+# shellcheck disable=SC1091
+source "$ROOT/scripts/node-services-lib.sh"
+
+zttato_node_prepare_runtime_dirs
+
+if ! command -v pm2 >/dev/null 2>&1; then
+  echo 'ERROR: pm2 is required to start managed Node services.' >&2
+  echo 'Install it with: npm install -g pm2' >&2
+  exit 1
+fi
+
+printf '=================================\n'
+printf 'Starting Node Services\n'
+printf '=================================\n'
+
+pm2 start "$ROOT/ecosystem.config.js" --update-env
+pm2 save >/dev/null
+pm2 ls
+
+printf '✅ Node services started via PM2\n'
+printf 'Logs: %s\n' "$ZTTATO_NODE_LOG_DIR"
+printf 'PIDs: %s\n' "$ZTTATO_NODE_PID_DIR"

--- a/scripts/start-node-services.sh
+++ b/scripts/start-node-services.sh
@@ -1,41 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SERVICES="$ROOT/services"
 
-echo "================================="
-echo "Installing Node Dependencies"
-echo "================================="
-
-for dir in \
-  shopee-crawler \
-  tiktok-uploader \
-  tiktok-shop-miner \
-  tiktok-farm \
-  account-farm \
-  analytics \
-  admin-panel \
-  ai-video-generator \
-  click-tracker
-do
-  echo "Installing dependencies -> $dir"
-  cd "$SERVICES/$dir"
-  npm install --production
-done
-
-echo "================================="
-echo "Starting Node Services via PM2"
-echo "================================="
-
-cd "$ROOT"
-
-pm2 start ecosystem.config.js
-pm2 save
-
-echo "================================="
-echo "Node Services Running"
-echo "================================="
-
-pm2 list
+bash "$ROOT/scripts/install-node-services.sh"
+bash "$ROOT/scripts/run-node-services.sh"

--- a/scripts/stop-node-services.sh
+++ b/scripts/stop-node-services.sh
@@ -1,4 +1,32 @@
 #!/usr/bin/env bash
 
-pm2 delete all
-pm2 save
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZTTATO_ROOT="$ROOT"
+# shellcheck disable=SC1091
+source "$ROOT/scripts/node-services-lib.sh"
+
+zttato_node_prepare_runtime_dirs
+
+printf '=================================\n'
+printf 'Stopping Node Services\n'
+printf '=================================\n'
+
+if command -v pm2 >/dev/null 2>&1; then
+  for service in "${ZTTATO_NODE_SERVICES[@]}"; do
+    app_name="node-$service"
+    if pm2 describe "$app_name" >/dev/null 2>&1; then
+      printf '[STOP] %s\n' "$app_name"
+      pm2 delete "$app_name" >/dev/null
+    else
+      printf '[SKIP] %s (not running in PM2)\n' "$app_name"
+    fi
+  done
+  pm2 save >/dev/null || true
+else
+  printf '[WARN] pm2 not found; removing stale pid files only\n'
+fi
+
+find "$ZTTATO_NODE_PID_DIR" -maxdepth 1 -type f -name '*.pid' -delete
+printf '✅ Node services stopped\n'

--- a/scripts/zttato
+++ b/scripts/zttato
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # zttato
 
-set -e
+set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -51,6 +51,30 @@ curl -I https://api.zeaz.dev || true
 curl -I https://gpu.zeaz.dev || true
 ;;
 
+node-install)
+bash "$ROOT/scripts/install-node-services.sh"
+;;
+
+node-start)
+bash "$ROOT/scripts/run-node-services.sh"
+;;
+
+node-stop)
+bash "$ROOT/scripts/stop-node-services.sh"
+;;
+
+node-restart)
+bash "$ROOT/scripts/zttato-node.sh" restart
+;;
+
+node-status)
+bash "$ROOT/scripts/zttato-node.sh" status
+;;
+
+node-logs)
+bash "$ROOT/scripts/zttato-node.sh" logs "${2:-}"
+;;
+
 *)
 echo "Usage:"
 echo "zttato up"
@@ -59,6 +83,12 @@ echo "zttato restart"
 echo "zttato status"
 echo "zttato logs [service]"
 echo "zttato edge"
+echo "zttato node-install"
+echo "zttato node-start"
+echo "zttato node-stop"
+echo "zttato node-status"
+echo "zttato node-restart"
+echo "zttato node-logs [service]"
 ;;
 
 esac

--- a/scripts/zttato-node.sh
+++ b/scripts/zttato-node.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZTTATO_ROOT="$ROOT"
+# shellcheck disable=SC1091
+source "$ROOT/scripts/node-services-lib.sh"
+
+usage() {
+  echo 'Usage: scripts/zttato-node.sh {install|start|stop|restart|status|logs [service]}'
+}
+
+case "${1:-}" in
+  install)
+    bash "$ROOT/scripts/install-node-services.sh"
+    ;;
+  start)
+    bash "$ROOT/scripts/run-node-services.sh"
+    ;;
+  stop)
+    bash "$ROOT/scripts/stop-node-services.sh"
+    ;;
+  restart)
+    bash "$ROOT/scripts/stop-node-services.sh"
+    bash "$ROOT/scripts/run-node-services.sh"
+    ;;
+  status)
+    if ! command -v pm2 >/dev/null 2>&1; then
+      echo 'PM2 is not installed.' >&2
+      exit 1
+    fi
+    pm2 ls
+    ;;
+  logs)
+    if ! command -v pm2 >/dev/null 2>&1; then
+      echo 'PM2 is not installed.' >&2
+      exit 1
+    fi
+
+    if [[ -n "${2:-}" ]]; then
+      pm2 logs "node-$2"
+    else
+      echo "Managed log files: $ZTTATO_NODE_LOG_DIR"
+      find "$ZTTATO_NODE_LOG_DIR" -maxdepth 1 -type f | sort
+    fi
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/zttato
+++ b/zttato
@@ -72,16 +72,27 @@ bash "$ROOT/scripts/zttato-doctor.sh"
 ;;
 
 node-install)
-bash "$ROOT/scripts/node-install.sh"
+bash "$ROOT/scripts/install-node-services.sh"
 ;;
 
-node-status)
-ps aux | grep node
+node-start)
+bash "$ROOT/scripts/run-node-services.sh"
+;;
+
+node-stop)
+bash "$ROOT/scripts/stop-node-services.sh"
 ;;
 
 node-restart)
-pkill node
-zttato up
+bash "$ROOT/scripts/zttato-node.sh" restart
+;;
+
+node-status)
+bash "$ROOT/scripts/zttato-node.sh" status
+;;
+
+node-logs)
+bash "$ROOT/scripts/zttato-node.sh" logs "${2:-}"
 ;;
 
 deploy)
@@ -105,8 +116,11 @@ echo "zttato monitor"
 echo "zttato edge"
 echo "zttato deploy"
 echo "node-install"
+echo "node-start"
+echo "node-stop"
 echo "node-status"
 echo "node-restart"
+echo "node-logs [service]"
 echo
 
 ;;


### PR DESCRIPTION
### Motivation

- Separate Node service dependency installation from runtime lifecycle and provide a clean, production-ready launcher for standalone Node services. 
- Provide a consistent PM2-based runtime that centralizes log/pid locations and exposes lifecycle commands from the existing CLI. 

### Description

- Add a small shared inventory/runtime library `scripts/node-services-lib.sh` and new lifecycle scripts `scripts/install-node-services.sh`, `scripts/run-node-services.sh`, and `scripts/zttato-node.sh` to provide `install|start|stop|restart|status|logs` for Node services, writing runtime artifacts under `logs/node/` and `pids/node/`. 
- Replace the old per-service PM2 configuration with a generated `ecosystem.config.js` that maps the repository service list to PM2 apps running `npm run start` for each managed Node service. 
- Update existing script wrappers (`scripts/start-node-services.sh`, `scripts/stop-node-services.sh`, `scripts/node-install.sh`) to call the new dedicated scripts and make the stop flow PM2-aware while also cleaning pid files when PM2 is not present. 
- Expose the Node lifecycle commands through both top-level CLIs (`zttato` and `scripts/zttato`) and document the optional standalone Node flow in `docs/quick-start.md` and `docs/installation.md`. 
- Keep the change scoped to lifecycle tooling and docs; service sources and Docker/K8s artifacts were not modified. 

### Testing

- Performed shell syntax checks: `bash -n` on the new and updated scripts and they passed. 
- Validated PM2 config generation with Node: `require('./ecosystem.config.js')` succeeded and produced the expected app list. 
- Ran the automated test suite: `pytest` — all tests passed (`18 passed`). 
- Verified runtime guard: `scripts/zttato-node.sh status` correctly exits with a helpful message because `pm2` is not installed in the execution environment (expected behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdb818af8083219409808112db6ec7)