### PR TITLE
Reduce viral-predictor image size by replacing PyTorch with lightweight NumPy model

### DIFF
--- a/services/viral-predictor/requirements.txt
+++ b/services/viral-predictor/requirements.txt
@@ -3,8 +3,6 @@ uvicorn==0.35.0
 pydantic==2.11.7
 numpy==2.3.3
 pandas==2.3.2
-scikit-learn==1.7.2
-torch==2.8.0
 psycopg2-binary==2.9.10
 redis==6.4.0
 prometheus-client==0.23.1

--- a/services/viral-predictor/src/model/model.py
+++ b/services/viral-predictor/src/model/model.py
@@ -1,39 +1,40 @@
-import torch
-import torch.nn as nn
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+MODEL_PATH = Path(__file__).resolve().parents[1] / "viral_model.json"
+FEATURE_COUNT = 5
+DEFAULT_WEIGHTS = np.array([1e-6, 2e-4, 4e-4, 6e-4, 3.5], dtype=float)
+DEFAULT_BIAS = -2.0
 
 
-class ViralNet(nn.Module):
+class ViralNet:
+    def __init__(self, weights: np.ndarray | None = None, bias: float = DEFAULT_BIAS):
+        self.weights = np.array(weights if weights is not None else DEFAULT_WEIGHTS, dtype=float)
+        self.bias = float(bias)
 
-    def __init__(self):
+    def forward(self, x: np.ndarray) -> np.ndarray:
+        logits = x @ self.weights + self.bias
+        return 1.0 / (1.0 + np.exp(-np.clip(logits, -50.0, 50.0)))
 
-        super().__init__()
+    def save(self, path: Path = MODEL_PATH) -> None:
+        path.write_text(json.dumps({"weights": self.weights.tolist(), "bias": self.bias}), encoding="utf-8")
 
-        self.net = nn.Sequential(
-
-            nn.Linear(5,64),
-            nn.ReLU(),
-
-            nn.Linear(64,32),
-            nn.ReLU(),
-
-            nn.Linear(32,1),
-            nn.Sigmoid()
-
-        )
-
-    def forward(self,x):
-
-        return self.net(x)
+    @classmethod
+    def load(cls, path: Path = MODEL_PATH) -> "ViralNet":
+        if not path.exists():
+            return cls()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return cls(weights=np.array(data["weights"], dtype=float), bias=float(data["bias"]))
 
 
-model = ViralNet()
+model = ViralNet.load()
 
-def predict(features):
 
-    x = torch.tensor(features).float()
-
-    with torch.no_grad():
-
-        score = model(x)
-
+def predict(features: np.ndarray) -> float:
+    feature_array = np.asarray(features, dtype=float).reshape(1, FEATURE_COUNT)
+    score = model.forward(feature_array)[0]
     return float(score)

--- a/services/viral-predictor/src/training/train.py
+++ b/services/viral-predictor/src/training/train.py
@@ -1,34 +1,45 @@
-import torch
+from __future__ import annotations
+
+import numpy as np
 import pandas as pd
 
-from model.model import ViralNet
+from model.model import FEATURE_COUNT, ViralNet
+
+FEATURE_COLUMNS = ["views", "likes", "comments", "shares", "engagement"]
+TARGET_COLUMN = "viral"
 
 
-def train(datafile):
+def _sigmoid(values: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(values, -50.0, 50.0)))
 
+
+def train(datafile: str, epochs: int = 1500, learning_rate: float = 0.1) -> ViralNet:
     df = pd.read_csv(datafile)
+    X = df[FEATURE_COLUMNS].to_numpy(dtype=float)
+    y = df[TARGET_COLUMN].to_numpy(dtype=float)
 
-    X = df[["views","likes","comments","shares","engagement"]].values
-    y = df["viral"].values
+    if X.shape[1] != FEATURE_COUNT:
+        raise ValueError(f"Expected {FEATURE_COUNT} features, got {X.shape[1]}")
 
-    model = ViralNet()
+    means = X.mean(axis=0)
+    stds = np.where(X.std(axis=0) == 0.0, 1.0, X.std(axis=0))
+    X_scaled = (X - means) / stds
 
-    optimizer = torch.optim.Adam(model.parameters())
-    loss_fn = torch.nn.BCELoss()
+    weights = np.zeros(FEATURE_COUNT, dtype=float)
+    bias = 0.0
 
-    X = torch.tensor(X).float()
-    y = torch.tensor(y).float().unsqueeze(1)
+    sample_count = len(X_scaled)
+    for _ in range(epochs):
+        logits = X_scaled @ weights + bias
+        predictions = _sigmoid(logits)
+        errors = predictions - y
 
-    for epoch in range(100):
+        weights -= learning_rate * (X_scaled.T @ errors) / sample_count
+        bias -= learning_rate * errors.mean()
 
-        pred = model(X)
+    scaled_weights = weights / stds
+    scaled_bias = bias - np.dot(means / stds, weights)
 
-        loss = loss_fn(pred,y)
-
-        optimizer.zero_grad()
-
-        loss.backward()
-
-        optimizer.step()
-
-    torch.save(model.state_dict(),"viral_model.pt")
+    model = ViralNet(weights=scaled_weights, bias=scaled_bias)
+    model.save()
+    return model


### PR DESCRIPTION
### Motivation
- The `viral-predictor` Docker build was exhausting disk space during `pip install` because the service pulled the large GPU-enabled PyTorch/CUDA wheels.  
- The service only needs a tiny inference/training surface for a 5-feature scoring flow, so replacing heavy ML runtime with a small numeric implementation reduces image footprint.  

### Description
- Removed `torch` and `scikit-learn` from `services/viral-predictor/requirements.txt` so the image no longer downloads massive CUDA/PyTorch packages.  
- Replaced the PyTorch-based model with a lightweight NumPy-based `ViralNet` that loads/saves JSON weights and provides the same `predict(...)` function contract in `services/viral-predictor/src/model/model.py`.  
- Rewrote the training helper in `services/viral-predictor/src/training/train.py` to implement simple gradient-descent training using NumPy and persist learned weights to the new model format.  

### Testing
- Ran `python -m compileall services/viral-predictor/src` which compiled the updated sources successfully.  
- Attempted `docker build -t zttato-platform-viral-predictor-test services/viral-predictor` but `docker` is not available in the execution environment so the container build could not be validated here.  
- Attempted a quick runtime import check outside a container but the host Python lacked `numpy`, so runtime import verification could not complete outside of a container build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be4e2f4bc4832199e060920bd677c7)