### PR TITLE
Add compliant execution engine, affiliate webhook, and safe egress client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,54 @@ services:
     networks:
       - zttato-net
 
+  execution-engine:
+    build:
+      context: ./services/execution-engine
+      dockerfile: Dockerfile
+    container_name: zttato-execution-engine
+    restart: always
+    env_file: .env
+    environment:
+      PLATFORM_API_BASE: ${PLATFORM_API_BASE:-https://api.partner.example}
+      PLATFORM_API_KEY: ${PLATFORM_API_KEY:-}
+      HTTP_TIMEOUT: ${HTTP_TIMEOUT:-10}
+      RATE_TOKENS: ${RATE_TOKENS:-60}
+      RATE_MAX_TOKENS: ${RATE_MAX_TOKENS:-120}
+      RATE_REFILL_PER_SEC: ${RATE_REFILL_PER_SEC:-1}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9600),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  affiliate-webhook:
+    build:
+      context: ./services/affiliate-webhook
+      dockerfile: Dockerfile
+    container_name: zttato-affiliate-webhook
+    restart: always
+    env_file: .env
+    environment:
+      AFFILIATE_WEBHOOK_SECRET: ${AFFILIATE_WEBHOOK_SECRET:-change-me}
+      DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9700),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
   nginx:
     image: nginx:1.27-alpine
     container_name: zttato-nginx

--- a/infrastructure/postgres/migrations/001_schema.sql
+++ b/infrastructure/postgres/migrations/001_schema.sql
@@ -146,6 +146,24 @@ created_at TIMESTAMP DEFAULT NOW()
 
 
 
+CREATE TABLE IF NOT EXISTS campaign_metrics (
+
+id BIGSERIAL PRIMARY KEY,
+
+campaign_id UUID REFERENCES campaigns(id),
+
+views INT DEFAULT 0,
+
+clicks INT DEFAULT 0,
+
+conversions INT DEFAULT 0,
+
+revenue NUMERIC DEFAULT 0,
+
+created_at TIMESTAMP DEFAULT NOW()
+
+);
+
 CREATE TABLE IF NOT EXISTS clicks (
 
 id BIGSERIAL PRIMARY KEY,

--- a/services/affiliate-webhook/Dockerfile
+++ b/services/affiliate-webhook/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12.8-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+
+CMD ["python", "src/main.py"]

--- a/services/affiliate-webhook/requirements.txt
+++ b/services/affiliate-webhook/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+psycopg2-binary==2.9.10

--- a/services/affiliate-webhook/src/main.py
+++ b/services/affiliate-webhook/src/main.py
@@ -1,0 +1,73 @@
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+
+import psycopg2
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request
+
+app = FastAPI(title="Affiliate Webhook (Verified)")
+
+SECRET = os.getenv("AFFILIATE_WEBHOOK_SECRET", "")
+DB_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://zttato:zttato@postgres:5432/zttato",
+)
+
+
+def verify(signature: str, body: bytes) -> bool:
+    mac = hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(mac, signature or "")
+
+
+def db_connection():
+    return psycopg2.connect(DB_URL)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    db_ok = False
+    try:
+        with db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("select 1")
+                cur.fetchone()
+        db_ok = True
+    except Exception:
+        db_ok = False
+
+    return {
+        "status": "ok" if db_ok else "degraded",
+        "service": "affiliate-webhook",
+        "checks": {"db": db_ok},
+    }
+
+
+@app.post("/conversion")
+async def conversion(req: Request) -> dict[str, bool]:
+    body = await req.body()
+    signature = req.headers.get("X-Signature", "")
+    if not verify(signature, body):
+        raise HTTPException(status_code=401, detail="invalid signature")
+
+    data = json.loads(body.decode())
+    campaign_id = data["campaign_id"]
+    revenue = float(data.get("revenue", 0))
+
+    with db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO campaign_metrics (campaign_id, views, clicks, conversions, revenue)
+                VALUES (%s, 0, 0, 1, %s)
+                """,
+                (campaign_id, revenue),
+            )
+
+    return {"ok": True}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=9700)

--- a/services/execution-engine/Dockerfile
+++ b/services/execution-engine/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12.8-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+
+CMD ["python", "src/main.py"]

--- a/services/execution-engine/requirements.txt
+++ b/services/execution-engine/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+requests==2.32.5
+pydantic==2.11.7

--- a/services/execution-engine/src/main.py
+++ b/services/execution-engine/src/main.py
@@ -1,0 +1,119 @@
+import logging
+import os
+import time
+from threading import Lock
+from typing import Any
+from typing import Optional
+
+import requests
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Execution Engine (Compliant)")
+log = logging.getLogger("execution-engine")
+logging.basicConfig(level=logging.INFO)
+
+API_BASE = os.getenv("PLATFORM_API_BASE", "https://api.partner.example")
+API_KEY = os.getenv("PLATFORM_API_KEY", "")
+TIMEOUT = float(os.getenv("HTTP_TIMEOUT", "10"))
+MAX_TOKENS = int(os.getenv("RATE_MAX_TOKENS", "120"))
+TOKENS = int(os.getenv("RATE_TOKENS", str(min(60, MAX_TOKENS))))
+LAST_REFILL = time.time()
+REFILL_RATE = float(os.getenv("RATE_REFILL_PER_SEC", "1"))
+TOKEN_LOCK = Lock()
+
+
+class PublishRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    video_url: str = Field(min_length=1)
+    caption: str = Field(min_length=1, max_length=2200)
+    destination_url: str = Field(min_length=1)
+
+
+class PublishResponse(BaseModel):
+    ok: bool
+    external_id: Optional[str] = None
+    status: str
+
+
+def http_post(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {API_KEY}",
+                "Content-Type": "application/json",
+            },
+            timeout=TIMEOUT,
+        )
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(status_code=502, detail=f"Upstream error: {response.text}")
+
+    return response.json()
+
+
+def acquire_token() -> None:
+    global TOKENS, LAST_REFILL
+
+    with TOKEN_LOCK:
+        now = time.time()
+        delta = now - LAST_REFILL
+        refill = int(delta * REFILL_RATE)
+        if refill > 0:
+            TOKENS = min(MAX_TOKENS, TOKENS + refill)
+            LAST_REFILL = now
+
+        if TOKENS <= 0:
+            raise HTTPException(status_code=429, detail="Rate limited")
+
+        TOKENS -= 1
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "service": "execution-engine",
+        "config": {
+            "api_base": API_BASE,
+            "timeout": TIMEOUT,
+            "max_tokens": MAX_TOKENS,
+            "refill_rate": REFILL_RATE,
+        },
+    }
+
+
+@app.post("/publish", response_model=PublishResponse)
+def publish(req: PublishRequest) -> PublishResponse:
+    acquire_token()
+
+    payload = {
+        "video_url": req.video_url,
+        "caption": req.caption,
+        "destination_url": req.destination_url,
+        "metadata": {"campaign_id": req.campaign_id},
+    }
+
+    log.info("Publishing campaign=%s", req.campaign_id)
+    data = http_post(f"{API_BASE}/content/publish", payload)
+
+    return PublishResponse(
+        ok=True,
+        external_id=data.get("id"),
+        status=data.get("status", "submitted"),
+    )
+
+
+@app.get("/status/{external_id}")
+def status(external_id: str) -> dict[str, Any]:
+    acquire_token()
+    return http_post(f"{API_BASE}/content/status", {"id": external_id})
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=9600)

--- a/services/master-orchestrator/src/execution.py
+++ b/services/master-orchestrator/src/execution.py
@@ -1,0 +1,14 @@
+import requests
+
+
+def execute_campaign(campaign):
+    payload = {
+        "campaign_id": campaign["id"],
+        "video_url": campaign["video_url"],
+        "caption": campaign["caption"],
+        "destination_url": campaign["landing"],
+    }
+
+    response = requests.post("http://execution-engine:9600/publish", json=payload, timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/services/network-egress/src/client.py
+++ b/services/network-egress/src/client.py
@@ -1,0 +1,22 @@
+import time
+
+import requests
+
+
+class SafeHttpClient:
+    def __init__(self, timeout: int = 10, retries: int = 3, backoff: float = 0.5):
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff = backoff
+
+    def post(self, url, json=None, headers=None):
+        for attempt in range(self.retries):
+            try:
+                response = requests.post(url, json=json, headers=headers, timeout=self.timeout)
+                if response.status_code < 500:
+                    return response
+            except requests.RequestException:
+                pass
+            time.sleep(self.backoff * (2 ** attempt))
+
+        raise RuntimeError("request failed after retries")


### PR DESCRIPTION
### Motivation
- Add a production-compliant execution path to publish campaign content through official partner APIs with rate limiting and safety controls. 
- Capture affiliate conversion events securely and persist revenue/metrics to Postgres for analytics and optimization. 
- Provide a small reusable HTTP client with retries/backoff to centralize egress policies and make orchestrator-to-executor calls robust. 

### Description
- Introduce a new FastAPI `execution-engine` service that publishes via `PLATFORM_API_BASE` with an in-memory token-bucket rate limiter, health/status endpoints, and configurable timeouts (`services/execution-engine/src/main.py`, Dockerfile, requirements). 
- Add an `affiliate-webhook` FastAPI service that verifies HMAC `X-Signature` and inserts conversion/revenue rows into a new `campaign_metrics` Postgres table (`services/affiliate-webhook/src/main.py`, Dockerfile, requirements; DB migration updated). 
- Add a `SafeHttpClient` with retries and exponential backoff for compliant egress (`services/network-egress/src/client.py`) and a simple orchestrator helper that posts campaigns to the execution engine (`services/master-orchestrator/src/execution.py`). 
- Wire services into `docker-compose.yml` with env variables, Postgres dependency/healthchecks, and network membership, and extend DB bootstrap SQL to create `campaign_metrics`. 

### Testing
- Ran Python compilation with `python -m compileall services/execution-engine/src services/affiliate-webhook/src services/network-egress/src services/master-orchestrator/src` which completed successfully. 
- Ran unit/integration test suite with `pytest` which passed: 21 tests passed. 
- Attempted `docker compose config` validation but the `docker` CLI is not available in this environment, so compose validation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be532bed308321be2e56bddf9ba721)