### PR TITLE
Add end-to-end RL loop: LinUCB RL engine, reward collector, and scaling engine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      reward-collector:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',9700),2); s.close()"]
       interval: 15s
@@ -329,6 +331,67 @@ services:
     networks:
       - zttato-net
 
+  rl-engine:
+    build:
+      context: ./services/rl-engine
+      dockerfile: Dockerfile
+    container_name: zttato-rl-engine
+    restart: always
+    env_file: .env
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0
+      DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  scaling-engine:
+    build:
+      context: ./services/scaling-engine
+      dockerfile: Dockerfile
+    container_name: zttato-scaling-engine
+    restart: always
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  reward-collector:
+    build:
+      context: ./services/reward-collector
+      dockerfile: Dockerfile
+    container_name: zttato-reward-collector
+    restart: always
+    env_file: .env
+    depends_on:
+      feature-store:
+        condition: service_healthy
+      rl-engine:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
   master-orchestrator:
     build:
       context: ./services/master-orchestrator
@@ -342,6 +405,10 @@ services:
       feature-store:
         condition: service_healthy
       model-service:
+        condition: service_healthy
+      rl-engine:
+        condition: service_healthy
+      scaling-engine:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]

--- a/infrastructure/postgres/migrations/001_schema.sql
+++ b/infrastructure/postgres/migrations/001_schema.sql
@@ -223,3 +223,24 @@ ON products(sold);
 
 
 
+
+
+CREATE TABLE IF NOT EXISTS rl_decisions (
+
+id BIGSERIAL PRIMARY KEY,
+
+campaign_id TEXT NOT NULL,
+
+selected_campaign_id TEXT NOT NULL,
+
+score NUMERIC NOT NULL,
+
+features JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+created_at TIMESTAMP DEFAULT NOW()
+
+);
+
+CREATE INDEX IF NOT EXISTS idx_rl_decisions_campaign_created_at
+
+ON rl_decisions(campaign_id, created_at DESC);

--- a/services/affiliate-webhook/src/main.py
+++ b/services/affiliate-webhook/src/main.py
@@ -5,16 +5,16 @@ import os
 from typing import Any
 
 import psycopg2
+import requests
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 
 app = FastAPI(title="Affiliate Webhook (Verified)")
 
 SECRET = os.getenv("AFFILIATE_WEBHOOK_SECRET", "")
-DB_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://zttato:zttato@postgres:5432/zttato",
-)
+DB_URL = os.getenv("DATABASE_URL", "postgresql://zttato:zttato@postgres:5432/zttato")
+REWARD_COLLECTOR_URL = os.getenv("REWARD_COLLECTOR_URL", "http://reward-collector:8000/reward")
+TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "10"))
 
 
 def verify(signature: str, body: bytes) -> bool:
@@ -65,6 +65,22 @@ async def conversion(req: Request) -> dict[str, bool]:
                 """,
                 (campaign_id, revenue),
             )
+
+    try:
+        response = requests.post(
+            REWARD_COLLECTOR_URL,
+            json={
+                "campaign_id": campaign_id,
+                "revenue": revenue,
+                "conversions": 1,
+                "clicks": int(data.get("clicks", 0)),
+                "views": int(data.get("views", 0)),
+            },
+            timeout=TIMEOUT,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"reward collector unavailable: {exc}") from exc
 
     return {"ok": True}
 

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -9,6 +9,20 @@ app = FastAPI(title="Master Orchestrator")
 TIMEOUT = 10
 
 
+def decide_and_scale(campaign_id: str, features: dict[str, Any]) -> dict[str, Any]:
+    selection = safe_call(
+        requests.post,
+        "http://rl-engine:8000/select",
+        json={"campaign_id": campaign_id, "features": features},
+    )
+    scaling = safe_call(
+        requests.post,
+        "http://scaling-engine:8000/scale",
+        json={"campaign_id": selection["selected_campaign_id"], "score": selection["score"]},
+    )
+    return {"rl": selection, "scaling": scaling}
+
+
 class Offer(BaseModel):
     id: str = Field(min_length=1)
     video_url: str = Field(min_length=1)
@@ -20,6 +34,8 @@ class CampaignDecision(BaseModel):
     offer: dict[str, Any]
     features: dict[str, Any]
     model: dict[str, Any]
+    rl: dict[str, Any]
+    scaling: dict[str, Any]
     execution: dict[str, Any]
 
 
@@ -44,6 +60,7 @@ def healthz() -> dict[str, Any]:
 def run_campaign(offer: Offer) -> CampaignDecision:
     metrics = safe_call(requests.get, f"http://feature-store:8000/features/{offer.id}")
     model = safe_call(requests.post, "http://model-service:8000/predict", json=metrics)
+    rl_result = decide_and_scale(offer.id, metrics)
     execution = safe_call(
         requests.post,
         "http://execution-engine:9600/publish",
@@ -59,6 +76,8 @@ def run_campaign(offer: Offer) -> CampaignDecision:
         offer=offer.model_dump(),
         features=metrics,
         model=model,
+        rl=rl_result["rl"],
+        scaling=rl_result["scaling"],
         execution=execution,
     )
 

--- a/services/master-orchestrator/src/rl_loop.py
+++ b/services/master-orchestrator/src/rl_loop.py
@@ -1,0 +1,26 @@
+import requests
+
+TIMEOUT = 10
+
+
+def decide_and_scale(campaign_id: str) -> dict:
+    features_response = requests.get(f"http://feature-store:8000/features/{campaign_id}", timeout=TIMEOUT)
+    features_response.raise_for_status()
+    features = features_response.json()
+
+    selection_response = requests.post(
+        "http://rl-engine:8000/select",
+        json={"campaign_id": campaign_id, "features": features},
+        timeout=TIMEOUT,
+    )
+    selection_response.raise_for_status()
+    selection = selection_response.json()
+
+    scale_response = requests.post(
+        "http://scaling-engine:8000/scale",
+        json={"campaign_id": selection["selected_campaign_id"], "score": selection["score"]},
+        timeout=TIMEOUT,
+    )
+    scale_response.raise_for_status()
+
+    return {"features": features, "rl": selection, "scale": scale_response.json()}

--- a/services/reward-collector/Dockerfile
+++ b/services/reward-collector/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/reward-collector/requirements.txt
+++ b/services/reward-collector/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-psycopg2-binary==2.9.10
 requests==2.32.5
+pydantic==2.11.7

--- a/services/reward-collector/src/main.py
+++ b/services/reward-collector/src/main.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+import requests
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Reward Collector")
+TIMEOUT = 10
+
+
+class RewardEvent(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    revenue: float = Field(default=0.0, ge=0.0)
+    conversions: int = Field(default=0, ge=0)
+    clicks: int = Field(default=0, ge=0)
+    views: int = Field(default=0, ge=0)
+
+
+class RewardResponse(BaseModel):
+    ok: bool
+    campaign_id: str
+    reward: float
+
+
+def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
+    kwargs.setdefault("timeout", TIMEOUT)
+    try:
+        response = method(url, **kwargs)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"Upstream call failed for {url}: {exc}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail=f"Invalid JSON response from {url}: {exc}") from exc
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {"status": "ok", "service": "reward-collector"}
+
+
+@app.post("/reward", response_model=RewardResponse)
+def reward(event: RewardEvent) -> RewardResponse:
+    ctr = (event.clicks / event.views) if event.views else 0.0
+    cvr = (event.conversions / event.clicks) if event.clicks else 0.0
+    reward_value = round((0.5 * ctr) + (0.5 * cvr) + (event.revenue * 0.01), 6)
+
+    features = safe_call(requests.get, f"http://feature-store:8000/features/{event.campaign_id}")
+    safe_call(
+        requests.post,
+        "http://rl-engine:8000/update",
+        json={"campaign_id": event.campaign_id, "features": features, "reward": reward_value},
+    )
+    return RewardResponse(ok=True, campaign_id=event.campaign_id, reward=reward_value)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/rl-engine/Dockerfile
+++ b/services/rl-engine/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/rl-engine/requirements.txt
+++ b/services/rl-engine/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+requests==2.32.5
+redis==6.4.0
+psycopg2-binary==2.9.10
+pydantic==2.11.7
+numpy==2.3.2

--- a/services/rl-engine/src/linucb.py
+++ b/services/rl-engine/src/linucb.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+
+class LinUCB:
+    """Disjoint LinUCB contextual bandit with ridge regularization."""
+
+    def __init__(self, arms: list[str], d: int, alpha: float = 1.0, lam: float = 1.0):
+        if d <= 0:
+            raise ValueError("d must be > 0")
+        if not arms:
+            raise ValueError("at least one arm is required")
+
+        deduped_arms = list(dict.fromkeys(arms))
+        self.alpha = float(alpha)
+        self.lam = float(lam)
+        self.d = d
+        self.arms = deduped_arms
+        self.A = {arm: np.eye(d, dtype=np.float64) * self.lam for arm in self.arms}
+        self.b = {arm: np.zeros((d, 1), dtype=np.float64) for arm in self.arms}
+
+    def add_arm(self, arm: str) -> None:
+        if arm in self.A:
+            return
+        self.arms.append(arm)
+        self.A[arm] = np.eye(self.d, dtype=np.float64) * self.lam
+        self.b[arm] = np.zeros((self.d, 1), dtype=np.float64)
+
+    def select(self, x: np.ndarray) -> tuple[str, float]:
+        if x.shape != (self.d, 1):
+            raise ValueError("x must be shaped (d, 1)")
+
+        best_arm = self.arms[0]
+        best_score = float("-inf")
+        for arm in self.arms:
+            a_inv = np.linalg.inv(self.A[arm])
+            theta = a_inv @ self.b[arm]
+            uncertainty = float(np.sqrt((x.T @ a_inv @ x).item()))
+            score = float((theta.T @ x).item() + (self.alpha * uncertainty))
+            if score > best_score:
+                best_score = score
+                best_arm = arm
+
+        return best_arm, best_score
+
+    def update(self, arm: str, x: np.ndarray, reward: float) -> None:
+        if x.shape != (self.d, 1):
+            raise ValueError("x must be shaped (d, 1)")
+        if arm not in self.A:
+            self.add_arm(arm)
+
+        self.A[arm] += x @ x.T
+        self.b[arm] += float(reward) * x

--- a/services/rl-engine/src/main.py
+++ b/services/rl-engine/src/main.py
@@ -1,0 +1,138 @@
+import os
+from typing import Any
+
+import numpy as np
+import redis
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from linucb import LinUCB
+from store import load_state, log_decision, save_state
+
+app = FastAPI(title="RL Engine (LinUCB)")
+STATE_KEY = os.getenv("RL_STATE_KEY", "rl:linucb")
+DEFAULT_ALPHA = float(os.getenv("RL_ALPHA", "1.0"))
+DEFAULT_LAMBDA = float(os.getenv("RL_LAMBDA", "1.0"))
+
+
+class Features(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    views: int = Field(default=0, ge=0)
+    clicks: int = Field(default=0, ge=0)
+    conversions: int = Field(default=0, ge=0)
+
+
+class SelectionRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    candidate_campaign_ids: list[str] = Field(default_factory=list)
+    features: Features
+
+
+class UpdateRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    features: Features
+    reward: float = Field(ge=0.0)
+
+
+class RLDecision(BaseModel):
+    campaign_id: str
+    selected_campaign_id: str
+    score: float
+    arms: list[str]
+
+
+class UpdateResponse(BaseModel):
+    ok: bool
+    campaign_id: str
+    reward: float
+
+
+def to_vector(features: Features) -> np.ndarray:
+    ctr = (features.clicks / features.views) if features.views else 0.0
+    cvr = (features.conversions / features.clicks) if features.clicks else 0.0
+    return np.array([[ctr], [cvr]], dtype=np.float64)
+
+
+def load_agent(arms: list[str]) -> LinUCB:
+    agent = LinUCB(arms=arms, d=2, alpha=DEFAULT_ALPHA, lam=DEFAULT_LAMBDA)
+    stored = load_state(STATE_KEY)
+    if not stored:
+        return agent
+
+    for arm in stored.get("arms", []):
+        agent.add_arm(arm)
+        agent.A[arm] = np.array(stored["A"][arm], dtype=np.float64)
+        agent.b[arm] = np.array(stored["b"][arm], dtype=np.float64)
+    return agent
+
+
+def persist_agent(agent: LinUCB) -> None:
+    payload = {
+        "arms": agent.arms,
+        "A": {arm: agent.A[arm].tolist() for arm in agent.arms},
+        "b": {arm: agent.b[arm].tolist() for arm in agent.arms},
+    }
+    save_state(STATE_KEY, payload)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    try:
+        saved = load_state(STATE_KEY)
+        redis_ok = True
+    except redis.RedisError:
+        saved = None
+        redis_ok = False
+    return {
+        "status": "ok" if redis_ok else "degraded",
+        "service": "rl-engine",
+        "checks": {"redis": redis_ok},
+        "arms": len(saved.get("arms", [])) if saved else 0,
+    }
+
+
+@app.post("/select", response_model=RLDecision)
+def select(request: SelectionRequest) -> RLDecision:
+    arms = list(dict.fromkeys([request.campaign_id, *request.candidate_campaign_ids]))
+    try:
+        agent = load_agent(arms)
+        vector = to_vector(request.features)
+        selected_campaign_id, score = agent.select(vector)
+        persist_agent(agent)
+        log_decision(
+            campaign_id=request.campaign_id,
+            selected_campaign_id=selected_campaign_id,
+            score=score,
+            features=request.features.model_dump(),
+        )
+    except redis.RedisError as exc:
+        raise HTTPException(status_code=503, detail=f"redis unavailable: {exc}") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"selection failed: {exc}") from exc
+
+    return RLDecision(
+        campaign_id=request.campaign_id,
+        selected_campaign_id=selected_campaign_id,
+        score=score,
+        arms=agent.arms,
+    )
+
+
+@app.post("/update", response_model=UpdateResponse)
+def update(request: UpdateRequest) -> UpdateResponse:
+    try:
+        agent = load_agent([request.campaign_id])
+        agent.update(request.campaign_id, to_vector(request.features), request.reward)
+        persist_agent(agent)
+    except redis.RedisError as exc:
+        raise HTTPException(status_code=503, detail=f"redis unavailable: {exc}") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"update failed: {exc}") from exc
+
+    return UpdateResponse(ok=True, campaign_id=request.campaign_id, reward=request.reward)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/rl-engine/src/store.py
+++ b/services/rl-engine/src/store.py
@@ -1,0 +1,42 @@
+import json
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import psycopg2
+import redis
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://zttato:zttato@postgres:5432/zttato")
+REDIS = redis.Redis.from_url(REDIS_URL, decode_responses=True)
+
+
+@contextmanager
+def db_connection() -> Iterator[Any]:
+    conn = psycopg2.connect(DATABASE_URL)
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def save_state(key: str, state: dict[str, Any]) -> None:
+    REDIS.set(key, json.dumps(state))
+
+
+def load_state(key: str) -> dict[str, Any] | None:
+    raw = REDIS.get(key)
+    return json.loads(raw) if raw else None
+
+
+def log_decision(campaign_id: str, selected_campaign_id: str, score: float, features: dict[str, float]) -> None:
+    with db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO rl_decisions (campaign_id, selected_campaign_id, score, features)
+                VALUES (%s, %s, %s, %s::jsonb)
+                """,
+                (campaign_id, selected_campaign_id, score, json.dumps(features)),
+            )

--- a/services/scaling-engine/Dockerfile
+++ b/services/scaling-engine/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/scaling-engine/requirements.txt
+++ b/services/scaling-engine/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+pydantic==2.11.7

--- a/services/scaling-engine/src/main.py
+++ b/services/scaling-engine/src/main.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Scaling Engine")
+
+
+class ScaleRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    score: float = Field(ge=0.0)
+
+
+class ScaleResponse(BaseModel):
+    campaign_id: str
+    action: str
+    factor: float
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {"status": "ok", "service": "scaling-engine"}
+
+
+@app.post("/scale", response_model=ScaleResponse)
+def scale(request: ScaleRequest) -> ScaleResponse:
+    if request.score >= 0.2:
+        action = "scale_up"
+        factor = min(5.0, 1.0 + (request.score * 10.0))
+    elif request.score <= 0.05:
+        action = "scale_down"
+        factor = max(0.2, request.score * 10.0)
+    else:
+        action = "hold"
+        factor = 1.0
+
+    return ScaleResponse(campaign_id=request.campaign_id, action=action, factor=round(factor, 4))
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
### Motivation
- Introduce an online contextual bandit to enable per-campaign online selection and closed-loop learning from conversion/revenue feedback.
- Use a lightweight, production-oriented stack (Redis for online state + Postgres for auditing/metrics) so the RL state is durable and auditable.
- Provide a safe, stateless autoscale driver so orchestrator decisions can directly drive scaling actions over HTTP.
- Wire the existing orchestrator and webhook paths into the learning loop to close the loop between events → features → RL → scaling → reward updates.

### Description
- Added `services/rl-engine` implementing a persisted LinUCB bandit (`linucb.py`) with Redis state persistence and Postgres audit via `store.py`, and HTTP endpoints in `src/main.py` for `/select` and `/update`.
- Added `services/reward-collector` to compute a smoothed reward from `revenue/clicks/views/conversions` and forward updates to the RL engine, with validation and safe upstream calls.
- Added `services/scaling-engine` that exposes a simple threshold-based `/scale` decision API for `scale_up`/`hold`/`scale_down` actions.
- Extended the master orchestrator by adding an RL loop helper (`master-orchestrator/src/rl_loop.py`) and invoking RL selection + scaling inside `/campaign/run` so campaign execution includes the RL decision and scaling result.
- Updated `services/affiliate-webhook` to forward conversion events to the reward collector (with safe HTTP call and timeout) so conversions feed the RL update path.
- Wired new services into `docker-compose.yml`, added Dockerfiles and `requirements.txt` for each service, and added a Postgres migration (`infrastructure/postgres/migrations/001_schema.sql`) to create the `rl_decisions` audit table.

### Testing
- Ran code compilation with `python -m compileall services/rl-engine/src services/scaling-engine/src services/reward-collector/src services/master-orchestrator/src services/affiliate-webhook/src` which succeeded.
- Ran the test suite with `pytest` and all tests passed (`21 passed`).
- Attempted `docker compose config` in this environment but Docker is not available, so container-level integration was not executed here (desktop/CI run expected to validate full compose startup).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be5890275883219473b8a1f95c8f86)