### PR TITLE
Add distributed RL coordinator, budget allocator, RTB engine and Kafka decision loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -355,6 +355,113 @@ services:
     networks:
       - zttato-net
 
+  rl-agent-1:
+    build:
+      context: ./services/rl-engine
+      dockerfile: Dockerfile
+    container_name: zttato-rl-agent-1
+    restart: always
+    env_file: .env
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0
+      DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+      RL_STATE_KEY: rl:linucb:agent1
+      RL_ALPHA: ${RL_AGENT_1_ALPHA:-1.0}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  rl-agent-2:
+    build:
+      context: ./services/rl-engine
+      dockerfile: Dockerfile
+    container_name: zttato-rl-agent-2
+    restart: always
+    env_file: .env
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0
+      DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+      RL_STATE_KEY: rl:linucb:agent2
+      RL_ALPHA: ${RL_AGENT_2_ALPHA:-1.25}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  rl-coordinator:
+    build:
+      context: ./services/rl-coordinator
+      dockerfile: Dockerfile
+    container_name: zttato-rl-coordinator
+    restart: always
+    env_file: .env
+    environment:
+      RL_AGENTS: rl-agent-1:8000,rl-agent-2:8000
+    depends_on:
+      rl-agent-1:
+        condition: service_healthy
+      rl-agent-2:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  budget-allocator:
+    build:
+      context: ./services/budget-allocator
+      dockerfile: Dockerfile
+    container_name: zttato-budget-allocator
+    restart: always
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  rtb-engine:
+    build:
+      context: ./services/rtb-engine
+      dockerfile: Dockerfile
+    container_name: zttato-rtb-engine
+    restart: always
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
   scaling-engine:
     build:
       context: ./services/scaling-engine
@@ -378,10 +485,14 @@ services:
     container_name: zttato-reward-collector
     restart: always
     env_file: .env
+    environment:
+      KAFKA_BROKER: redpanda:9092
     depends_on:
       feature-store:
         condition: service_healthy
-      rl-engine:
+      rl-coordinator:
+        condition: service_healthy
+      redpanda:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
@@ -399,6 +510,8 @@ services:
     container_name: zttato-master-orchestrator
     restart: always
     env_file: .env
+    environment:
+      KAFKA_BROKER: redpanda:9092
     depends_on:
       execution-engine:
         condition: service_healthy
@@ -406,9 +519,15 @@ services:
         condition: service_healthy
       model-service:
         condition: service_healthy
-      rl-engine:
+      rl-coordinator:
+        condition: service_healthy
+      budget-allocator:
+        condition: service_healthy
+      rtb-engine:
         condition: service_healthy
       scaling-engine:
+        condition: service_healthy
+      redpanda:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]

--- a/services/budget-allocator/Dockerfile
+++ b/services/budget-allocator/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/budget-allocator/requirements.txt
+++ b/services/budget-allocator/requirements.txt
@@ -1,5 +1,3 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-requests==2.32.5
 pydantic==2.11.7
-confluent-kafka==2.5.0

--- a/services/budget-allocator/src/main.py
+++ b/services/budget-allocator/src/main.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Budget Allocator")
+
+
+class BudgetRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    score: float = Field(ge=0.0)
+    current_spend: float = Field(default=0.0, ge=0.0)
+    max_budget: float = Field(gt=0.0)
+    daily_cap: float | None = Field(default=None, gt=0.0)
+    min_step: float = Field(default=1.0, gt=0.0)
+    max_step: float = Field(default=25.0, gt=0.0)
+
+
+class BudgetResponse(BaseModel):
+    campaign_id: str
+    target_budget: float
+    adjustment: float
+    available_budget: float
+    capped: bool
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {"status": "ok", "service": "budget-allocator"}
+
+
+@app.post("/allocate", response_model=BudgetResponse)
+def allocate(request: BudgetRequest) -> BudgetResponse:
+    ratio = min(max(request.score, 0.01), 1.0)
+    cap = min(request.max_budget, request.daily_cap) if request.daily_cap is not None else request.max_budget
+    target = cap * ratio
+    raw_delta = target - request.current_spend
+    bounded_delta = max(-request.max_step, min(raw_delta, request.max_step))
+
+    if 0 < abs(bounded_delta) < request.min_step:
+        bounded_delta = request.min_step if bounded_delta > 0 else -request.min_step
+
+    adjusted_target = max(0.0, min(cap, request.current_spend + bounded_delta))
+    adjustment = round(adjusted_target - request.current_spend, 4)
+    return BudgetResponse(
+        campaign_id=request.campaign_id,
+        target_budget=round(adjusted_target, 4),
+        adjustment=adjustment,
+        available_budget=round(max(0.0, cap - request.current_spend), 4),
+        capped=adjusted_target >= cap,
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/master-orchestrator/src/distributed_loop.py
+++ b/services/master-orchestrator/src/distributed_loop.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from fastapi import HTTPException
+
+TIMEOUT = 10
+
+
+def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
+    kwargs.setdefault("timeout", TIMEOUT)
+    try:
+        response = method(url, **kwargs)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"Upstream call failed for {url}: {exc}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail=f"Invalid JSON response from {url}: {exc}") from exc
+
+
+def run_cycle(campaign_id: str) -> dict[str, Any]:
+    features = safe_call(requests.get, f"http://feature-store:8000/features/{campaign_id}")
+    rl = safe_call(
+        requests.post,
+        "http://rl-coordinator:8000/decide",
+        json={"campaign_id": campaign_id, "features": features},
+    )
+
+    current_spend = float(features.get("spend", 0.0))
+    max_budget = float(features.get("max_budget", 100.0))
+    daily_cap = float(features.get("daily_cap", max_budget))
+    views = max(int(features.get("views", 0)), 1)
+    clicks = max(int(features.get("clicks", 0)), 0)
+    conversions = max(int(features.get("conversions", 0)), 0)
+    ctr = clicks / views
+    cvr = conversions / max(clicks, 1)
+    pacing_ratio = min(2.0, max(0.1, (current_spend / daily_cap) if daily_cap else 1.0))
+
+    budget = safe_call(
+        requests.post,
+        "http://budget-allocator:8000/allocate",
+        json={
+            "campaign_id": campaign_id,
+            "score": rl["score"],
+            "current_spend": current_spend,
+            "max_budget": max_budget,
+            "daily_cap": daily_cap,
+        },
+    )
+    bid = safe_call(
+        requests.post,
+        "http://rtb-engine:8000/bid",
+        json={
+            "campaign_id": campaign_id,
+            "score": rl["score"],
+            "ctr": ctr,
+            "cvr": cvr,
+            "base_bid": float(features.get("base_bid", 0.1)),
+            "pacing_ratio": pacing_ratio,
+        },
+    )
+    scale = safe_call(
+        requests.post,
+        "http://scaling-engine:8000/scale",
+        json={"campaign_id": rl["selected_campaign_id"], "score": rl["score"]},
+    )
+
+    return {"features": features, "rl": rl, "budget": budget, "bid": bid, "scale": scale}

--- a/services/master-orchestrator/src/kafka_producer.py
+++ b/services/master-orchestrator/src/kafka_producer.py
@@ -1,0 +1,19 @@
+import json
+import logging
+import os
+from typing import Any
+
+from confluent_kafka import Producer
+
+log = logging.getLogger("master-orchestrator.kafka")
+BROKER = os.getenv("KAFKA_BROKER", "redpanda:9092")
+DECISIONS_TOPIC = os.getenv("KAFKA_DECISIONS_TOPIC", "decisions")
+producer = Producer({"bootstrap.servers": BROKER})
+
+
+def emit_decision(data: dict[str, Any]) -> None:
+    try:
+        producer.produce(DECISIONS_TOPIC, json.dumps(data).encode("utf-8"))
+        producer.flush()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log.warning("Failed to emit decision event: %s", exc)

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -5,38 +5,11 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from distributed_loop import run_cycle
+from kafka_producer import emit_decision
+
 app = FastAPI(title="Master Orchestrator")
 TIMEOUT = 10
-
-
-def decide_and_scale(campaign_id: str, features: dict[str, Any]) -> dict[str, Any]:
-    selection = safe_call(
-        requests.post,
-        "http://rl-engine:8000/select",
-        json={"campaign_id": campaign_id, "features": features},
-    )
-    scaling = safe_call(
-        requests.post,
-        "http://scaling-engine:8000/scale",
-        json={"campaign_id": selection["selected_campaign_id"], "score": selection["score"]},
-    )
-    return {"rl": selection, "scaling": scaling}
-
-
-class Offer(BaseModel):
-    id: str = Field(min_length=1)
-    video_url: str = Field(min_length=1)
-    caption: str = Field(min_length=1)
-    landing: str = Field(min_length=1)
-
-
-class CampaignDecision(BaseModel):
-    offer: dict[str, Any]
-    features: dict[str, Any]
-    model: dict[str, Any]
-    rl: dict[str, Any]
-    scaling: dict[str, Any]
-    execution: dict[str, Any]
 
 
 def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
@@ -51,6 +24,24 @@ def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
         raise HTTPException(status_code=502, detail=f"Invalid JSON response from {url}: {exc}") from exc
 
 
+class Offer(BaseModel):
+    id: str = Field(min_length=1)
+    video_url: str = Field(min_length=1)
+    caption: str = Field(min_length=1)
+    landing: str = Field(min_length=1)
+
+
+class CampaignDecision(BaseModel):
+    offer: dict[str, Any]
+    features: dict[str, Any]
+    model: dict[str, Any]
+    rl: dict[str, Any]
+    budget: dict[str, Any]
+    bid: dict[str, Any]
+    scaling: dict[str, Any]
+    execution: dict[str, Any]
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
     return {"status": "ok", "service": "master-orchestrator"}
@@ -58,9 +49,8 @@ def healthz() -> dict[str, Any]:
 
 @app.post("/campaign/run", response_model=CampaignDecision)
 def run_campaign(offer: Offer) -> CampaignDecision:
-    metrics = safe_call(requests.get, f"http://feature-store:8000/features/{offer.id}")
-    model = safe_call(requests.post, "http://model-service:8000/predict", json=metrics)
-    rl_result = decide_and_scale(offer.id, metrics)
+    cycle = run_cycle(offer.id)
+    model = safe_call(requests.post, "http://model-service:8000/predict", json=cycle["features"])
     execution = safe_call(
         requests.post,
         "http://execution-engine:9600/publish",
@@ -69,15 +59,31 @@ def run_campaign(offer: Offer) -> CampaignDecision:
             "video_url": offer.video_url,
             "caption": offer.caption,
             "destination_url": offer.landing,
+            "target_budget": cycle["budget"]["target_budget"],
+            "bid_price": cycle["bid"]["bid_price"],
         },
+    )
+
+    emit_decision(
+        {
+            "campaign_id": offer.id,
+            "features": cycle["features"],
+            "rl": cycle["rl"],
+            "budget": cycle["budget"],
+            "bid": cycle["bid"],
+            "scale": cycle["scale"],
+            "execution": execution,
+        }
     )
 
     return CampaignDecision(
         offer=offer.model_dump(),
-        features=metrics,
+        features=cycle["features"],
         model=model,
-        rl=rl_result["rl"],
-        scaling=rl_result["scaling"],
+        rl=cycle["rl"],
+        budget=cycle["budget"],
+        bid=cycle["bid"],
+        scaling=cycle["scale"],
         execution=execution,
     )
 

--- a/services/master-orchestrator/src/rl_loop.py
+++ b/services/master-orchestrator/src/rl_loop.py
@@ -1,26 +1,6 @@
-import requests
-
-TIMEOUT = 10
+from distributed_loop import run_cycle
 
 
 def decide_and_scale(campaign_id: str) -> dict:
-    features_response = requests.get(f"http://feature-store:8000/features/{campaign_id}", timeout=TIMEOUT)
-    features_response.raise_for_status()
-    features = features_response.json()
-
-    selection_response = requests.post(
-        "http://rl-engine:8000/select",
-        json={"campaign_id": campaign_id, "features": features},
-        timeout=TIMEOUT,
-    )
-    selection_response.raise_for_status()
-    selection = selection_response.json()
-
-    scale_response = requests.post(
-        "http://scaling-engine:8000/scale",
-        json={"campaign_id": selection["selected_campaign_id"], "score": selection["score"]},
-        timeout=TIMEOUT,
-    )
-    scale_response.raise_for_status()
-
-    return {"features": features, "rl": selection, "scale": scale_response.json()}
+    cycle = run_cycle(campaign_id)
+    return {"features": cycle["features"], "rl": cycle["rl"], "scale": cycle["scale"], "budget": cycle["budget"], "bid": cycle["bid"]}

--- a/services/reward-collector/requirements.txt
+++ b/services/reward-collector/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.116.1
 uvicorn==0.35.0
 requests==2.32.5
 pydantic==2.11.7
+confluent-kafka==2.5.0

--- a/services/reward-collector/src/kafka_producer.py
+++ b/services/reward-collector/src/kafka_producer.py
@@ -1,0 +1,19 @@
+import json
+import logging
+import os
+from typing import Any
+
+from confluent_kafka import Producer
+
+log = logging.getLogger("reward-collector.kafka")
+BROKER = os.getenv("KAFKA_BROKER", "redpanda:9092")
+FEEDBACK_TOPIC = os.getenv("KAFKA_FEEDBACK_TOPIC", "feedback")
+producer = Producer({"bootstrap.servers": BROKER})
+
+
+def emit_feedback(data: dict[str, Any]) -> None:
+    try:
+        producer.produce(FEEDBACK_TOPIC, json.dumps(data).encode("utf-8"))
+        producer.flush()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log.warning("Failed to emit feedback event: %s", exc)

--- a/services/reward-collector/src/main.py
+++ b/services/reward-collector/src/main.py
@@ -5,6 +5,8 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from kafka_producer import emit_feedback
+
 app = FastAPI(title="Reward Collector")
 TIMEOUT = 10
 
@@ -49,9 +51,10 @@ def reward(event: RewardEvent) -> RewardResponse:
     features = safe_call(requests.get, f"http://feature-store:8000/features/{event.campaign_id}")
     safe_call(
         requests.post,
-        "http://rl-engine:8000/update",
+        "http://rl-coordinator:8000/update",
         json={"campaign_id": event.campaign_id, "features": features, "reward": reward_value},
     )
+    emit_feedback({"campaign_id": event.campaign_id, "reward": reward_value, "features": features})
     return RewardResponse(ok=True, campaign_id=event.campaign_id, reward=reward_value)
 
 

--- a/services/rl-coordinator/Dockerfile
+++ b/services/rl-coordinator/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/rl-coordinator/requirements.txt
+++ b/services/rl-coordinator/requirements.txt
@@ -2,4 +2,3 @@ fastapi==0.116.1
 uvicorn==0.35.0
 requests==2.32.5
 pydantic==2.11.7
-confluent-kafka==2.5.0

--- a/services/rl-coordinator/src/main.py
+++ b/services/rl-coordinator/src/main.py
@@ -1,0 +1,121 @@
+import os
+from typing import Any
+
+import requests
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+app = FastAPI(title="RL Coordinator")
+TIMEOUT = float(os.getenv("RL_COORDINATOR_TIMEOUT", "2.0"))
+AGENTS = [agent.strip() for agent in os.getenv("RL_AGENTS", "rl-agent-1:8000,rl-agent-2:8000").split(",") if agent.strip()]
+
+
+class DecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    campaign_id: str = Field(min_length=1)
+    candidate_campaign_ids: list[str] = Field(default_factory=list)
+    features: dict[str, Any] = Field(default_factory=dict)
+
+
+class UpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    campaign_id: str = Field(min_length=1)
+    features: dict[str, Any] = Field(default_factory=dict)
+    reward: float = Field(ge=0.0)
+
+
+class AgentStatus(BaseModel):
+    agent: str
+    ok: bool
+    detail: str | None = None
+
+
+def call_agent(agent: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        response = requests.post(f"http://{agent}{path}", json=payload, timeout=TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+        data["agent"] = agent
+        return data
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"agent {agent} unavailable: {exc}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail=f"agent {agent} returned invalid json: {exc}") from exc
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    statuses: list[dict[str, Any]] = []
+    healthy = 0
+    for agent in AGENTS:
+        try:
+            response = requests.get(f"http://{agent}/healthz", timeout=TIMEOUT)
+            response.raise_for_status()
+            statuses.append(AgentStatus(agent=agent, ok=True).model_dump())
+            healthy += 1
+        except requests.RequestException as exc:
+            statuses.append(AgentStatus(agent=agent, ok=False, detail=str(exc)).model_dump())
+
+    return {
+        "status": "ok" if healthy else "degraded",
+        "service": "rl-coordinator",
+        "healthy_agents": healthy,
+        "configured_agents": len(AGENTS),
+        "agents": statuses,
+    }
+
+
+@app.post("/decide")
+def decide(request: DecisionRequest) -> dict[str, Any]:
+    best: dict[str, Any] | None = None
+    best_score = float("-inf")
+    errors: list[str] = []
+
+    for agent in AGENTS:
+        try:
+            candidate = call_agent(agent, "/select", request.model_dump())
+        except HTTPException as exc:
+            errors.append(str(exc.detail))
+            continue
+
+        score = float(candidate.get("score", float("-inf")))
+        if score > best_score:
+            best = candidate
+            best_score = score
+
+    if best is None:
+        raise HTTPException(status_code=503, detail={"message": "no agent available", "errors": errors})
+
+    best["evaluated_agents"] = len(AGENTS)
+    return best
+
+
+@app.post("/update")
+def update(request: UpdateRequest) -> dict[str, Any]:
+    updated_agents: list[str] = []
+    errors: list[str] = []
+
+    for agent in AGENTS:
+        try:
+            call_agent(agent, "/update", request.model_dump())
+            updated_agents.append(agent)
+        except HTTPException as exc:
+            errors.append(str(exc.detail))
+
+    if not updated_agents:
+        raise HTTPException(status_code=503, detail={"message": "update failed on all agents", "errors": errors})
+
+    return {
+        "ok": True,
+        "campaign_id": request.campaign_id,
+        "reward": request.reward,
+        "updated_agents": updated_agents,
+        "errors": errors,
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/rtb-engine/Dockerfile
+++ b/services/rtb-engine/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/rtb-engine/requirements.txt
+++ b/services/rtb-engine/requirements.txt
@@ -1,5 +1,3 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-requests==2.32.5
 pydantic==2.11.7
-confluent-kafka==2.5.0

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="RTB Engine")
+
+
+class BidRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    score: float = Field(ge=0.0)
+    ctr: float = Field(ge=0.0)
+    cvr: float = Field(ge=0.0)
+    base_bid: float = Field(gt=0.0)
+    pacing_ratio: float = Field(default=1.0, ge=0.1, le=2.0)
+    max_bid: float = Field(default=10.0, gt=0.0)
+
+
+class BidResponse(BaseModel):
+    campaign_id: str
+    bid_price: float
+    ev: float
+    pacing_multiplier: float
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {"status": "ok", "service": "rtb-engine"}
+
+
+@app.post("/bid", response_model=BidResponse)
+def bid(request: BidRequest) -> BidResponse:
+    ev = request.ctr * request.cvr * request.score
+    pacing_multiplier = 0.5 + (request.pacing_ratio / 2)
+    bid_price = request.base_bid * (1 + (ev * 10.0)) * pacing_multiplier
+    bid_price = max(0.01, min(bid_price, request.max_bid))
+    return BidResponse(
+        campaign_id=request.campaign_id,
+        bid_price=round(bid_price, 4),
+        ev=round(ev, 8),
+        pacing_multiplier=round(pacing_multiplier, 4),
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/stream-consumer/src/producer.py
+++ b/services/stream-consumer/src/producer.py
@@ -1,0 +1,12 @@
+import json
+import os
+from typing import Any
+
+from confluent_kafka import Producer
+
+producer = Producer({"bootstrap.servers": os.getenv("KAFKA_BROKER", "redpanda:9092")})
+
+
+def emit_decision(data: dict[str, Any], topic: str = "decisions") -> None:
+    producer.produce(topic, json.dumps(data).encode("utf-8"))
+    producer.flush()

--- a/tests/test_distributed_rl_stack.py
+++ b/tests/test_distributed_rl_stack.py
@@ -1,0 +1,93 @@
+import sys
+import types
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_app(service: str):
+    module_path = ROOT / 'services' / service / 'src' / 'main.py'
+    spec = spec_from_file_location(f"{service.replace('-', '_')}_main", module_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+def test_budget_allocator_enforces_step_and_cap() -> None:
+    app = _load_app('budget-allocator')
+    client = TestClient(app)
+
+    response = client.post(
+        '/allocate',
+        json={
+            'campaign_id': 'cmp-1',
+            'score': 0.9,
+            'current_spend': 95,
+            'max_budget': 100,
+            'daily_cap': 98,
+            'min_step': 1,
+            'max_step': 25,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data['target_budget'] == 88.2
+    assert data['adjustment'] == -6.8
+    assert data['available_budget'] == 3.0
+    assert data['capped'] is False
+
+
+def test_rtb_engine_clamps_bid_and_applies_pacing() -> None:
+    app = _load_app('rtb-engine')
+    client = TestClient(app)
+
+    response = client.post(
+        '/bid',
+        json={
+            'campaign_id': 'cmp-1',
+            'score': 1.0,
+            'ctr': 1.0,
+            'cvr': 1.0,
+            'base_bid': 2.0,
+            'pacing_ratio': 2.0,
+            'max_bid': 5.0,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data['bid_price'] == 5.0
+    assert data['pacing_multiplier'] == 1.5
+
+
+def test_rl_coordinator_picks_highest_score(monkeypatch) -> None:
+    requests_stub = types.SimpleNamespace(post=None, get=None, RequestException=Exception)
+    sys.modules['requests'] = requests_stub
+    app = _load_app('rl-coordinator')
+    client = TestClient(app)
+
+    class DummyResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def fake_post(url, json, timeout):
+        if 'rl-agent-1' in url:
+            return DummyResponse({'selected_campaign_id': json['campaign_id'], 'score': 0.25, 'arms': [json['campaign_id']]})
+        return DummyResponse({'selected_campaign_id': json['campaign_id'], 'score': 0.5, 'arms': [json['campaign_id']]})
+
+    monkeypatch.setattr(sys.modules['requests'], 'post', fake_post)
+
+    response = client.post('/decide', json={'campaign_id': 'cmp-1', 'features': {'views': 10, 'clicks': 2, 'conversions': 1}})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['score'] == 0.5
+    assert data['agent'] == 'rl-agent-2:8000'


### PR DESCRIPTION
### Motivation

- Introduce a multi-agent distributed RL decision path so selection can be ensembled across independent agents with a global coordinator. 
- Add bounded budget allocation and pacing-aware RTB bidding to make the orchestration safe and production-ready for real-time auctioning.
- Stream decisions and feedback via Kafka so the system can operate asynchronously and close the RL feedback loop.

### Description

- Added an `rl-coordinator` service that fans out `/select` and `/update` to multiple RL agents and exposes health and aggregated selection results (`services/rl-coordinator/src/main.py`, plus Dockerfile/requirements). 
- Added `budget-allocator` and `rtb-engine` services implementing safe bounded budget adjustments and pacing-aware EV bidding (`services/budget-allocator/*`, `services/rtb-engine/*`).
- Extended the master orchestrator with a distributed decision cycle (`services/master-orchestrator/src/distributed_loop.py`), wired it to call `rl-coordinator`, `budget-allocator`, `rtb-engine`, and `scaling-engine`, include budget/bid outputs in execution calls, and emit decision events to Kafka (`services/master-orchestrator/src/kafka_producer.py`).
- Updated the `reward-collector` to route RL updates via the coordinator and emit feedback events to Kafka (`services/reward-collector/src/main.py`, `services/reward-collector/src/kafka_producer.py`).
- Added a small Kafka producer helper for the stream consumer and wired Kafka broker environment variables into compose for decision/feedback topics (`services/stream-consumer/src/producer.py`).
- Updated `docker-compose.yml` with `rl-agent-1`, `rl-agent-2`, `rl-coordinator`, `budget-allocator`, and `rtb-engine`, and adjusted service dependencies and Kafka environment wiring.
- Added focused unit tests validating budget allocation bounds, RTB bid clamping/pacing, and coordinator selection logic (`tests/test_distributed_rl_stack.py`).

### Testing

- Ran `python -m compileall services/rl-coordinator services/budget-allocator services/rtb-engine services/master-orchestrator services/reward-collector services/stream-consumer` which succeeded. 
- Ran `pytest -q tests/test_distributed_rl_stack.py` which passed (3 tests). 
- Attempted `docker compose config` validation but the execution environment does not have Docker installed, so compose validation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be5a411eb08321b77f4388740e32eb)