### PR TITLE
Add global edge deployment and latency-aware bidding

### DIFF
--- a/cloudflare-devops/api/create-dns.sh
+++ b/cloudflare-devops/api/create-dns.sh
@@ -4,12 +4,24 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# shellcheck source=/dev/null
 source "$ROOT_DIR/env"
 
-TUNNEL_ID=$1
+TUNNEL_ID="${1:-${CF_TUNNEL_ID:-}}"
+RECORD_NAME="${2:-${SUBDOMAIN:-}}"
+
+if [[ -z "$TUNNEL_ID" ]]; then
+  echo "Missing tunnel id argument or CF_TUNNEL_ID in cloudflare-devops/env" >&2
+  exit 1
+fi
+
+if [[ -z "$RECORD_NAME" ]]; then
+  echo "Missing DNS record name argument or SUBDOMAIN in cloudflare-devops/env" >&2
+  exit 1
+fi
 
 curl -s -X POST \
 "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" \
 -H "Authorization: Bearer $CF_API_TOKEN" \
 -H "Content-Type: application/json" \
---data "{\"type\":\"CNAME\",\"name\":\"$SUBDOMAIN\",\"content\":\"$TUNNEL_ID.cfargotunnel.com\",\"ttl\":1,\"proxied\":true}"
+--data "{\"type\":\"CNAME\",\"name\":\"$RECORD_NAME\",\"content\":\"$TUNNEL_ID.cfargotunnel.com\",\"ttl\":1,\"proxied\":true}"

--- a/cloudflare-devops/install.sh
+++ b/cloudflare-devops/install.sh
@@ -72,8 +72,9 @@ echo "Tunnel ID: $TUNNEL_ID"
 # save token
 ########################################
 
-grep -v '^CF_TUNNEL_TOKEN=' "$ENV_FILE" > "$ENV_FILE.tmp" || true
+grep -Ev '^(CF_TUNNEL_TOKEN|CF_TUNNEL_ID)=' "$ENV_FILE" > "$ENV_FILE.tmp" || true
 mv "$ENV_FILE.tmp" "$ENV_FILE"
+echo "CF_TUNNEL_ID=$TUNNEL_ID" >> "$ENV_FILE"
 echo "CF_TUNNEL_TOKEN=$TOKEN" >> "$ENV_FILE"
 
 ########################################

--- a/cloudflare-devops/tunnel/config.yml
+++ b/cloudflare-devops/tunnel/config.yml
@@ -1,0 +1,23 @@
+tunnel: zttato-global
+credentials-file: /root/.cloudflared/creds.json
+
+ingress:
+  - hostname: api.zeaz.dev
+    service: http://nginx:80
+  - hostname: admin.zeaz.dev
+    service: http://admin-panel:3000
+  - hostname: auth.zeaz.dev
+    service: http://jwt-auth:80
+  - hostname: ai.zeaz.dev
+    service: http://ai-video-generator:9200
+  - hostname: crawl.zeaz.dev
+    service: http://market-crawler:9400
+  - hostname: predict.zeaz.dev
+    service: http://viral-predictor:9100
+  - hostname: grafana.zeaz.dev
+    service: http://grafana:3000
+  - hostname: kafka.zeaz.dev
+    service: http://kafka-ui:8080
+  - hostname: '*.zeaz.dev'
+    service: http://localhost:80
+  - service: http_status:404

--- a/infrastructure/k8s/multi-region/asia.yaml
+++ b/infrastructure/k8s/multi-region/asia.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zttato-asia
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orchestrator
+  namespace: zttato-asia
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: orchestrator
+  template:
+    metadata:
+      labels:
+        app: orchestrator
+        region: asia
+    spec:
+      containers:
+        - name: orchestrator
+          image: zttato/orchestrator:latest
+          env:
+            - name: REGION
+              value: asia

--- a/infrastructure/k8s/multi-region/eu.yaml
+++ b/infrastructure/k8s/multi-region/eu.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zttato-eu
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orchestrator
+  namespace: zttato-eu
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: orchestrator
+  template:
+    metadata:
+      labels:
+        app: orchestrator
+        region: eu
+    spec:
+      containers:
+        - name: orchestrator
+          image: zttato/orchestrator:latest
+          env:
+            - name: REGION
+              value: eu

--- a/scripts/deploy-global.sh
+++ b/scripts/deploy-global.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd kubectl
+require_cmd bash
+require_cmd npx
+
+if [[ ! -f cloudflare-devops/env ]]; then
+  echo "Missing cloudflare-devops/env" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source cloudflare-devops/env
+
+echo "Deploy multi-region K8s..."
+kubectl apply -f infrastructure/k8s/multi-region/asia.yaml
+kubectl apply -f infrastructure/k8s/multi-region/eu.yaml
+
+echo "Deploy Cloudflare tunnel..."
+bash cloudflare-devops/install.sh
+
+# shellcheck source=/dev/null
+source cloudflare-devops/env
+
+echo "Deploy DNS wildcard..."
+bash cloudflare-devops/api/create-dns.sh "${CF_TUNNEL_ID:-${1:-}}" "*.zeaz.dev"
+
+echo "Deploy edge worker..."
+npx wrangler deploy --config services/edge-worker/wrangler.toml
+
+echo "DONE: Global system live"

--- a/services/edge-worker/index.js
+++ b/services/edge-worker/index.js
@@ -1,0 +1,13 @@
+export default {
+  async fetch(request) {
+    const url = new URL(request.url)
+    const country = request.headers.get('cf-ipcountry') || 'US'
+
+    let backend = 'https://us.zeaz.dev'
+    if (country === 'TH') backend = 'https://asia.zeaz.dev'
+    if (country === 'DE') backend = 'https://eu.zeaz.dev'
+
+    const target = new URL(url.pathname + url.search, backend)
+    return fetch(new Request(target.toString(), request))
+  },
+}

--- a/services/edge-worker/wrangler.toml
+++ b/services/edge-worker/wrangler.toml
@@ -1,0 +1,4 @@
+name = "zttato-edge-worker"
+main = "index.js"
+compatibility_date = "2026-03-21"
+workers_dev = true

--- a/services/rtb-engine/src/latency_bid.py
+++ b/services/rtb-engine/src/latency_bid.py
@@ -1,0 +1,15 @@
+def latency_adjusted_bid(
+    base_bid: float,
+    score: float,
+    latency_ms: float,
+    pacing_multiplier: float = 1.0,
+    ctr: float = 0.0,
+    cvr: float = 0.0,
+    max_bid: float = 10.0,
+) -> float:
+    """Apply a latency penalty while preserving EV- and pacing-based bid shaping."""
+    safe_latency = max(latency_ms, 0.0)
+    latency_penalty = max(0.5, 1 - (max(safe_latency - 100.0, 0.0) / 500.0))
+    expected_value = ctr * cvr * score
+    bid = base_bid * (1 + (expected_value * 10.0)) * pacing_multiplier * latency_penalty
+    return max(0.01, min(bid, max_bid))

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -1,8 +1,16 @@
+from pathlib import Path
+import sys
 from typing import Any
 
 import uvicorn
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
+
+CURRENT_DIR = Path(__file__).resolve().parent
+if str(CURRENT_DIR) not in sys.path:
+    sys.path.insert(0, str(CURRENT_DIR))
+
+from latency_bid import latency_adjusted_bid
 
 app = FastAPI(title="RTB Engine")
 
@@ -15,6 +23,7 @@ class BidRequest(BaseModel):
     base_bid: float = Field(gt=0.0)
     pacing_ratio: float = Field(default=1.0, ge=0.1, le=2.0)
     max_bid: float = Field(default=10.0, gt=0.0)
+    latency_ms: float = Field(default=100.0, ge=0.0)
 
 
 class BidResponse(BaseModel):
@@ -33,8 +42,15 @@ def healthz() -> dict[str, Any]:
 def bid(request: BidRequest) -> BidResponse:
     ev = request.ctr * request.cvr * request.score
     pacing_multiplier = 0.5 + (request.pacing_ratio / 2)
-    bid_price = request.base_bid * (1 + (ev * 10.0)) * pacing_multiplier
-    bid_price = max(0.01, min(bid_price, request.max_bid))
+    bid_price = latency_adjusted_bid(
+        base_bid=request.base_bid,
+        score=request.score,
+        latency_ms=request.latency_ms,
+        pacing_multiplier=pacing_multiplier,
+        ctr=request.ctr,
+        cvr=request.cvr,
+        max_bid=request.max_bid,
+    )
     return BidResponse(
         campaign_id=request.campaign_id,
         bid_price=round(bid_price, 4),

--- a/tests/test_distributed_rl_stack.py
+++ b/tests/test_distributed_rl_stack.py
@@ -91,3 +91,26 @@ def test_rl_coordinator_picks_highest_score(monkeypatch) -> None:
     data = response.json()
     assert data['score'] == 0.5
     assert data['agent'] == 'rl-agent-2:8000'
+
+
+def test_rtb_engine_applies_latency_penalty() -> None:
+    app = _load_app('rtb-engine')
+    client = TestClient(app)
+
+    response = client.post(
+        '/bid',
+        json={
+            'campaign_id': 'cmp-latency',
+            'score': 0.8,
+            'ctr': 0.5,
+            'cvr': 0.2,
+            'base_bid': 2.0,
+            'pacing_ratio': 1.0,
+            'max_bid': 10.0,
+            'latency_ms': 600.0,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data['bid_price'] == 1.8
+    assert data['pacing_multiplier'] == 1.0

--- a/tests/test_safe_edge_pack.py
+++ b/tests/test_safe_edge_pack.py
@@ -26,3 +26,15 @@ def test_kong_config_exposes_summary_and_redirect_routes():
 def test_go_live_doc_has_safety_note():
     text = Path("docs/operations/go-live-safe-edge.md").read_text()
     assert "Do not use it to automate account creation" in text
+
+
+def test_global_tunnel_config_supports_wildcard_host():
+    text = Path("cloudflare-devops/tunnel/config.yml").read_text()
+    assert "*.zeaz.dev" in text
+
+
+def test_global_deploy_script_includes_multi_region_and_worker_steps():
+    text = Path("scripts/deploy-global.sh").read_text()
+    assert "infrastructure/k8s/multi-region/asia.yaml" in text
+    assert "infrastructure/k8s/multi-region/eu.yaml" in text
+    assert "wrangler deploy" in text


### PR DESCRIPTION
### Motivation
- Provide a production-ready global edge rollout (multi-region K8s + Cloudflare edge + wildcard DNS) to route traffic by geography and enable low-latency failover.
- Improve the RTB engine to account for measured latency in bid shaping so high-RTT targets are penalized while preserving pacing and max-bid constraints.

### Description
- Add multi-region Kubernetes manifests for Asia and EU orchestrator deployments at `infrastructure/k8s/multi-region/asia.yaml` and `infrastructure/k8s/multi-region/eu.yaml`.
- Add Cloudflare tunnel config and tooling: `cloudflare-devops/tunnel/config.yml`, update `cloudflare-devops/install.sh` to persist `CF_TUNNEL_ID`, and make `cloudflare-devops/api/create-dns.sh` accept tunnel id and record name arguments.
- Add a Cloudflare Worker and Wrangler config for geo routing at `services/edge-worker/index.js` and `services/edge-worker/wrangler.toml` and a top-level deployment script `scripts/deploy-global.sh` that applies the multi-region manifests, runs the Cloudflare installer, creates wildcard DNS, and deploys the Worker.
- Implement latency-aware bidding in `services/rtb-engine/src/latency_bid.py` and wire it into the RTB API by adding `latency_ms` to `BidRequest` and using `latency_adjusted_bid` in `services/rtb-engine/src/main.py` while preserving pacing and max-bid clamping.
- Add/extend tests to cover the new latency path and global edge artifacts in `tests/test_distributed_rl_stack.py` and `tests/test_safe_edge_pack.py`.

### Testing
- Ran `python -m pytest tests/test_distributed_rl_stack.py tests/test_safe_edge_pack.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be5ec844e48321b50bf5112c102b64)