### PR TITLE
Add safe federation control plane, capacity-aware scheduler, capital allocator and allowlisted P2P node

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -707,6 +707,12 @@ services:
         condition: service_healthy
       scaling-engine:
         condition: service_healthy
+      federation:
+        condition: service_healthy
+      scheduler:
+        condition: service_healthy
+      capital-allocator:
+        condition: service_healthy
       redpanda:
         condition: service_healthy
     healthcheck:
@@ -715,6 +721,78 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+    networks:
+      - zttato-net
+
+  federation:
+    build:
+      context: ./services/federation
+      dockerfile: Dockerfile
+    container_name: zttato-federation
+    restart: always
+    env_file: .env
+    environment:
+      DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
+      FEDERATION_SECRET: ${FEDERATION_SECRET:-change-me}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  scheduler:
+    build:
+      context: ./services/scheduler
+      dockerfile: Dockerfile
+    container_name: zttato-scheduler
+    restart: always
+    env_file: .env
+    environment:
+      FEDERATION_URL: http://federation:8000
+      FEDERATION_SECRET: ${FEDERATION_SECRET:-change-me}
+    depends_on:
+      federation:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  capital-allocator:
+    build:
+      context: ./services/capital-allocator
+      dockerfile: Dockerfile
+    container_name: zttato-capital-allocator
+    restart: always
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  p2p-node:
+    build:
+      context: ./services/p2p-node
+      dockerfile: Dockerfile
+    container_name: zttato-p2p-node
+    restart: always
+    env_file: .env
+    environment:
+      PEER_ALLOWLIST: ${PEER_ALLOWLIST:-}
     networks:
       - zttato-net
 

--- a/services/capital-allocator/Dockerfile
+++ b/services/capital-allocator/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/capital-allocator/requirements.txt
+++ b/services/capital-allocator/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+pydantic==2.11.7

--- a/services/capital-allocator/src/main.py
+++ b/services/capital-allocator/src/main.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Capital Allocator")
+
+
+class CapitalRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    tenant_id: str = Field(default="default", min_length=1)
+    score: float = Field(ge=0.0)
+    max_budget: float = Field(gt=0.0)
+    spent: float = Field(default=0.0, ge=0.0)
+    hard_cap_ratio: float = Field(default=0.5, gt=0.0, le=1.0)
+
+
+class CapitalResponse(BaseModel):
+    campaign_id: str
+    tenant_id: str
+    target: float
+    delta: float
+    remaining_budget: float
+    capped: bool
+    observability: dict[str, Any]
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "service": "capital-allocator",
+        "prometheus_labels": {"service": "capital-allocator", "policy": "bounded"},
+    }
+
+
+@app.post("/allocate", response_model=CapitalResponse)
+def allocate(request: CapitalRequest) -> CapitalResponse:
+    ratio = min(max(request.score, 0.01), request.hard_cap_ratio)
+    target = round(request.max_budget * ratio, 4)
+    delta = round(target - request.spent, 4)
+    return CapitalResponse(
+        campaign_id=request.campaign_id,
+        tenant_id=request.tenant_id,
+        target=target,
+        delta=delta,
+        remaining_budget=round(max(0.0, request.max_budget - request.spent), 4),
+        capped=ratio >= request.hard_cap_ratio,
+        observability={
+            "tenant_id": request.tenant_id,
+            "campaign_id": request.campaign_id,
+            "hard_cap_ratio": request.hard_cap_ratio,
+        },
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/federation/Dockerfile
+++ b/services/federation/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/federation/requirements.txt
+++ b/services/federation/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+pydantic==2.11.7
+psycopg2-binary==2.9.10

--- a/services/federation/src/main.py
+++ b/services/federation/src/main.py
@@ -1,0 +1,165 @@
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Federation Control Plane")
+SECRET = os.getenv("FEDERATION_SECRET", "change-me")
+DB_URL = os.getenv("DATABASE_URL", "postgresql://zttato:zttato@postgres:5432/zttato")
+AUDIT_LOG_PATH = Path(os.getenv("FEDERATION_AUDIT_LOG", "/tmp/federation-audit.log"))
+DEFAULT_TENANT = os.getenv("FEDERATION_DEFAULT_TENANT", "default")
+
+
+class NodeRegister(BaseModel):
+    node_id: str = Field(min_length=6)
+    region: str = Field(min_length=2)
+    capacity: int = Field(ge=1)
+    tenant_id: str = Field(default=DEFAULT_TENANT, min_length=1)
+    labels: dict[str, str] = Field(default_factory=dict)
+
+
+class NodeRecord(NodeRegister):
+    registered_at: int
+
+
+def encode_signed_claims(claims: dict[str, Any]) -> str:
+    payload = json.dumps(claims, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    signature = hmac.new(SECRET.encode("utf-8"), payload, hashlib.sha256).digest()
+    return f"{base64.urlsafe_b64encode(payload).decode('utf-8')}.{base64.urlsafe_b64encode(signature).decode('utf-8')}"
+
+
+def db_connection():
+    return psycopg2.connect(DB_URL)
+
+
+def ensure_schema() -> None:
+    with db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS federation_nodes (
+                    node_id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    region TEXT NOT NULL,
+                    capacity INTEGER NOT NULL,
+                    labels JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    registered_at BIGINT NOT NULL
+                )
+                """
+            )
+        conn.commit()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    ensure_schema()
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    try:
+        ensure_schema()
+        database_ok = True
+    except psycopg2.Error:
+        database_ok = False
+    return {
+        "status": "ok" if database_ok else "degraded",
+        "service": "federation",
+        "checks": {"database": database_ok},
+        "prometheus_labels": {"service": "federation", "component": "control-plane"},
+    }
+
+
+@app.get("/nodes")
+def list_nodes() -> dict[str, Any]:
+    try:
+        with db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT node_id, tenant_id, region, capacity, labels, registered_at FROM federation_nodes ORDER BY registered_at DESC"
+                )
+                rows = cur.fetchall()
+    except psycopg2.Error as exc:
+        raise HTTPException(status_code=503, detail=f"database unavailable: {exc}") from exc
+
+    nodes = [
+        {
+            "node_id": row[0],
+            "tenant_id": row[1],
+            "region": row[2],
+            "capacity": row[3],
+            "labels": row[4] or {},
+            "registered_at": row[5],
+        }
+        for row in rows
+    ]
+    return {"nodes": nodes, "count": len(nodes)}
+
+
+@app.post("/register")
+def register(node: NodeRegister) -> dict[str, Any]:
+    issued_at = int(time.time())
+    token = encode_signed_claims(
+        {
+            "node_id": node.node_id,
+            "tenant_id": node.tenant_id,
+            "region": node.region,
+            "iat": issued_at,
+        }
+    )
+
+    try:
+        with db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO federation_nodes (node_id, tenant_id, region, capacity, labels, registered_at)
+                    VALUES (%s, %s, %s, %s, %s::jsonb, %s)
+                    ON CONFLICT (node_id) DO UPDATE
+                    SET tenant_id = EXCLUDED.tenant_id,
+                        region = EXCLUDED.region,
+                        capacity = EXCLUDED.capacity,
+                        labels = EXCLUDED.labels,
+                        registered_at = EXCLUDED.registered_at
+                    """,
+                    (node.node_id, node.tenant_id, node.region, node.capacity, json.dumps(node.labels), issued_at),
+                )
+            conn.commit()
+    except psycopg2.Error as exc:
+        raise HTTPException(status_code=503, detail=f"database unavailable: {exc}") from exc
+
+    AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with AUDIT_LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "event": "node.registered",
+                    "node_id": node.node_id,
+                    "tenant_id": node.tenant_id,
+                    "region": node.region,
+                    "capacity": node.capacity,
+                    "labels": node.labels,
+                    "timestamp": issued_at,
+                }
+            )
+            + "\n"
+        )
+
+    return {
+        "token": token,
+        "node": NodeRecord(**node.model_dump(), registered_at=issued_at).model_dump(),
+        "prometheus_labels": {"tenant_id": node.tenant_id, "region": node.region},
+    }
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/master-orchestrator/src/federated_loop.py
+++ b/services/master-orchestrator/src/federated_loop.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+
+import requests
+from fastapi import HTTPException
+
+TIMEOUT = float(os.getenv("FEDERATED_LOOP_TIMEOUT", "5.0"))
+FEDERATION_SECRET = os.getenv("FEDERATION_SECRET", "change-me")
+DEFAULT_REGION = os.getenv("FEDERATED_DEFAULT_REGION", "asia")
+DEFAULT_TENANT = os.getenv("FEDERATED_DEFAULT_TENANT", "default")
+DEFAULT_MAX_BUDGET = float(os.getenv("FEDERATED_MAX_BUDGET", "100"))
+
+
+def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
+    kwargs.setdefault("timeout", TIMEOUT)
+    try:
+        response = method(url, **kwargs)
+        response.raise_for_status()
+        return response.json()
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"Upstream call failed for {url}: {exc}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail=f"Invalid JSON response from {url}: {exc}") from exc
+
+
+def build_task_token(campaign_id: str, tenant_id: str, region: str) -> str:
+    payload = json.dumps(
+        {"campaign_id": campaign_id, "tenant_id": tenant_id, "region": region},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    signature = hmac.new(FEDERATION_SECRET.encode("utf-8"), payload, hashlib.sha256).digest()
+    return f"{base64.urlsafe_b64encode(payload).decode('utf-8')}.{base64.urlsafe_b64encode(signature).decode('utf-8')}"
+
+
+def run_global_task(campaign_id: str, tenant_id: str = DEFAULT_TENANT, region: str = DEFAULT_REGION) -> dict[str, Any]:
+    features = safe_call(requests.get, f"http://feature-store:8000/features/{campaign_id}")
+    rl = safe_call(
+        requests.post,
+        "http://rl-coordinator:8000/decide",
+        json={"campaign_id": campaign_id, "features": features},
+    )
+    capital = safe_call(
+        requests.post,
+        "http://capital-allocator:8000/allocate",
+        json={
+            "campaign_id": campaign_id,
+            "tenant_id": tenant_id,
+            "score": rl["score"],
+            "max_budget": float(features.get("max_budget", DEFAULT_MAX_BUDGET)),
+            "spent": float(features.get("spend", 0.0)),
+        },
+    )
+    scheduler = safe_call(
+        requests.post,
+        "http://scheduler:8000/assign",
+        json={
+            "task_id": campaign_id,
+            "required_capacity": 1,
+            "region": region,
+            "tenant_id": tenant_id,
+            "task_token": build_task_token(campaign_id, tenant_id, region),
+        },
+    )
+    return {"features": features, "rl": rl, "capital": capital, "node": scheduler}

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from distributed_loop import run_cycle
 from economy_loop import run_economy
+from federated_loop import run_global_task
 from kafka_producer import emit_decision
 
 app = FastAPI(title="Master Orchestrator")
@@ -53,6 +54,12 @@ class EconomyRequest(BaseModel):
     markets: list[str] | None = None
 
 
+class FederatedTaskRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    tenant_id: str = Field(default="default", min_length=1)
+    region: str = Field(default="asia", min_length=2)
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
     return {"status": "ok", "service": "master-orchestrator"}
@@ -68,6 +75,11 @@ def run_cycle_endpoint(request: CampaignCycleRequest) -> dict[str, Any]:
 @app.post("/economy/run")
 def run_economy_endpoint(request: EconomyRequest) -> dict[str, Any]:
     return run_economy(request.tenant_id, request.niche, request.markets)
+
+
+@app.post("/federation/run")
+def run_federated_task_endpoint(request: FederatedTaskRequest) -> dict[str, Any]:
+    return run_global_task(request.campaign_id, request.tenant_id, request.region)
 
 
 @app.post("/campaign/run", response_model=CampaignDecision)

--- a/services/p2p-node/Dockerfile
+++ b/services/p2p-node/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY src ./src
+CMD ["npm", "run", "start"]

--- a/services/p2p-node/package.json
+++ b/services/p2p-node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "p2p-node",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "node src/node.js"
+  },
+  "dependencies": {
+    "@chainsafe/libp2p-noise": "^16.1.4",
+    "@libp2p/mplex": "^12.0.10",
+    "@libp2p/tcp": "^10.1.19",
+    "libp2p": "^2.10.0"
+  }
+}

--- a/services/p2p-node/src/node.js
+++ b/services/p2p-node/src/node.js
@@ -1,0 +1,34 @@
+import { createLibp2p } from 'libp2p'
+import { tcp } from '@libp2p/tcp'
+import { noise } from '@chainsafe/libp2p-noise'
+import { mplex } from '@libp2p/mplex'
+import process from 'node:process'
+
+const ALLOWLIST = (process.env.PEER_ALLOWLIST || '').split(',').map((peer) => peer.trim()).filter(Boolean)
+
+export async function startNode() {
+  const node = await createLibp2p({
+    transports: [tcp()],
+    connectionEncryption: [noise()],
+    streamMuxers: [mplex()]
+  })
+
+  node.addEventListener('peer:connect', async (evt) => {
+    const peerId = evt.detail.toString()
+    if (ALLOWLIST.length > 0 && !ALLOWLIST.includes(peerId)) {
+      await node.hangUp(evt.detail)
+    }
+  })
+
+  await node.start()
+  return node
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  startNode().then(() => {
+    console.log('p2p node started with allowlist size', ALLOWLIST.length)
+  }).catch((error) => {
+    console.error('failed to start p2p node', error)
+    process.exitCode = 1
+  })
+}

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12.8-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/main.py"]

--- a/services/scheduler/requirements.txt
+++ b/services/scheduler/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+uvicorn==0.35.0
+pydantic==2.11.7
+requests==2.32.5

--- a/services/scheduler/src/main.py
+++ b/services/scheduler/src/main.py
@@ -1,0 +1,124 @@
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+from typing import Any
+
+import requests
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+app = FastAPI(title="Global Scheduler")
+FEDERATION_URL = os.getenv("FEDERATION_URL", "http://federation:8000")
+FEDERATION_SECRET = os.getenv("FEDERATION_SECRET", "change-me")
+TIMEOUT = float(os.getenv("SCHEDULER_TIMEOUT", "3.0"))
+
+
+class Task(BaseModel):
+    task_id: str = Field(min_length=1)
+    required_capacity: int = Field(ge=1)
+    region: str = Field(min_length=2)
+    tenant_id: str = Field(default="default", min_length=1)
+    max_latency_ms: int = Field(default=250, ge=1)
+    task_token: str = Field(min_length=16)
+
+
+class Assignment(BaseModel):
+    assigned: str | None
+    candidate_count: int
+    policy: str
+    reason: str | None = None
+    observability: dict[str, Any]
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    federation_ok = False
+    try:
+        response = requests.get(f"{FEDERATION_URL}/healthz", timeout=TIMEOUT)
+        federation_ok = response.ok
+    except requests.RequestException:
+        federation_ok = False
+    return {
+        "status": "ok" if federation_ok else "degraded",
+        "service": "scheduler",
+        "checks": {"federation": federation_ok},
+        "prometheus_labels": {"service": "scheduler", "policy": "capacity-latency-aware"},
+    }
+
+
+def fetch_nodes() -> list[dict[str, Any]]:
+    try:
+        response = requests.get(f"{FEDERATION_URL}/nodes", timeout=TIMEOUT)
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise HTTPException(status_code=503, detail=f"federation unavailable: {exc}") from exc
+    return payload.get("nodes", [])
+
+
+def decode_task_token(token: str) -> dict[str, Any]:
+    try:
+        payload_b64, signature_b64 = token.split('.', 1)
+        payload = base64.urlsafe_b64decode(payload_b64.encode('utf-8'))
+        actual_signature = base64.urlsafe_b64decode(signature_b64.encode('utf-8'))
+    except (ValueError, binascii.Error) as exc:
+        raise HTTPException(status_code=401, detail=f"invalid task token format: {exc}") from exc
+
+    expected_signature = hmac.new(FEDERATION_SECRET.encode('utf-8'), payload, hashlib.sha256).digest()
+    if not hmac.compare_digest(actual_signature, expected_signature):
+        raise HTTPException(status_code=401, detail='invalid task token signature')
+
+    try:
+        claims = json.loads(payload.decode('utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=401, detail=f"invalid task token payload: {exc}") from exc
+    return claims
+
+
+def verify_task_token(task: Task) -> dict[str, Any]:
+    claims = decode_task_token(task.task_token)
+    if claims.get('tenant_id') != task.tenant_id:
+        raise HTTPException(status_code=403, detail='tenant mismatch in task token')
+    return claims
+
+
+@app.post("/assign", response_model=Assignment)
+def assign(task: Task) -> Assignment:
+    verify_task_token(task)
+    nodes = fetch_nodes()
+    tenant_nodes = [node for node in nodes if node.get("tenant_id") == task.tenant_id]
+    candidates = [node for node in tenant_nodes if node.get("capacity", 0) >= task.required_capacity]
+    if not candidates:
+        return Assignment(
+            assigned=None,
+            candidate_count=0,
+            policy="capacity-latency-aware",
+            reason="no nodes satisfy tenant and capacity constraints",
+            observability={"tenant_id": task.tenant_id, "region": task.region, "task_id": task.task_id},
+        )
+
+    def score(node: dict[str, Any]) -> tuple[int, int, str]:
+        latency_penalty = 0 if node.get("region") == task.region else 1
+        available_capacity = int(node.get("capacity", 0))
+        return (latency_penalty, -available_capacity, node.get("node_id", ""))
+
+    selected = sorted(candidates, key=score)[0]
+    return Assignment(
+        assigned=selected.get("node_id"),
+        candidate_count=len(candidates),
+        policy="capacity-latency-aware",
+        observability={
+            "tenant_id": task.tenant_id,
+            "region": task.region,
+            "selected_node": selected.get("node_id"),
+            "labels": selected.get("labels", {}),
+        },
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
### Motivation

- Implement a production-safe variant of a federated P2P compute stack that prevents uncontrolled self-expansion by adding explicit registration, signed task tokens, tenant isolation, audit logging and budget caps. 
- Provide governance, consent, auditability and cost-control primitives so global orchestration can be run at planetary scale with guardrails.

### Description

- Add a Federation Control Plane service that persists node inventory to Postgres, issues signed node claims, exposes `/nodes` and `/register`, and writes audit records (`services/federation/src/main.py`, Dockerfile and `requirements.txt`).
- Add a Scheduler that validates HMAC-signed task tokens, filters nodes by tenant and capacity, uses a latency/capacity scoring policy to assign work and returns observability metadata (`services/scheduler/src/main.py`, Dockerfile and `requirements.txt`).
- Add a Capital Allocator service implementing bounded, policy-driven allocations with a hard-cap ratio and observability fields (`services/capital-allocator/src/main.py`, Dockerfile and `requirements.txt`).
- Add an allowlisted libp2p node service to limit peer connections (`services/p2p-node/src/node.js`, `package.json`, Dockerfile) and integrate a federated execution loop (`services/master-orchestrator/src/federated_loop.py`) plus a new `/federation/run` endpoint and `docker-compose.yml` entries to wire the new services into the stack.

### Testing

- Ran `python -m compileall services/federation/src services/scheduler/src services/capital-allocator/src services/master-orchestrator/src` successfully. 
- Ran `pytest` and all tests passed (`31 passed`).
- Verified the JS entry with `node --check services/p2p-node/src/node.js` which succeeded. 
- Attempted `docker compose config` but it could not be executed in this environment because `docker` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be5ffc4fcc8321bece8d1ee2e46660)