### PR TITLE
Harden federated orchestration governance

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -734,6 +734,7 @@ services:
     environment:
       DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
       FEDERATION_SECRET: ${FEDERATION_SECRET:-change-me}
+      FEDERATION_TOKEN_TTL: ${FEDERATION_TOKEN_TTL:-3600}
     depends_on:
       postgres:
         condition: service_healthy
@@ -756,6 +757,7 @@ services:
     environment:
       FEDERATION_URL: http://federation:8000
       FEDERATION_SECRET: ${FEDERATION_SECRET:-change-me}
+      FEDERATION_TOKEN_TTL: ${FEDERATION_TOKEN_TTL:-3600}
     depends_on:
       federation:
         condition: service_healthy
@@ -793,6 +795,7 @@ services:
     env_file: .env
     environment:
       PEER_ALLOWLIST: ${PEER_ALLOWLIST:-}
+      NODE_ENV: production
     networks:
       - zttato-net
 

--- a/services/federation/src/main.py
+++ b/services/federation/src/main.py
@@ -7,6 +7,8 @@ import time
 from pathlib import Path
 from typing import Any
 
+TOKEN_TTL_SECONDS = int(os.getenv("FEDERATION_TOKEN_TTL", "3600"))
+
 import psycopg2
 import uvicorn
 from fastapi import FastAPI, HTTPException
@@ -25,10 +27,13 @@ class NodeRegister(BaseModel):
     capacity: int = Field(ge=1)
     tenant_id: str = Field(default=DEFAULT_TENANT, min_length=1)
     labels: dict[str, str] = Field(default_factory=dict)
+    attestation: str = Field(min_length=16)
+    consent_approved: bool = Field(default=False)
 
 
 class NodeRecord(NodeRegister):
     registered_at: int
+    expires_at: int
 
 
 def encode_signed_claims(claims: dict[str, Any]) -> str:
@@ -52,7 +57,10 @@ def ensure_schema() -> None:
                     region TEXT NOT NULL,
                     capacity INTEGER NOT NULL,
                     labels JSONB NOT NULL DEFAULT '{}'::jsonb,
-                    registered_at BIGINT NOT NULL
+                    attestation TEXT NOT NULL,
+                    consent_approved BOOLEAN NOT NULL DEFAULT FALSE,
+                    registered_at BIGINT NOT NULL,
+                    expires_at BIGINT NOT NULL
                 )
                 """
             )
@@ -85,7 +93,8 @@ def list_nodes() -> dict[str, Any]:
         with db_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT node_id, tenant_id, region, capacity, labels, registered_at FROM federation_nodes ORDER BY registered_at DESC"
+                    "SELECT node_id, tenant_id, region, capacity, labels, attestation, consent_approved, registered_at, expires_at FROM federation_nodes WHERE expires_at >= %s ORDER BY registered_at DESC",
+                    (int(time.time()),),
                 )
                 rows = cur.fetchall()
     except psycopg2.Error as exc:
@@ -98,7 +107,10 @@ def list_nodes() -> dict[str, Any]:
             "region": row[2],
             "capacity": row[3],
             "labels": row[4] or {},
-            "registered_at": row[5],
+            "attestation": row[5],
+            "consent_approved": row[6],
+            "registered_at": row[7],
+            "expires_at": row[8],
         }
         for row in rows
     ]
@@ -107,13 +119,21 @@ def list_nodes() -> dict[str, Any]:
 
 @app.post("/register")
 def register(node: NodeRegister) -> dict[str, Any]:
+    if not node.consent_approved:
+        raise HTTPException(status_code=400, detail="node consent approval required")
+
     issued_at = int(time.time())
+    expires_at = issued_at + TOKEN_TTL_SECONDS
+    attestation_digest = hashlib.sha256(node.attestation.encode("utf-8")).hexdigest()
     token = encode_signed_claims(
         {
             "node_id": node.node_id,
             "tenant_id": node.tenant_id,
             "region": node.region,
+            "attestation_sha256": attestation_digest,
             "iat": issued_at,
+            "exp": expires_at,
+            "token_type": "federation-node",
         }
     )
 
@@ -122,16 +142,29 @@ def register(node: NodeRegister) -> dict[str, Any]:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO federation_nodes (node_id, tenant_id, region, capacity, labels, registered_at)
-                    VALUES (%s, %s, %s, %s, %s::jsonb, %s)
+                    INSERT INTO federation_nodes (node_id, tenant_id, region, capacity, labels, attestation, consent_approved, registered_at, expires_at)
+                    VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
                     ON CONFLICT (node_id) DO UPDATE
                     SET tenant_id = EXCLUDED.tenant_id,
                         region = EXCLUDED.region,
                         capacity = EXCLUDED.capacity,
                         labels = EXCLUDED.labels,
-                        registered_at = EXCLUDED.registered_at
+                        attestation = EXCLUDED.attestation,
+                        consent_approved = EXCLUDED.consent_approved,
+                        registered_at = EXCLUDED.registered_at,
+                        expires_at = EXCLUDED.expires_at
                     """,
-                    (node.node_id, node.tenant_id, node.region, node.capacity, json.dumps(node.labels), issued_at),
+                    (
+                        node.node_id,
+                        node.tenant_id,
+                        node.region,
+                        node.capacity,
+                        json.dumps(node.labels),
+                        attestation_digest,
+                        node.consent_approved,
+                        issued_at,
+                        expires_at,
+                    ),
                 )
             conn.commit()
     except psycopg2.Error as exc:
@@ -148,7 +181,10 @@ def register(node: NodeRegister) -> dict[str, Any]:
                     "region": node.region,
                     "capacity": node.capacity,
                     "labels": node.labels,
+                    "attestation_sha256": attestation_digest,
+                    "consent_approved": node.consent_approved,
                     "timestamp": issued_at,
+                    "expires_at": expires_at,
                 }
             )
             + "\n"
@@ -156,7 +192,7 @@ def register(node: NodeRegister) -> dict[str, Any]:
 
     return {
         "token": token,
-        "node": NodeRecord(**node.model_dump(), registered_at=issued_at).model_dump(),
+        "node": NodeRecord(**node.model_dump(), attestation=attestation_digest, registered_at=issued_at, expires_at=expires_at).model_dump(),
         "prometheus_labels": {"tenant_id": node.tenant_id, "region": node.region},
     }
 

--- a/services/master-orchestrator/src/federated_loop.py
+++ b/services/master-orchestrator/src/federated_loop.py
@@ -31,7 +31,7 @@ def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
 
 def build_task_token(campaign_id: str, tenant_id: str, region: str) -> str:
     payload = json.dumps(
-        {"campaign_id": campaign_id, "tenant_id": tenant_id, "region": region},
+        {"campaign_id": campaign_id, "tenant_id": tenant_id, "region": region, "token_type": "scheduler-task"},
         separators=(",", ":"),
         sort_keys=True,
     ).encode("utf-8")
@@ -68,4 +68,10 @@ def run_global_task(campaign_id: str, tenant_id: str = DEFAULT_TENANT, region: s
             "task_token": build_task_token(campaign_id, tenant_id, region),
         },
     )
-    return {"features": features, "rl": rl, "capital": capital, "node": scheduler}
+    return {
+        "features": features,
+        "rl": rl,
+        "capital": capital,
+        "node": scheduler,
+        "audit": {"tenant_id": tenant_id, "region": region, "campaign_id": campaign_id},
+    }

--- a/services/scheduler/src/main.py
+++ b/services/scheduler/src/main.py
@@ -83,6 +83,8 @@ def verify_task_token(task: Task) -> dict[str, Any]:
     claims = decode_task_token(task.task_token)
     if claims.get('tenant_id') != task.tenant_id:
         raise HTTPException(status_code=403, detail='tenant mismatch in task token')
+    if claims.get('region') != task.region:
+        raise HTTPException(status_code=403, detail='region mismatch in task token')
     return claims
 
 
@@ -91,13 +93,19 @@ def assign(task: Task) -> Assignment:
     verify_task_token(task)
     nodes = fetch_nodes()
     tenant_nodes = [node for node in nodes if node.get("tenant_id") == task.tenant_id]
-    candidates = [node for node in tenant_nodes if node.get("capacity", 0) >= task.required_capacity]
+    candidates = [
+        node
+        for node in tenant_nodes
+        if node.get("capacity", 0) >= task.required_capacity
+        and int((node.get("labels") or {}).get("latency_ms", task.max_latency_ms)) <= task.max_latency_ms
+        and (node.get("labels") or {}).get("status", "ready") == "ready"
+    ]
     if not candidates:
         return Assignment(
             assigned=None,
             candidate_count=0,
             policy="capacity-latency-aware",
-            reason="no nodes satisfy tenant and capacity constraints",
+            reason="no nodes satisfy tenant, capacity, and latency constraints",
             observability={"tenant_id": task.tenant_id, "region": task.region, "task_id": task.task_id},
         )
 


### PR DESCRIPTION
### Motivation

- Prevent uncontrolled self-expansion and arbitrary remote execution by adding governance, consent, attestation and expiry to the federation control plane. 
- Ensure scheduled P2P compute tasks are authorized and constrained by tenant/region/latency policies before being dispatched. 
- Improve traceability and operational defaults for runtime (token TTL, p2p production mode) so the system is safe for production deployment.

### Description

- Federation control plane: require `attestation` and explicit `consent_approved` on node registration, store `attestation` SHA256 and `expires_at` in DB, filter expired nodes, and emit richer audit entries and expiring signed claims; introduced `TOKEN_TTL_SECONDS` and related token fields in claims. (modified `services/federation/src/main.py`)
- Scheduler: validate task tokens against both `tenant_id` and `region`, and filter candidate nodes by `latency_ms` and `status` labels in addition to capacity; selection remains capacity/latency-aware. (modified `services/scheduler/src/main.py`)
- Orchestration loop: include a `token_type` in generated task tokens and return an `audit` payload from `run_global_task` for easier tracing. (modified `services/master-orchestrator/src/federated_loop.py`)
- Docker Compose: wire `FEDERATION_TOKEN_TTL` into service envs and set `NODE_ENV=production` for the `p2p-node` service to enforce runtime defaults. (modified `docker-compose.yml`)

### Testing

- Ran Python bytecode checks with `python -m compileall` against modified Python modules and they succeeded. 
- Validated JavaScript syntax with `node --check services/p2p-node/src/node.js` and it succeeded. 
- Executed full test suite with `pytest` and all tests passed (`31 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be8255aa248321b46dea04506ba1dd)