### PR TITLE
Fix model-service build dependencies

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -1,6 +1,17 @@
-FROM python:3.12.8-slim
+FROM python:3.12
+
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+
+RUN pip install --upgrade pip \
+ && pip install --no-cache-dir -r requirements.txt
+
 COPY src ./src
+
 CMD ["python", "src/main.py"]

--- a/services/model-service/requirements.txt
+++ b/services/model-service/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-torch==2.8.0
-numpy==2.3.3
 pydantic==2.11.7
+numpy==1.26.4
+torch==2.2.2


### PR DESCRIPTION
### Motivation

- The model-service image failed to build because `pip install -r requirements.txt` was breaking with the current base image and dependency combination. 
- The change aims to make image builds more reliable by providing necessary system build tooling and using a stable `torch`/`numpy` combination.

### Description

- Changed `services/model-service/Dockerfile` from `FROM python:3.12.8-slim` to `FROM python:3.12` and added `apt-get install -y build-essential curl` to provide required build tools. 
- Added `pip install --upgrade pip` in the image build before installing requirements to improve dependency resolution. 
- Re-pinned `services/model-service/requirements.txt` to `numpy==1.26.4` and `torch==2.2.2` while keeping FastAPI/Uvicorn/Pydantic versions the same. 
- Kept the application entrypoint as `CMD [

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb5dfa7688321b5dd31cc4ad137ca)