### PR TITLE
Add async result pipeline to model-service (Redis + Kafka + APIs + metrics)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -438,6 +438,18 @@ services:
     container_name: zttato-model-service
     restart: always
     env_file: .env
+    environment:
+      REDIS_URL: redis://${REDIS_HOST:-redis}:${REDIS_PORT:-6379}/0
+      KAFKA_BROKER: redpanda:9092
+      MODEL_REQUEST_TOPIC: inference.request
+      MODEL_RESPONSE_TOPIC: inference.response
+      MODEL_DLQ_TOPIC: inference.dlq
+      PROMETHEUS_METRICS_ENABLED: ${PROMETHEUS_METRICS_ENABLED:-1}
+    depends_on:
+      redis:
+        condition: service_healthy
+      redpanda:
+        condition: service_started
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
       interval: 15s

--- a/services/model-service/requirements.txt
+++ b/services/model-service/requirements.txt
@@ -3,3 +3,7 @@ uvicorn==0.35.0
 pydantic==2.11.7
 numpy==1.26.4
 torch==2.2.2
+confluent-kafka==2.5.0
+redis==5.0.4
+msgpack==1.0.8
+prometheus-client==0.23.1

--- a/services/model-service/src/main.py
+++ b/services/model-service/src/main.py
@@ -1,14 +1,37 @@
+import asyncio
+import logging
 import os
+import json
+from contextlib import asynccontextmanager
+import time
+import uuid
 from typing import Any
 
 import torch
 import uvicorn
-from fastapi import FastAPI
+from confluent_kafka import Producer
+from fastapi import FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.responses import Response
 from pydantic import BaseModel, Field
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
-app = FastAPI(title="Model Service")
+from metrics import ASYNC_REQUESTS_TOTAL, RESULT_LOOKUP_LATENCY
+from queue_runtime import REQUEST_TOPIC, start_background_consumers
+from result_store import result_store
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    start_background_consumers(predict_from_payload)
+    yield
+
+
+app = FastAPI(title="Model Service", lifespan=lifespan)
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("model-service")
 WEIGHTS = torch.tensor([0.3, 0.7], dtype=torch.float32)
 MODEL_VERSION = os.getenv("MODEL_VERSION", "baseline-ctr-cvr-v1")
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "redpanda:9092")
+producer = Producer({"bootstrap.servers": KAFKA_BROKER})
 
 
 class FeatureVector(BaseModel):
@@ -24,6 +47,11 @@ class PredictionResult(BaseModel):
     model_version: str
 
 
+class AsyncJobAccepted(BaseModel):
+    job_id: str
+    status: str
+
+
 def predict(features: FeatureVector) -> PredictionResult:
     ctr = features.clicks / features.views if features.views else 0.0
     cvr = features.conversions / features.clicks if features.clicks else 0.0
@@ -32,14 +60,91 @@ def predict(features: FeatureVector) -> PredictionResult:
     return PredictionResult(score=score, ctr=ctr, cvr=cvr, model_version=MODEL_VERSION)
 
 
+def predict_from_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    features = FeatureVector.model_validate(payload)
+    return predict(features).model_dump()
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
-    return {"status": "ok", "service": "model-service", "model_version": MODEL_VERSION}
+    return {
+        "status": "ok",
+        "service": "model-service",
+        "model_version": MODEL_VERSION,
+        "kafka_broker": KAFKA_BROKER,
+    }
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
 @app.post("/predict", response_model=PredictionResult)
 def predict_api(features: FeatureVector) -> PredictionResult:
     return predict(features)
+
+
+@app.post("/predict_async", response_model=AsyncJobAccepted)
+def predict_async(
+    features: FeatureVector,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> AsyncJobAccepted:
+    try:
+        job_id = idempotency_key or str(uuid.uuid4())
+        result_store.set_result(job_id, {"status": "queued", "model_version": MODEL_VERSION})
+        producer.produce(
+            REQUEST_TOPIC,
+            json.dumps(
+                {
+                    "job_id": job_id,
+                    "features": features.model_dump(),
+                    "model_version": MODEL_VERSION,
+                }
+            ).encode("utf-8"),
+        )
+        producer.flush()
+        ASYNC_REQUESTS_TOTAL.inc()
+        return AsyncJobAccepted(job_id=job_id, status="queued")
+    except Exception as exc:
+        log.exception("Failed to enqueue async prediction")
+        raise HTTPException(status_code=500, detail=f"Failed to enqueue async prediction: {exc}") from exc
+
+
+@app.get("/result/{job_id}")
+def fetch_result(job_id: str) -> dict[str, Any]:
+    started_at = time.perf_counter()
+    result = result_store.get_result(job_id)
+    RESULT_LOOKUP_LATENCY.observe(time.perf_counter() - started_at)
+    return result or {"job_id": job_id, "status": "pending"}
+
+
+@app.get("/result/{job_id}/wait")
+async def wait_result(job_id: str, timeout: int = 10, poll_interval: float = 0.2) -> dict[str, Any]:
+    deadline = asyncio.get_running_loop().time() + max(timeout, 1)
+    while True:
+        result = result_store.get_result(job_id)
+        if result and result.get("status") not in {"queued", "pending"}:
+            return result
+        if asyncio.get_running_loop().time() >= deadline:
+            return {"job_id": job_id, "status": "timeout"}
+        await asyncio.sleep(max(poll_interval, 0.05))
+
+
+@app.websocket("/ws/result/{job_id}")
+async def ws_result(websocket: WebSocket, job_id: str) -> None:
+    await websocket.accept()
+    try:
+        while True:
+            result = result_store.get_result(job_id)
+            if result and result.get("status") not in {"queued", "pending"}:
+                await websocket.send_json(result)
+                return
+            await asyncio.sleep(0.2)
+    except WebSocketDisconnect:
+        return
+    finally:
+        await websocket.close()
 
 
 if __name__ == "__main__":

--- a/services/model-service/src/metrics.py
+++ b/services/model-service/src/metrics.py
@@ -1,0 +1,39 @@
+import os
+
+_METRICS_ENABLED = os.getenv("PROMETHEUS_METRICS_ENABLED", "1") != "0"
+
+if _METRICS_ENABLED:
+    from prometheus_client import Counter, Histogram
+
+    ASYNC_REQUESTS_TOTAL = Counter(
+        "model_service_async_requests_total",
+        "Async inference requests accepted",
+    )
+    ASYNC_RESULTS_TOTAL = Counter(
+        "model_service_async_results_total",
+        "Async results persisted",
+        ["status"],
+    )
+    ASYNC_DLQ_TOTAL = Counter(
+        "model_service_async_dlq_total",
+        "Async inference failures routed to DLQ",
+    )
+    RESULT_LOOKUP_LATENCY = Histogram(
+        "model_service_result_lookup_seconds",
+        "Latency for async result lookups",
+    )
+else:
+    class _NoopMetric:
+        def inc(self, amount: float = 1.0) -> None:
+            return None
+
+        def observe(self, value: float) -> None:
+            return None
+
+        def labels(self, *args, **kwargs):
+            return self
+
+    ASYNC_REQUESTS_TOTAL = _NoopMetric()
+    ASYNC_RESULTS_TOTAL = _NoopMetric()
+    ASYNC_DLQ_TOTAL = _NoopMetric()
+    RESULT_LOOKUP_LATENCY = _NoopMetric()

--- a/services/model-service/src/queue_runtime.py
+++ b/services/model-service/src/queue_runtime.py
@@ -1,0 +1,120 @@
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable
+
+from confluent_kafka import Consumer, Producer
+
+from metrics import ASYNC_DLQ_TOTAL, ASYNC_RESULTS_TOTAL
+from result_store import result_store
+
+log = logging.getLogger("model-service.queue")
+KAFKA_BROKER = os.getenv("KAFKA_BROKER", "redpanda:9092")
+REQUEST_TOPIC = os.getenv("MODEL_REQUEST_TOPIC", "inference.request")
+RESPONSE_TOPIC = os.getenv("MODEL_RESPONSE_TOPIC", "inference.response")
+DLQ_TOPIC = os.getenv("MODEL_DLQ_TOPIC", "inference.dlq")
+REQUEST_GROUP = os.getenv("MODEL_REQUEST_GROUP", "model-service-request-consumer")
+RESPONSE_GROUP = os.getenv("MODEL_RESPONSE_GROUP", "model-service-response-consumer")
+POLL_SECONDS = float(os.getenv("MODEL_CONSUMER_POLL_SECONDS", "0.2"))
+_STARTED = False
+_LOCK = threading.Lock()
+
+
+def _consumer(group_id: str) -> Consumer:
+    return Consumer(
+        {
+            "bootstrap.servers": KAFKA_BROKER,
+            "group.id": group_id,
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": True,
+        }
+    )
+
+
+producer = Producer({"bootstrap.servers": KAFKA_BROKER})
+
+
+def _decode_message(message: bytes) -> dict[str, Any]:
+    payload = json.loads(message.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("message payload must be a JSON object")
+    return payload
+
+
+def _publish(topic: str, payload: dict[str, Any]) -> None:
+    producer.produce(topic, json.dumps(payload).encode("utf-8"))
+    producer.flush()
+
+
+def _request_loop(predict_fn: Callable[[dict[str, Any]], dict[str, Any]]) -> None:
+    consumer = _consumer(REQUEST_GROUP)
+    consumer.subscribe([REQUEST_TOPIC])
+    log.info("Request consumer listening to %s via %s", REQUEST_TOPIC, KAFKA_BROKER)
+
+    while True:
+        msg = consumer.poll(POLL_SECONDS)
+        if msg is None:
+            continue
+        if msg.error():
+            log.warning("Kafka request consumer error: %s", msg.error())
+            continue
+
+        try:
+            payload = _decode_message(msg.value())
+            job_id = payload.get("job_id")
+            features = payload.get("features")
+            if not job_id or not isinstance(features, dict):
+                raise ValueError("job_id and features object are required")
+
+            result = predict_fn(features)
+            response = {"job_id": job_id, "status": "done", **result}
+            _publish(RESPONSE_TOPIC, response)
+        except Exception as exc:  # pragma: no cover - thread failure path
+            dlq_payload = {
+                "job_id": payload.get("job_id") if 'payload' in locals() and isinstance(payload, dict) else None,
+                "status": "failed",
+                "error": str(exc),
+                "failed_at": int(time.time()),
+            }
+            log.warning("Routing async job to DLQ: %s", dlq_payload)
+            _publish(DLQ_TOPIC, dlq_payload)
+            ASYNC_DLQ_TOTAL.inc()
+
+
+def _response_loop() -> None:
+    consumer = _consumer(RESPONSE_GROUP)
+    consumer.subscribe([RESPONSE_TOPIC, DLQ_TOPIC])
+    log.info("Response consumer listening to %s and %s", RESPONSE_TOPIC, DLQ_TOPIC)
+
+    while True:
+        msg = consumer.poll(POLL_SECONDS)
+        if msg is None:
+            continue
+        if msg.error():
+            log.warning("Kafka response consumer error: %s", msg.error())
+            continue
+
+        try:
+            payload = _decode_message(msg.value())
+            job_id = payload.get("job_id")
+            if not job_id:
+                raise ValueError("job_id is required")
+            stored = result_store.set_result(job_id, payload)
+            ASYNC_RESULTS_TOTAL.labels(stored.get("status", "unknown")).inc()
+        except Exception:  # pragma: no cover - thread failure path
+            log.warning("Failed to persist async result", exc_info=True)
+
+
+def start_background_consumers(predict_fn: Callable[[dict[str, Any]], dict[str, Any]]) -> None:
+    global _STARTED
+    with _LOCK:
+        if _STARTED:
+            return
+        _STARTED = True
+
+    for target in (_request_loop, _response_loop):
+        kwargs = {"predict_fn": predict_fn} if target is _request_loop else {}
+        thread = threading.Thread(target=target, kwargs=kwargs, daemon=True)
+        thread.start()

--- a/services/model-service/src/result_store.py
+++ b/services/model-service/src/result_store.py
@@ -1,0 +1,65 @@
+import logging
+import os
+import time
+from typing import Any
+
+import msgpack
+from redis import Redis
+from redis.cluster import RedisCluster
+
+log = logging.getLogger("model-service.result-store")
+RESULT_TTL_SECONDS = int(os.getenv("RESULT_TTL", "3600"))
+RESULT_NAMESPACE = os.getenv("RESULT_NAMESPACE", "result")
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+REDIS_CLUSTER_URL = os.getenv("REDIS_CLUSTER_URL", "")
+
+
+class ResultStore:
+    def __init__(self) -> None:
+        self._client = self._build_client()
+
+    def _build_client(self) -> Redis | RedisCluster:
+        if REDIS_CLUSTER_URL:
+            log.info("Connecting to Redis cluster at %s", REDIS_CLUSTER_URL)
+            return RedisCluster.from_url(REDIS_CLUSTER_URL, decode_responses=False)
+        return Redis.from_url(REDIS_URL, decode_responses=False)
+
+    def _key(self, job_id: str) -> str:
+        return f"{RESULT_NAMESPACE}:{job_id}"
+
+    def set_result(self, job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if not job_id:
+            raise ValueError("job_id is required")
+
+        data = {
+            "job_id": job_id,
+            "status": payload.get("status", "done"),
+            "score": payload.get("score"),
+            "ctr": payload.get("ctr"),
+            "cvr": payload.get("cvr"),
+            "model_version": payload.get("model_version"),
+            "error": payload.get("error"),
+            "updated_at": int(time.time()),
+        }
+        packed = msgpack.packb(data, use_bin_type=True)
+        self._client.setex(self._key(job_id), RESULT_TTL_SECONDS, packed)
+        return data
+
+    def get_result(self, job_id: str) -> dict[str, Any] | None:
+        if not job_id:
+            return None
+
+        raw = self._client.get(self._key(job_id))
+        if not raw:
+            return None
+
+        try:
+            decoded = msgpack.unpackb(raw, raw=False)
+            if isinstance(decoded, dict):
+                return decoded
+        except Exception:  # pragma: no cover - defensive fallback
+            log.warning("Failed to decode result for job_id=%s", job_id, exc_info=True)
+        return None
+
+
+result_store = ResultStore()

--- a/tests/test_model_service_async.py
+++ b/tests/test_model_service_async.py
@@ -1,0 +1,126 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+class FakeTensor:
+    def __init__(self, values):
+        self.values = [float(v) for v in values]
+
+    def __getitem__(self, index):
+        return self.values[index]
+
+    def __len__(self):
+        return len(self.values)
+
+    def item(self):
+        if len(self.values) != 1:
+            raise ValueError("item() expects a single value")
+        return self.values[0]
+
+
+class FakeTorch(types.SimpleNamespace):
+    float32 = "float32"
+
+    @staticmethod
+    def tensor(values, dtype=None):
+        return FakeTensor(values)
+
+    @staticmethod
+    def dot(left, right):
+        return FakeTensor([sum(a * b for a, b in zip(left.values, right.values))])
+
+
+class FakeProducer:
+    def __init__(self, *args, **kwargs):
+        self.messages = []
+
+    def produce(self, topic, value):
+        self.messages.append((topic, value))
+
+    def flush(self):
+        return None
+
+
+class FakeConsumer:
+    def __init__(self, *args, **kwargs):
+        self.subscriptions = []
+
+    def subscribe(self, topics):
+        self.subscriptions.append(tuple(topics))
+
+    def poll(self, timeout):
+        return None
+
+
+class FakeResultStore:
+    def __init__(self):
+        self.data = {}
+
+    def set_result(self, job_id, payload):
+        record = {"job_id": job_id, **payload}
+        self.data[job_id] = record
+        return record
+
+    def get_result(self, job_id):
+        return self.data.get(job_id)
+
+
+class NoopMetric:
+    def inc(self, amount=1):
+        return None
+
+    def observe(self, value):
+        return None
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+def load_main_module():
+    base = Path("/workspace/zttato-platform/services/model-service/src")
+    sys.path.insert(0, str(base))
+    sys.modules["torch"] = FakeTorch()
+    sys.modules["confluent_kafka"] = types.SimpleNamespace(Producer=FakeProducer, Consumer=FakeConsumer)
+    sys.modules["prometheus_client"] = types.SimpleNamespace(
+        CONTENT_TYPE_LATEST="text/plain",
+        generate_latest=lambda: b"metrics 1\n",
+        Counter=lambda *args, **kwargs: NoopMetric(),
+        Histogram=lambda *args, **kwargs: NoopMetric(),
+    )
+    sys.modules["result_store"] = types.SimpleNamespace(result_store=FakeResultStore())
+
+    spec = importlib.util.spec_from_file_location("model_service_main", base / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_predict_async_accepts_idempotency_key():
+    module = load_main_module()
+    client = TestClient(module.app)
+
+    response = client.post(
+        "/predict_async",
+        headers={"Idempotency-Key": "job-123"},
+        json={"views": 10, "clicks": 4, "conversions": 2},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"job_id": "job-123", "status": "queued"}
+    assert module.result_store.get_result("job-123")["status"] == "queued"
+    assert module.producer.messages[0][0] == module.REQUEST_TOPIC
+
+
+def test_fetch_result_returns_pending_when_missing():
+    module = load_main_module()
+    client = TestClient(module.app)
+
+    response = client.get("/result/unknown-job")
+
+    assert response.status_code == 200
+    assert response.json() == {"job_id": "unknown-job", "status": "pending"}


### PR DESCRIPTION
### Motivation
- Provide an end-to-end async inference flow so clients can submit jobs, retrieve results with low-latency reads, and enable scalable decoupling via Kafka and Redis.
- Make async jobs idempotent and observable by adding idempotency, TTL-based result retention, DLQ routing and optional Prometheus metrics.
- Add long-poll and WebSocket delivery options to support realtime use-cases while preserving the existing synchronous `/predict` API.

### Description
- Add a Redis-backed result store with msgpack encoding, TTL support and optional Redis Cluster discovery in `services/model-service/src/result_store.py`.
- Add Kafka request/response runtime threads plus DLQ routing and publisher helpers in `services/model-service/src/queue_runtime.py` to consume requests and persist responses to Redis.
- Expose async APIs in `services/model-service/src/main.py`: `POST /predict_async` (with `Idempotency-Key` header), `GET /result/{job_id}`, `GET /result/{job_id}/wait` (long-poll), WebSocket `/ws/result/{job_id}`, and `/metrics` for Prometheus; start background consumers via a FastAPI lifespan handler.
- Add optional Prometheus counters and histogram with no-op fallbacks in `services/model-service/src/metrics.py` and wire metrics exposure in the main app.
- Update runtime wiring: add Kafka/Redis/msgpack/prometheus dependencies to `services/model-service/requirements.txt` and configure the `model-service` environment in `docker-compose.yml` to depend on Redis and Redpanda and expose necessary env vars.
- Add focused tests in `tests/test_model_service_async.py` that mock external deps and validate idempotency behavior and pending-result fallback.

### Testing
- Ran the unit/integration-style tests with `pytest -q tests/test_model_service_async.py`, which passed (`2 passed`).
- Performed a bytecode sanity check with `python -m compileall services/model-service/src`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec00b9b448321aae8acc44078b204)