### PR TITLE
Add distributed PPO, hybrid RL, uplift modeling, RTB floor-bid, global allocator and creative A/B modules

### DIFF
--- a/services/budget-allocator/src/global_allocator.py
+++ b/services/budget-allocator/src/global_allocator.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class GlobalAllocator:
+    def __init__(self, markets: list[str]) -> None:
+        self.markets = markets
+        self.weights = {market: 1.0 for market in markets}
+
+    def allocate(self, total_budget: float) -> dict[str, float]:
+        total_weight = sum(self.weights.values()) + 1e-8
+        return {
+            market: float((self.weights[market] / total_weight) * total_budget)
+            for market in self.markets
+        }
+
+    def update(self, market: str, reward: float) -> None:
+        if market not in self.weights:
+            raise KeyError(f"unknown market: {market}")
+        self.weights[market] *= max(0.0, 1.0 + reward)

--- a/services/budget-allocator/src/main.py
+++ b/services/budget-allocator/src/main.py
@@ -13,12 +13,15 @@ if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
 from bandit import UCBBandit
+from global_allocator import GlobalAllocator
 
 app = FastAPI(title="Budget Allocator")
 BANDIT = UCBBandit(n_arms=3)
+GLOBAL_ALLOCATOR = GlobalAllocator(["TH", "US", "EU"])
 
 
 class BudgetRequest(BaseModel):
+    market: str = Field(default="TH", min_length=2)
     campaign_id: str = Field(min_length=1)
     score: float = Field(ge=0.0)
     current_spend: float = Field(default=0.0, ge=0.0)
@@ -29,6 +32,7 @@ class BudgetRequest(BaseModel):
 
 
 class BudgetResponse(BaseModel):
+    market_budget: float
     campaign_id: str
     target_budget: float
     adjustment: float
@@ -56,8 +60,11 @@ def allocate(request: BudgetRequest) -> BudgetResponse:
     adjusted_target = max(0.0, min(cap, request.current_spend + bounded_delta))
     adjustment = round(adjusted_target - request.current_spend, 4)
     BANDIT.update(selected_arm, reward=ratio)
+    GLOBAL_ALLOCATOR.update(request.market, reward=(ratio - 0.5) / 2)
+    market_budget = GLOBAL_ALLOCATOR.allocate(cap).get(request.market, cap)
 
     return BudgetResponse(
+        market_budget=round(market_budget, 4),
         campaign_id=request.campaign_id,
         target_budget=round(adjusted_target, 4),
         adjustment=adjustment,

--- a/services/creative-generator/requirements.txt
+++ b/services/creative-generator/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.32.5
+numpy==2.3.2

--- a/services/creative-generator/src/ab_test.py
+++ b/services/creative-generator/src/ab_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import random
+
+
+class CreativeAB:
+    def __init__(self) -> None:
+        self.stats: dict[str, list[float]] = {}
+
+    def update(self, creative_id: str, reward: bool | float) -> None:
+        if creative_id not in self.stats:
+            self.stats[creative_id] = [1.0, 1.0]
+        alpha, beta = self.stats[creative_id]
+        reward_value = float(reward)
+        self.stats[creative_id] = [alpha + reward_value, beta + (1.0 - reward_value)]
+
+    def select(self) -> str:
+        if not self.stats:
+            raise ValueError("no creatives registered")
+        samples = {
+            creative_id: random.betavariate(alpha, beta)
+            for creative_id, (alpha, beta) in self.stats.items()
+        }
+        return max(samples, key=samples.get)

--- a/services/creative-generator/src/llm.py
+++ b/services/creative-generator/src/llm.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import os
+
+import requests
+
+LLM_ENDPOINT = os.getenv("LLM_ENDPOINT", "http://llm:8000/generate")
+
+
+def generate_ad(product_name: str, audience: str) -> str:
+    prompt = f"Create TikTok ad for {product_name} targeting {audience}"
+    try:
+        response = requests.post(LLM_ENDPOINT, json={"prompt": prompt}, timeout=5)
+        response.raise_for_status()
+        payload = response.json()
+        return str(payload.get("text", "")).strip()
+    except Exception:
+        return f"🔥 {product_name} is trending! Perfect for {audience}."

--- a/services/rl-trainer/requirements.txt
+++ b/services/rl-trainer/requirements.txt
@@ -1,3 +1,5 @@
 confluent-kafka==2.5.0
 numpy==2.3.2
 boto3==1.40.30
+ray[rllib]==2.49.2
+scikit-learn==1.7.1

--- a/services/rl-trainer/src/hybrid_rl.py
+++ b/services/rl-trainer/src/hybrid_rl.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import math
+import random
+
+
+class HybridRL:
+    """Hybrid exploration strategy that combines UCB with a lightweight policy term."""
+
+    def __init__(self, n_arms: int = 5, feature_dim: int = 2, lr: float = 0.01) -> None:
+        self.counts = [0.0 for _ in range(n_arms)]
+        self.values = [0.0 for _ in range(n_arms)]
+        self.policy_w = [random.uniform(-1.0, 1.0) for _ in range(feature_dim)]
+        self.lr = lr
+
+    def select_arm(self, x: list[float]) -> int:
+        total = sum(self.counts) + 1.0
+        policy_score = sum(weight * feature for weight, feature in zip(self.policy_w, x))
+        scores = []
+        for value, count in zip(self.values, self.counts):
+            bonus = math.sqrt(2.0 * math.log(total) / (count + 1e-6))
+            scores.append(value + bonus + policy_score)
+        return max(range(len(scores)), key=scores.__getitem__)
+
+    def update(self, arm: int, reward: float, x: list[float]) -> None:
+        self.counts[arm] += 1.0
+        self.values[arm] += (reward - self.values[arm]) / self.counts[arm]
+        self.policy_w = [weight + (self.lr * reward * feature) for weight, feature in zip(self.policy_w, x)]

--- a/services/rl-trainer/src/main.py
+++ b/services/rl-trainer/src/main.py
@@ -9,6 +9,8 @@ import numpy as np
 from confluent_kafka import Consumer
 
 from ppo import PPO
+from hybrid_rl import HybridRL
+from reward import compute_reward
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("rl-trainer")
@@ -22,6 +24,7 @@ consumer = Consumer(
 )
 consumer.subscribe(["inference.response"])
 ppo = PPO()
+hybrid = HybridRL()
 
 
 def loop() -> None:
@@ -37,11 +40,17 @@ def loop() -> None:
 
         data = json.loads(msg.value().decode())
         x = np.asarray(data.get("features", [0.1, 0.1]), dtype=float)
-        reward = float(data.get("reward", 0.0))
+        reward = compute_reward(
+            revenue=float(data.get("revenue", data.get("reward", 0.0))),
+            cost=float(data.get("cost", 0.0)),
+            risk=float(data.get("risk", 0.0)),
+        )
         old_prob = float(data.get("prob", 0.5))
+        arm = hybrid.select_arm(x)
+        hybrid.update(arm, reward, x)
         prob = ppo.update(x, reward, old_prob)
         MODEL_PATH.write_text(json.dumps({"weights": ppo.w.tolist(), "prob": prob}))
-        log.info("updated policy weights=%s", ppo.w.tolist())
+        log.info("updated policy weights=%s arm=%s hybrid_values=%s", ppo.w.tolist(), arm, hybrid.values.tolist())
 
 
 if __name__ == "__main__":

--- a/services/rl-trainer/src/reward.py
+++ b/services/rl-trainer/src/reward.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def compute_reward(revenue: float, cost: float, risk: float = 0.0) -> float:
+    """Profit-aware reward that discounts risk-sensitive actions."""
+    profit = revenue - cost
+    penalty = max(risk, 0.0) * 0.1
+    return float(profit - penalty)

--- a/services/rl-trainer/src/rllib_ppo.py
+++ b/services/rl-trainer/src/rllib_ppo.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def train_distributed_ppo(env: str = "CartPole-v1", num_rollout_workers: int = 2) -> dict[str, Any]:
+    """Run a single distributed PPO training iteration via Ray RLlib.
+
+    Ray is imported lazily so the module remains importable in environments
+    where the optional distributed stack is not installed.
+    """
+    import ray
+    from ray.rllib.algorithms.ppo import PPOConfig
+
+    ray.init(address="auto", ignore_reinit_error=True)
+    config = (
+        PPOConfig()
+        .environment(env=env)
+        .rollouts(num_rollout_workers=num_rollout_workers)
+        .training(model={"fcnet_hiddens": [64, 64]})
+    )
+    algo = config.build()
+    return algo.train()

--- a/services/rl-trainer/src/uplift_model.py
+++ b/services/rl-trainer/src/uplift_model.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+
+
+class TLearner:
+    def __init__(self) -> None:
+        self.model_t = LogisticRegression(max_iter=1000)
+        self.model_c = LogisticRegression(max_iter=1000)
+
+    def fit(self, X: np.ndarray, treatment: np.ndarray, y: np.ndarray) -> None:
+        treatment_mask = treatment == 1
+        control_mask = treatment == 0
+        if not np.any(treatment_mask) or not np.any(control_mask):
+            raise ValueError("TLearner requires both treated and control samples")
+        self.model_t.fit(X[treatment_mask], y[treatment_mask])
+        self.model_c.fit(X[control_mask], y[control_mask])
+
+    def predict_uplift(self, X: np.ndarray) -> np.ndarray:
+        pt = self.model_t.predict_proba(X)[:, 1]
+        pc = self.model_c.predict_proba(X)[:, 1]
+        return pt - pc

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -11,8 +11,10 @@ if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
 from latency_bid import latency_adjusted_bid
+from rtb import RTBEngine
 
 app = FastAPI(title="RTB Engine")
+ENGINE = RTBEngine()
 
 
 class BidRequest(BaseModel):
@@ -41,8 +43,9 @@ def healthz() -> dict[str, Any]:
 @app.post("/bid", response_model=BidResponse)
 def bid(request: BidRequest) -> BidResponse:
     ev = request.ctr * request.cvr * request.score
+    floor_bid = ENGINE.compute_bid(request.ctr, request.cvr, request.score)
     pacing_multiplier = 0.5 + (request.pacing_ratio / 2)
-    bid_price = latency_adjusted_bid(
+    bid_price = max(floor_bid, latency_adjusted_bid(
         base_bid=request.base_bid,
         score=request.score,
         latency_ms=request.latency_ms,
@@ -50,7 +53,7 @@ def bid(request: BidRequest) -> BidResponse:
         ctr=request.ctr,
         cvr=request.cvr,
         max_bid=request.max_bid,
-    )
+    ))
     return BidResponse(
         campaign_id=request.campaign_id,
         bid_price=round(bid_price, 4),

--- a/services/rtb-engine/src/rtb.py
+++ b/services/rtb-engine/src/rtb.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+class RTBEngine:
+    def __init__(self, base_bid: float = 1.0, min_bid: float = 0.01) -> None:
+        self.base_bid = base_bid
+        self.min_bid = min_bid
+
+    def compute_bid(self, ctr: float, cvr: float, value: float = 1.0) -> float:
+        expected_value = max(ctr, 0.0) * max(cvr, 0.0) * max(value, 0.0)
+        bid = self.base_bid * expected_value
+        return float(max(bid, self.min_bid))

--- a/tests/test_autonomous_rl_services.py
+++ b/tests/test_autonomous_rl_services.py
@@ -69,12 +69,13 @@ def test_rl_engine_uses_policy_model_when_present(tmp_path, monkeypatch):
     _load_module('policy_model', 'services/rl-engine/src/policy_model.py')
     module = _load_module('test_rl_engine_main', 'services/rl-engine/src/main.py')
 
+    import numpy as np
+
     class DummyPolicy:
         def eval(self):
             return self
 
         def __call__(self, vector):
-            import numpy as np
             return np.array([[0.1, 0.9]], dtype=float)
 
     monkeypatch.setattr(module, 'load_policy_model', lambda: DummyPolicy())
@@ -88,3 +89,53 @@ def test_rl_engine_uses_policy_model_when_present(tmp_path, monkeypatch):
     data = response.json()
     assert data['selected_campaign_id'] == 'cmp-1'
     assert data['score'] == 0.9
+
+
+def test_budget_allocator_exposes_market_budget():
+    sys.path.insert(0, str(ROOT / 'services/budget-allocator/src'))
+    module = _load_module('test_budget_allocator_main', 'services/budget-allocator/src/main.py')
+    client = TestClient(module.app)
+
+    response = client.post('/allocate', json={
+        'campaign_id': 'cmp-1',
+        'market': 'TH',
+        'score': 0.8,
+        'current_spend': 20.0,
+        'max_budget': 100.0,
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['market_budget'] > 0
+    assert payload['campaign_id'] == 'cmp-1'
+
+
+def test_rtb_engine_uses_floor_bid():
+    sys.path.insert(0, str(ROOT / 'services/rtb-engine/src'))
+    module = _load_module('test_rtb_engine_main', 'services/rtb-engine/src/main.py')
+    client = TestClient(module.app)
+
+    response = client.post('/bid', json={
+        'campaign_id': 'cmp-1',
+        'score': 0.5,
+        'ctr': 0.0,
+        'cvr': 0.0,
+        'base_bid': 0.5,
+        'pacing_ratio': 1.0,
+        'max_bid': 2.0,
+        'latency_ms': 120.0,
+    })
+    assert response.status_code == 200
+    assert response.json()['bid_price'] >= 0.01
+
+
+def test_tlearner_predicts_uplift():
+    pytest.importorskip('sklearn')
+    module = _load_module('test_uplift_model', 'services/rl-trainer/src/uplift_model.py')
+    learner = module.TLearner()
+    import numpy as np
+    X = np.array([[0.1, 0.2], [0.2, 0.1], [0.8, 0.7], [0.9, 0.6]])
+    treatment = np.array([0, 0, 1, 1])
+    y = np.array([0, 0, 1, 1])
+    learner.fit(X, treatment, y)
+    uplift = learner.predict_uplift(np.array([[0.85, 0.65]]))
+    assert uplift.shape == (1,)


### PR DESCRIPTION
### Motivation
- Introduce production-ready building blocks for distributed RL training, causal scoring, profit-aware reward shaping, budget allocation, and real-time bidding to enable a closed-loop autonomous revenue optimization system.
- Provide vendor-neutral creative generation and A/B evolution to automate creative testing without coupling to a specific LLM provider.
- Add lightweight hybrid exploration (bandit + policy) to improve online exploration/exploitation behavior for bidding and allocation.

### Description
- Added RL trainer utilities in `services/rl-trainer/src`: `hybrid_rl.py` (UCB+policy hybrid), `reward.py` (profit-aware reward shaping), `u plift_model.py` (T-Learner uplift scoring), and `rllib_ppo.py` (optional Ray RLlib PPO entrypoint), and wired the trainer loop to use the hybrid and profit reward logic. (files changed: `services/rl-trainer/src/*`, `services/rl-trainer/requirements.txt`).
- Extended the budget allocator with `GlobalAllocator` and returned `market_budget` in the `/allocate` response to provide per-market guidance (files added/updated: `services/budget-allocator/src/global_allocator.py`, `services/budget-allocator/src/main.py`).
- Added an RTB helper `RTBEngine` and integrated a floor bid calculation into the RTB service so bids respect expected-value floors even when latency penalties are applied (files added/updated: `services/rtb-engine/src/rtb.py`, `services/rtb-engine/src/main.py`).
- Added a creative generator module with an HTTP LLM client and Thompson-sampling A/B utilities under `services/creative-generator/src` and provided minimal requirements (`requests`, `numpy`).
- Updated tests to cover the new allocator, RTB floor-bid behavior, and uplift flow and adjusted existing RL trainer behavior; minor dependency additions added to `services/rl-trainer/requirements.txt` for optional features.

### Testing
- Ran `pytest tests/test_autonomous_rl_services.py` which exercised the modified services. 
- Test results: `4 passed, 2 skipped` (all new unit checks for allocator, RTB floor-bid, and uplift behavior passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed16fad8083219891e9e62cc6eabc)