### PR TITLE
Add autonomous economy orchestration modules

### DIFF
--- a/services/rl-trainer/src/agent_replicator.py
+++ b/services/rl-trainer/src/agent_replicator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from typing import Iterable
+
+log = logging.getLogger("rl-trainer.agent-replicator")
+
+
+@dataclass(frozen=True)
+class DeploymentTarget:
+    host: str
+    user: str = "root"
+    runtime: str = "docker-compose"
+
+
+class Replicator:
+    def __init__(
+        self,
+        targets: Iterable[DeploymentTarget] | None = None,
+        image: str | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        self.targets = list(targets) if targets is not None else parse_targets(os.getenv("TARGET_NODES", ""))
+        self.image = image or os.getenv("REPLICATOR_IMAGE", "zttato:latest")
+        self.enabled = enabled if enabled is not None else os.getenv("REPLICATOR_ENABLED", "false").lower() == "true"
+
+    def deploy(self, target: DeploymentTarget) -> int:
+        remote_command = build_remote_command(target.runtime, self.image)
+        ssh_target = f"{target.user}@{target.host}"
+        cmd = ["ssh", ssh_target, remote_command]
+        log.info("deploying autonomous node to %s with runtime=%s", ssh_target, target.runtime)
+        completed = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        if completed.returncode != 0:
+            log.warning("deployment to %s failed: %s", ssh_target, completed.stderr.strip())
+        return completed.returncode
+
+    def replicate(self) -> list[dict[str, object]]:
+        if not self.enabled:
+            log.info("replication disabled; set REPLICATOR_ENABLED=true to enable remote deployment")
+            return []
+
+        results: list[dict[str, object]] = []
+        for target in self.targets:
+            code = self.deploy(target)
+            results.append({"host": target.host, "runtime": target.runtime, "returncode": code})
+        return results
+
+
+def parse_targets(raw_targets: str) -> list[DeploymentTarget]:
+    targets: list[DeploymentTarget] = []
+    for raw in (item.strip() for item in raw_targets.split(",")):
+        if not raw:
+            continue
+        runtime = "docker-compose"
+        user_host = raw
+        if "@" in raw:
+            user, host = raw.split("@", 1)
+        else:
+            user, host = "root", raw
+        if ":" in host:
+            host, runtime = host.split(":", 1)
+        targets.append(DeploymentTarget(host=host, user=user, runtime=runtime or "docker-compose"))
+    return targets
+
+
+def build_remote_command(runtime: str, image: str) -> str:
+    quoted_image = shlex.quote(image)
+    if runtime == "k8s":
+        return (
+            "kubectl set image deployment/zttato zttato="
+            f"{quoted_image} --record && kubectl rollout status deployment/zttato"
+        )
+    return f"docker pull {quoted_image} && docker compose up -d"

--- a/services/rl-trainer/src/compute_market.py
+++ b/services/rl-trainer/src/compute_market.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class WorkerNode:
+    worker_id: str
+    capacity: float
+    price_per_unit: float = 1.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ComputeMarket:
+    def __init__(self) -> None:
+        self.workers: list[WorkerNode] = []
+
+    def register(self, worker_id: str, capacity: float, price_per_unit: float = 1.0, **metadata: Any) -> WorkerNode:
+        worker = WorkerNode(
+            worker_id=worker_id,
+            capacity=capacity,
+            price_per_unit=price_per_unit,
+            metadata=metadata,
+        )
+        self.workers.append(worker)
+        return worker
+
+    def bid(self, job_demand: float) -> list[dict[str, float | str]]:
+        bids: list[dict[str, float | str]] = []
+        for worker in self.workers:
+            if worker.capacity < job_demand:
+                continue
+            bids.append(
+                {
+                    "worker_id": worker.worker_id,
+                    "capacity": worker.capacity,
+                    "price": worker.price_per_unit * job_demand,
+                    "score": worker.capacity / max(worker.price_per_unit, 1e-8),
+                }
+            )
+        return sorted(bids, key=lambda item: (-float(item["score"]), float(item["price"])))
+
+    def assign(self, job: dict[str, Any]) -> WorkerNode | None:
+        demand = float(job.get("demand", 1.0))
+        bids = self.bid(demand)
+        if not bids:
+            return None
+        best_worker_id = str(bids[0]["worker_id"])
+        return next(worker for worker in self.workers if worker.worker_id == best_worker_id)

--- a/services/rl-trainer/src/global_strategy.py
+++ b/services/rl-trainer/src/global_strategy.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+class StrategyOptimizer:
+    def __init__(self, agents: int = 3, strategy_dim: int = 2, learning_rate: float = 0.01) -> None:
+        self.agents = agents
+        self.learning_rate = learning_rate
+        self.strategies = np.random.rand(agents, strategy_dim)
+
+    def update(self, rewards: list[float] | np.ndarray) -> np.ndarray:
+        reward_vector = np.asarray(rewards, dtype=float)
+        if reward_vector.shape[0] != self.agents:
+            raise ValueError("reward vector size must match number of agents")
+        self.strategies += self.learning_rate * reward_vector[:, None]
+        return self.strategies
+
+    def equilibrium(self) -> np.ndarray:
+        return np.mean(self.strategies, axis=0)
+
+    def coordinate(self, rewards: list[float] | np.ndarray) -> dict[str, list[float]]:
+        updated = self.update(rewards)
+        return {
+            "equilibrium": self.equilibrium().round(6).tolist(),
+            "agent_strategies": updated.round(6).tolist(),
+        }

--- a/services/rl-trainer/src/main.py
+++ b/services/rl-trainer/src/main.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import numpy as np
 from confluent_kafka import Consumer
 
+from agent_replicator import Replicator
+from compute_market import ComputeMarket
+from global_strategy import StrategyOptimizer
 from ppo import PPO
+from treasury import Treasury
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("rl-trainer")
@@ -22,6 +26,28 @@ consumer = Consumer(
 )
 consumer.subscribe(["inference.response"])
 ppo = PPO()
+market = ComputeMarket()
+treasury = Treasury()
+strategy = StrategyOptimizer()
+replicator = Replicator()
+
+market.register("node-1", capacity=10, price_per_unit=0.8, zone="us-east")
+market.register("node-2", capacity=5, price_per_unit=0.4, zone="us-west")
+
+
+def build_autonomous_snapshot(features: np.ndarray, reward: float) -> dict[str, object]:
+    allocation = treasury.allocate(features.tolist(), [0.02] * len(features))
+    hedge_amount = treasury.hedge(abs(reward))
+    assigned_worker = market.assign({"demand": max(float(np.linalg.norm(features)), 1.0)})
+    coordination = strategy.coordinate([reward] * strategy.agents)
+    replication = replicator.replicate()
+    return {
+        "allocation": allocation.round(6).tolist(),
+        "hedge_amount": hedge_amount,
+        "assigned_worker": assigned_worker.worker_id if assigned_worker else None,
+        "coordination": coordination,
+        "replication": replication,
+    }
 
 
 def loop() -> None:
@@ -40,8 +66,9 @@ def loop() -> None:
         reward = float(data.get("reward", 0.0))
         old_prob = float(data.get("prob", 0.5))
         prob = ppo.update(x, reward, old_prob)
-        MODEL_PATH.write_text(json.dumps({"weights": ppo.w.tolist(), "prob": prob}))
-        log.info("updated policy weights=%s", ppo.w.tolist())
+        snapshot = build_autonomous_snapshot(x, reward)
+        MODEL_PATH.write_text(json.dumps({"weights": ppo.w.tolist(), "prob": prob, "autonomous_snapshot": snapshot}))
+        log.info("updated policy weights=%s autonomous_snapshot=%s", ppo.w.tolist(), snapshot)
 
 
 if __name__ == "__main__":

--- a/services/rl-trainer/src/treasury.py
+++ b/services/rl-trainer/src/treasury.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+class Treasury:
+    def __init__(self, capital: float = 10_000.0, hedge_limit: float = 0.5) -> None:
+        self.capital = capital
+        self.hedge_limit = hedge_limit
+
+    def hedge(self, volatility: float) -> float:
+        hedge_ratio = min(max(volatility, 0.0), self.hedge_limit)
+        return float(self.capital * hedge_ratio)
+
+    def allocate(self, expected_returns: list[float], risk_penalties: list[float] | None = None) -> np.ndarray:
+        if not expected_returns:
+            return np.asarray([], dtype=float)
+        returns = np.asarray(expected_returns, dtype=float)
+        penalties = np.asarray(risk_penalties if risk_penalties is not None else np.zeros_like(returns), dtype=float)
+        adjusted = np.clip(returns - penalties, a_min=0.0, a_max=None)
+        if float(adjusted.sum()) == 0.0:
+            adjusted = np.full_like(adjusted, 1.0 / len(adjusted), dtype=float)
+        weights = adjusted / adjusted.sum()
+        return weights * self.capital


### PR DESCRIPTION
### Motivation
- Introduce an autonomous AI-economy feature set so the RL trainer can coordinate self-replication, decentralized compute allocation, capital management, and multi-agent strategy optimization. 
- Provide a safer, production-friendly integration by keeping remote replication disabled by default and controlled via environment flags. 
- Surface orchestration state alongside policy updates so downstream tooling and monitoring can consume an `autonomous_snapshot` for observability and auditing.

### Description
- Add new orchestration modules under `services/rl-trainer/src`: `agent_replicator.py` (SSH/Docker/K8s deployment helper gated by `REPLICATOR_ENABLED`), `compute_market.py` (worker registration, bidding, assignment), `treasury.py` (hedge and risk-adjusted allocation), and `global_strategy.py` (multi-agent strategy updates, equilibrium, coordination). 
- Integrate the new components into `services/rl-trainer/src/main.py` by importing `Replicator`, `ComputeMarket`, `Treasury`, and `StrategyOptimizer`, registering example workers, and emitting an `autonomous_snapshot` with `allocation`, `hedge_amount`, `assigned_worker`, `coordination`, and `replication` on each policy update. 
- Keep remote actions inert by default and make remote deployment explicit and opt-in using environment variables `REPLICATOR_ENABLED`, `REPLICATOR_IMAGE`, and `TARGET_NODES` to avoid unintended side effects.

### Testing
- Ran `python -m compileall services/rl-trainer/src` to verify the new modules compile successfully, and the step completed without errors. 
- Ran `pytest -q tests/test_autonomous_rl_services.py` which completed successfully with `2 passed, 1 skipped`. 
- Basic local import/run coverage validated by the test and compile steps above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed2e07ef883218b511e291abc44aa)