### PR TITLE
Harden startup/installer and fix broken docker-compose sections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./infrastructure/postgres/migrations:/docker-entrypoint-initdb.d:ro
-    volumes:
-      - ./feature_repo:/app/feature_repo:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-zttato} -d ${DB_NAME:-zttato}"]
       interval: 10s
@@ -227,9 +225,6 @@ services:
     environment:
       AFFILIATE_WEBHOOK_SECRET: ${AFFILIATE_WEBHOOK_SECRET:-change-me}
       DATABASE_URL: postgresql://${DB_USER:-zttato}:${DB_PASSWORD:-zttato}@postgres:${DB_PORT:-5432}/${DB_NAME:-zttato}
-    depends_on:
-      postgres:
-        condition: service_healthy
       RL_POLICY_MODEL_PATH: /models/policy.pt
     depends_on:
       postgres:
@@ -355,6 +350,40 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
+      start_period: 20s
+    networks:
+      - zttato-net
+
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.2.10
+    container_name: zttato-redpanda
+    restart: always
+    command:
+      - redpanda
+      - start
+      - --overprovisioned
+      - --smp
+      - "1"
+      - --memory
+      - 512M
+      - --reserve-memory
+      - 0M
+      - --node-id
+      - "0"
+      - --check=false
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://redpanda:9092
+      - --pandaproxy-addr
+      - 0.0.0.0:8082
+      - --advertise-pandaproxy-addr
+      - redpanda:8082
+    healthcheck:
+      test: ["CMD-SHELL", "rpk cluster health | grep -q 'Healthy:.*true'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
       start_period: 20s
     networks:
       - zttato-net
@@ -720,21 +749,8 @@ services:
       model-service:
         condition: service_healthy
       rl-trainer:
-    build:
-      context: ./services/rl-trainer
-      dockerfile: Dockerfile
-    container_name: zttato-rl-trainer
-    restart: always
-    env_file: .env
-    depends_on:
-      redpanda:
-        condition: service_healthy
-    volumes:
-      - model_runtime_data:/models
-    networks:
-      - zttato-net
-
-  rl-coordinator:
+        condition: service_started
+      rl-coordinator:
         condition: service_healthy
       budget-allocator:
         condition: service_healthy

--- a/scripts/install-node-services.sh
+++ b/scripts/install-node-services.sh
@@ -11,6 +11,16 @@ printf '=================================\n'
 printf 'Installing Node Services\n'
 printf '=================================\n'
 
+if ! command -v npm >/dev/null 2>&1; then
+  printf 'ERROR: npm is required to install Node services.\n' >&2
+  exit 1
+fi
+
+if [[ ${#ZTTATO_NODE_SERVICES[@]} -eq 0 ]]; then
+  printf '[SKIP] No Node services with package.json were discovered under %s\n' "$ZTTATO_NODE_SERVICES_ROOT"
+  exit 0
+fi
+
 for service in "${ZTTATO_NODE_SERVICES[@]}"; do
   dir="$(zttato_node_service_dir "$service")"
   package_json="$(zttato_node_service_package "$service")"

--- a/scripts/node-services-lib.sh
+++ b/scripts/node-services-lib.sh
@@ -10,17 +10,14 @@ ZTTATO_NODE_SERVICES_ROOT="$ZTTATO_ROOT/services"
 ZTTATO_NODE_LOG_DIR="$ZTTATO_ROOT/logs/node"
 ZTTATO_NODE_PID_DIR="$ZTTATO_ROOT/pids/node"
 
-ZTTATO_NODE_SERVICES=(
-  shopee-crawler
-  tiktok-uploader
-  tiktok-shop-miner
-  tiktok-farm
-  account-farm
-  analytics
-  admin-panel
-  ai-video-generator
-  click-tracker
-)
+zttato_node_discover_services() {
+  find "$ZTTATO_NODE_SERVICES_ROOT" -mindepth 1 -maxdepth 2 -name package.json -print \
+    | sed "s#^$ZTTATO_NODE_SERVICES_ROOT/##" \
+    | sed 's#/package.json$##' \
+    | sort
+}
+
+mapfile -t ZTTATO_NODE_SERVICES < <(zttato_node_discover_services)
 
 zttato_node_print_service_list() {
   printf '%s\n' "${ZTTATO_NODE_SERVICES[@]}"

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Starting zTTato Platform (production profile)..."
-docker compose pull
-docker compose build --pull
-docker compose up -d --remove-orphans
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
 
-echo "Platform started."
-docker compose ps
+if ! command -v docker >/dev/null 2>&1; then
+  echo 'ERROR: docker is required to start the platform.' >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo 'ERROR: docker compose or docker-compose is required.' >&2
+  exit 1
+fi
+
+if [[ ! -f .env ]]; then
+  if [[ -f configs/env/production.env ]]; then
+    cp configs/env/production.env .env
+    echo 'Created .env from configs/env/production.env'
+  else
+    cat > .env <<'ENVEOF'
+DB_NAME=zttato
+DB_USER=zttato
+DB_PASSWORD=zttato
+DB_PORT=5432
+REDIS_HOST=redis
+REDIS_PORT=6379
+FFMPEG_HWACCEL=none
+FFMPEG_CPU_PRESET=veryfast
+FFMPEG_CPU_CRF=23
+ENVEOF
+    echo 'Created .env with local defaults'
+  fi
+fi
+
+echo 'Validating compose configuration...'
+"${COMPOSE_CMD[@]}" config >/dev/null
+
+echo 'Starting zTTato Platform (production profile)...'
+"${COMPOSE_CMD[@]}" up -d --build --remove-orphans
+
+echo 'Platform started.'
+"${COMPOSE_CMD[@]}" ps


### PR DESCRIPTION
### Motivation
- Make the local startup and Node installer robust and self-healing so developers can reliably bring up the platform with minimal manual edits.
- Replace brittle hard-coded Node service lists and prevent the installer from failing silently when environment prerequisites or repository layout change.
- Repair malformed `docker-compose.yml` fragments that prevented YAML parsing and reliable `docker compose` startup.

### Description
- Replace the static Node service list with discovery of services by scanning `services/*/**/package.json` and populate `ZTTATO_NODE_SERVICES` dynamically in `scripts/node-services-lib.sh`.
- Harden `scripts/install-node-services.sh` with an `npm` availability check and an early-exit when no Node services are discovered to avoid noisy failures during CI or developer runs.
- Replace the root startup script with `start.sh` that checks for `docker`/Compose, auto-creates a `.env` from `configs/env/production.env` or writes sensible local defaults, validates the Compose configuration with `docker compose config`, and then runs `docker compose up -d --build --remove-orphans`.
- Repair multiple malformed/duplicated blocks in `docker-compose.yml` so the file parses as YAML; fixes include removing duplicate `volumes` entries, fixing the `affiliate-webhook` dependency/env block, separating and adding a proper `redpanda` service, and restoring a correct `master-orchestrator` dependency list.
- Modified files: `docker-compose.yml`, `scripts/node-services-lib.sh`, `scripts/install-node-services.sh`, and `start.sh`.

### Testing
- Ran shell syntax checks with `bash -n` for `start.sh`, `scripts/install-node-services.sh`, and `scripts/node-services-lib.sh`, and they succeeded.
- Parsed `docker-compose.yml` with `python` using `yaml.safe_load` to confirm the compose file is valid YAML and that key services (`reward-collector`, `redpanda`, `master-orchestrator`, `affiliate-webhook`) are present, which succeeded.
- Executed `scripts/install-node-services.sh` to validate discovery and installation of discovered Node services, and it completed successfully.
- Attempted `./start.sh` in this environment but it exits early with a clear error because Docker is not available here; this is expected behavior and confirms the fast-fail check works.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed748659883218b8aac3f7c29a6e5)