### PR TITLE
Add sovereign identity, compute token, signed exchange and civilization sim; integrate into rl-trainer

### DIFF
--- a/contracts/ComputeToken.sol
+++ b/contracts/ComputeToken.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
+contract ComputeToken is ERC20, AccessControl, Pausable {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER");
+
+    constructor() ERC20("ZTT Compute", "ZTC") {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(MINTER_ROLE, msg.sender);
+        _mint(msg.sender, 1_000_000 ether);
+    }
+
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function mint(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 amount) internal override whenNotPaused {
+        super._update(from, to, amount);
+    }
+}

--- a/services/blockchain/bridge_secure.py
+++ b/services/blockchain/bridge_secure.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+NONCES: dict[str, int] = {}
+
+
+def verify_tx(chain: str, sender: str, nonce: int) -> bool:
+    key = f"{chain}:{sender}"
+    previous = NONCES.get(key)
+    if previous is not None and nonce <= previous:
+        return False
+    NONCES[key] = nonce
+    return True

--- a/services/exchange/src/main.py
+++ b/services/exchange/src/main.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from pydantic import BaseModel, Field
+
+from orderbook import Order, OrderBook
+from security import check_replay, rate_limit, verify_signature
+
+app = FastAPI()
+orderbook = OrderBook()
+
+
+class OrderRequest(BaseModel):
+    side: str
+    price: float = Field(gt=0)
+    qty: float = Field(gt=0)
+    nonce: str
+    message_b64: str
+    signature_b64: str
+    public_key_b64: str
+
+
+@app.post("/order")
+def place(order: OrderRequest, request: Request) -> dict[str, object]:
+    client_ip = request.client.host if request.client else "unknown"
+    if not rate_limit(client_ip):
+        return {"error": "rate limit"}
+    if not check_replay(order.nonce):
+        return {"error": "replay"}
+    if not verify_signature(order.message_b64, order.signature_b64, order.public_key_b64):
+        return {"error": "signature"}
+
+    placed_order = Order(order.side, order.price, order.qty)
+    orderbook.add(placed_order)
+    trades = orderbook.match()
+    return {"order_id": placed_order.id, "trades": trades}

--- a/services/exchange/src/orderbook.py
+++ b/services/exchange/src/orderbook.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import heapq
+import time
+from dataclasses import dataclass, field
+
+
+@dataclass(order=False)
+class Order:
+    side: str
+    price: float
+    qty: float
+    oid: str | None = None
+    ts: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        if self.side not in {"buy", "sell"}:
+            raise ValueError("side must be 'buy' or 'sell'")
+        if self.price <= 0 or self.qty <= 0:
+            raise ValueError("price and qty must be positive")
+        self.id = self.oid or f"{self.side}-{self.ts:.6f}"
+
+
+class OrderBook:
+    def __init__(self) -> None:
+        self.buys: list[tuple[float, float, Order]] = []
+        self.sells: list[tuple[float, float, Order]] = []
+
+    def add(self, order: Order) -> None:
+        if order.side == "buy":
+            heapq.heappush(self.buys, (-order.price, order.ts, order))
+            return
+        heapq.heappush(self.sells, (order.price, order.ts, order))
+
+    def match(self) -> list[dict[str, float | str]]:
+        trades: list[dict[str, float | str]] = []
+        while self.buys and self.sells:
+            best_buy_price, _, buy = self.buys[0]
+            best_sell_price, _, sell = self.sells[0]
+            if -best_buy_price < best_sell_price:
+                break
+
+            qty = min(buy.qty, sell.qty)
+            trades.append(
+                {
+                    "buy_order_id": buy.id,
+                    "sell_order_id": sell.id,
+                    "price": float(best_sell_price),
+                    "qty": float(qty),
+                }
+            )
+            buy.qty -= qty
+            sell.qty -= qty
+            if buy.qty == 0:
+                heapq.heappop(self.buys)
+            if sell.qty == 0:
+                heapq.heappop(self.sells)
+        return trades

--- a/services/exchange/src/security.py
+++ b/services/exchange/src/security.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+
+from services.identity.did import verify
+
+NONCES: set[str] = set()
+RATE: dict[str, list[float]] = defaultdict(list)
+REQUESTS_PER_SECOND = 10
+
+
+def verify_signature(message_b64: str, signature_b64: str, public_key_b64: str) -> bool:
+    import base64
+
+    padding = "=" * (-len(public_key_b64) % 4)
+    public_key = base64.urlsafe_b64decode(f"{public_key_b64}{padding}")
+    return verify(public_key, message_b64, signature_b64)
+
+
+def check_replay(nonce: str | None) -> bool:
+    if not nonce or nonce in NONCES:
+        return False
+    NONCES.add(nonce)
+    return True
+
+
+def rate_limit(ip: str) -> bool:
+    now = time.time()
+    recent = [stamp for stamp in RATE[ip] if now - stamp < 1.0]
+    RATE[ip] = recent
+    if len(recent) >= REQUESTS_PER_SECOND:
+        return False
+    RATE[ip].append(now)
+    return True

--- a/services/identity/did.py
+++ b/services/identity/did.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+
+KEY_PATH = Path(os.getenv("AGENT_KEY_PATH", "/data/agent_ed25519.pem"))
+
+
+def _b64(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode().rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(f"{value}{padding}")
+
+
+def load_or_create_key(key_path: Path | None = None) -> Ed25519PrivateKey:
+    target = key_path or KEY_PATH
+    if target.exists():
+        return serialization.load_pem_private_key(target.read_bytes(), password=None)
+
+    secret_key = Ed25519PrivateKey.generate()
+    pem = secret_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(pem)
+    return secret_key
+
+
+def get_did(secret_key: Ed25519PrivateKey) -> str:
+    public_key = secret_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return "did:zttato:" + _b64(hashlib.sha256(public_key).digest()[:20])
+
+
+def export_public_key(secret_key: Ed25519PrivateKey) -> str:
+    public_key = secret_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return _b64(public_key)
+
+
+def sign(secret_key: Ed25519PrivateKey, payload: dict[str, Any]) -> tuple[str, str]:
+    message = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    signature = secret_key.sign(message)
+    return _b64(message), _b64(signature)
+
+
+def verify(public_key_bytes: bytes, message_b64: str, signature_b64: str) -> bool:
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(public_key_bytes)
+        public_key.verify(_b64decode(signature_b64), _b64decode(message_b64))
+        return True
+    except Exception:
+        return False

--- a/services/identity/keystore.py
+++ b/services/identity/keystore.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+ROTATE_INTERVAL = int(os.getenv("KEY_ROTATE_SEC", "86400"))
+DEFAULT_KEY_PATH = Path(os.getenv("AGENT_KEY_PATH", "/data/agent_ed25519.pem"))
+
+
+class KeyStore:
+    def __init__(self, key_path: Path | None = None) -> None:
+        self.key_path = key_path or DEFAULT_KEY_PATH
+        self.key = self._load_or_create(self.key_path)
+        self.last_rotate = time.time()
+
+    def _load_or_create(self, target: Path) -> Ed25519PrivateKey:
+        if target.exists():
+            return serialization.load_pem_private_key(target.read_bytes(), password=None)
+        key = Ed25519PrivateKey.generate()
+        pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(pem)
+        return key
+
+    def get(self) -> Ed25519PrivateKey:
+        if time.time() - self.last_rotate > ROTATE_INTERVAL:
+            self.key = Ed25519PrivateKey.generate()
+            self.last_rotate = time.time()
+        return self.key

--- a/services/rl-trainer/requirements.txt
+++ b/services/rl-trainer/requirements.txt
@@ -3,3 +3,7 @@ numpy==2.3.2
 boto3==1.40.30
 ray[rllib]==2.49.2
 scikit-learn==1.7.1
+
+cryptography==45.0.7
+fastapi==0.116.1
+pydantic==2.11.7

--- a/services/rl-trainer/src/civilization.py
+++ b/services/rl-trainer/src/civilization.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+class CivAgent:
+    def __init__(self) -> None:
+        self.tech = float(np.random.rand())
+        self.capital = float(np.random.rand() * 100.0)
+
+    def act(self) -> None:
+        invest = float(np.random.rand() * self.capital * 0.1)
+        self.tech += invest * 0.01
+        self.capital += (self.tech - 0.5) * 2.0
+
+
+class Civilization:
+    def __init__(self, n: int = 20) -> None:
+        self.agents = [CivAgent() for _ in range(n)]
+
+    def step(self) -> None:
+        for agent in self.agents:
+            agent.act()
+
+    def metrics(self) -> dict[str, float]:
+        return {
+            "avg_capital": float(np.mean([agent.capital for agent in self.agents])),
+            "avg_tech": float(np.mean([agent.tech for agent in self.agents])),
+        }

--- a/services/rl-trainer/src/main.py
+++ b/services/rl-trainer/src/main.py
@@ -12,7 +12,11 @@ from agent_replicator import Replicator
 from compute_market import ComputeMarket
 from global_strategy import StrategyOptimizer
 from ppo import PPO
+from reward import compute_reward
 from treasury import Treasury
+from token_engine import ComputeTokenEngine
+from civilization import Civilization
+from sovereign_identity import build_heartbeat_identity
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("rl-trainer")
@@ -30,6 +34,9 @@ market = ComputeMarket()
 treasury = Treasury()
 strategy = StrategyOptimizer()
 replicator = Replicator()
+token_engine = ComputeTokenEngine()
+simulation = Civilization()
+identity = build_heartbeat_identity()
 
 market.register("node-1", capacity=10, price_per_unit=0.8, zone="us-east")
 market.register("node-2", capacity=5, price_per_unit=0.4, zone="us-west")
@@ -41,12 +48,23 @@ def build_autonomous_snapshot(features: np.ndarray, reward: float) -> dict[str, 
     assigned_worker = market.assign({"demand": max(float(np.linalg.norm(features)), 1.0)})
     coordination = strategy.coordinate([reward] * strategy.agents)
     replication = replicator.replicate()
+    simulation.step()
+    staked = token_engine.stake("worker-1", 100.0)
+    rewarded = token_engine.reward("worker-1", 5.0)
     return {
         "allocation": allocation.round(6).tolist(),
         "hedge_amount": hedge_amount,
         "assigned_worker": assigned_worker.worker_id if assigned_worker else None,
         "coordination": coordination,
         "replication": replication,
+        "identity": {
+            "did": identity["did"],
+            "message_b64": identity["message_b64"],
+            "signature_b64": identity["signature_b64"],
+            "public_key_b64": identity["public_key_b64"],
+        },
+        "compute_economy": {"staked": staked, "rewarded": rewarded},
+        "civilization": simulation.metrics(),
     }
 
 

--- a/services/rl-trainer/src/sovereign_identity.py
+++ b/services/rl-trainer/src/sovereign_identity.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+DEFAULT_KEY_PATH = Path("/models/agent_ed25519.pem")
+
+
+def _b64(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode().rstrip("=")
+
+
+def load_or_create_key(key_path: Path | None = None) -> Ed25519PrivateKey:
+    target = key_path or DEFAULT_KEY_PATH
+    if target.exists():
+        return serialization.load_pem_private_key(target.read_bytes(), password=None)
+
+    secret_key = Ed25519PrivateKey.generate()
+    pem = secret_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(pem)
+    return secret_key
+
+
+def get_did(secret_key: Ed25519PrivateKey) -> str:
+    public_key = secret_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return "did:zttato:" + _b64(hashlib.sha256(public_key).digest()[:20])
+
+
+def export_public_key(secret_key: Ed25519PrivateKey) -> str:
+    public_key = secret_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return _b64(public_key)
+
+
+def sign(secret_key: Ed25519PrivateKey, payload: dict[str, Any]) -> tuple[str, str]:
+    message = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    return _b64(message), _b64(secret_key.sign(message))
+
+
+def build_heartbeat_identity(key_path: Path | None = None) -> dict[str, str | Ed25519PrivateKey]:
+    secret_key = load_or_create_key(key_path)
+    did = get_did(secret_key)
+    message_b64, signature_b64 = sign(secret_key, {"op": "heartbeat", "did": did})
+    return {
+        "secret_key": secret_key,
+        "did": did,
+        "message_b64": message_b64,
+        "signature_b64": signature_b64,
+        "public_key_b64": export_public_key(secret_key),
+    }

--- a/services/rl-trainer/src/token_engine.py
+++ b/services/rl-trainer/src/token_engine.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class ComputeTokenEngine:
+    def __init__(self) -> None:
+        self.stakes: dict[str, float] = {}
+        self.rewards: dict[str, float] = {}
+
+    def stake(self, worker: str, amount: float) -> float:
+        self.stakes[worker] = self.stakes.get(worker, 0.0) + amount
+        return self.stakes[worker]
+
+    def reward(self, worker: str, amount: float) -> float:
+        self.rewards[worker] = self.rewards.get(worker, 0.0) + amount
+        return self.rewards[worker]
+
+    def slash(self, worker: str, amount: float) -> float:
+        self.stakes[worker] = max(0.0, self.stakes.get(worker, 0.0) - amount)
+        return self.stakes[worker]

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -24,10 +24,12 @@ from hierarchical_rl import HierarchicalRL
 from latency_bid import latency_adjusted_bid
 from long_term_reward import long_term_reward
 from ltv_model import LTVModel
+from rtb import RTBEngine
 
 app = FastAPI(title="RTB Engine")
 hrl = HierarchicalRL()
 ltv_model = LTVModel()
+ENGINE = RTBEngine()
 
 
 class BidRequest(BaseModel):
@@ -85,14 +87,17 @@ def bid(request: BidRequest) -> BidResponse:
     ev = request.ctr * request.cvr * request.score
     floor_bid = ENGINE.compute_bid(request.ctr, request.cvr, request.score)
     pacing_multiplier = 0.5 + (request.pacing_ratio / 2)
-    bid_price = max(floor_bid, latency_adjusted_bid(
-        base_bid=request.base_bid,
-        score=request.score,
-        latency_ms=request.latency_ms,
-        pacing_multiplier=pacing_multiplier,
-        ctr=request.ctr,
-        cvr=request.cvr,
-        max_bid=request.max_bid,
+    bid_price = max(
+        floor_bid,
+        latency_adjusted_bid(
+            base_bid=request.base_bid,
+            score=request.score,
+            latency_ms=request.latency_ms,
+            pacing_multiplier=pacing_multiplier,
+            ctr=request.ctr,
+            cvr=request.cvr,
+            max_bid=request.max_bid,
+        ),
     )
 
     features = [request.ctr, request.cvr]

--- a/services/shared/kafka_secure.py
+++ b/services/shared/kafka_secure.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from confluent_kafka import Producer
+
+producer = Producer(
+    {
+        "bootstrap.servers": "redpanda:9092",
+        "enable.idempotence": True,
+    }
+)
+DLQ = "dead_letter"
+
+
+def safe_produce(topic: str, data: dict[str, Any]) -> None:
+    payload = json.dumps(data).encode()
+    try:
+        producer.produce(topic, payload)
+    except Exception:
+        producer.produce(DLQ, payload)

--- a/services/shared/schema.py
+++ b/services/shared/schema.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def validate(schema: dict[str, type] | list[str], data: dict[str, Any]) -> bool:
+    if isinstance(schema, list):
+        return all(key in data for key in schema)
+
+    for key, expected_type in schema.items():
+        if key not in data or not isinstance(data[key], expected_type):
+            return False
+    return True

--- a/tests/test_autonomous_rl_services.py
+++ b/tests/test_autonomous_rl_services.py
@@ -139,3 +139,65 @@ def test_tlearner_predicts_uplift():
     learner.fit(X, treatment, y)
     uplift = learner.predict_uplift(np.array([[0.85, 0.65]]))
     assert uplift.shape == (1,)
+
+
+
+def test_identity_signatures_round_trip(tmp_path):
+    pytest.importorskip("cryptography")
+    sys.path.insert(0, str(ROOT / 'services/identity'))
+    module = _load_module('test_identity_did', 'services/identity/did.py')
+    key = module.load_or_create_key(tmp_path / 'agent.pem')
+    did = module.get_did(key)
+    message_b64, signature_b64 = module.sign(key, {'op': 'heartbeat', 'did': did})
+    public_key = key.public_key().public_bytes(
+        encoding=module.serialization.Encoding.Raw,
+        format=module.serialization.PublicFormat.Raw,
+    )
+    assert did.startswith('did:zttato:')
+    assert module.verify(public_key, message_b64, signature_b64) is True
+
+
+def test_exchange_matches_orders_with_signature(tmp_path):
+    pytest.importorskip("cryptography")
+    sys.path.insert(0, str(ROOT / 'services/exchange/src'))
+    sys.path.insert(0, str(ROOT / 'services/identity'))
+    did_module = _load_module('test_exchange_did', 'services/identity/did.py')
+    app_module = _load_module('test_exchange_main', 'services/exchange/src/main.py')
+    key = did_module.load_or_create_key(tmp_path / 'exchange.pem')
+    client = TestClient(app_module.app)
+
+    def signed_order(side, price, qty, nonce):
+        payload = {'side': side, 'price': price, 'qty': qty, 'nonce': nonce}
+        message_b64, signature_b64 = did_module.sign(key, payload)
+        public_key_b64 = did_module.export_public_key(key)
+        return {
+            'side': side,
+            'price': price,
+            'qty': qty,
+            'nonce': nonce,
+            'message_b64': message_b64,
+            'signature_b64': signature_b64,
+            'public_key_b64': public_key_b64,
+        }
+
+    buy = client.post('/order', json=signed_order('buy', 1.0, 10.0, 'n-1'))
+    sell = client.post('/order', json=signed_order('sell', 0.9, 5.0, 'n-2'))
+
+    assert buy.status_code == 200
+    assert sell.status_code == 200
+    assert sell.json()['trades'][0]['qty'] == 5.0
+    assert client.post('/order', json=signed_order('sell', 0.9, 1.0, 'n-2')).json()['error'] == 'replay'
+
+
+def test_rl_trainer_autonomous_snapshot_includes_new_subsystems(tmp_path):
+    pytest.importorskip("cryptography")
+    sys.path.insert(0, str(ROOT / 'services/rl-trainer/src'))
+    module = _load_module('test_rl_trainer_main', 'services/rl-trainer/src/main.py')
+    module.identity = module.build_heartbeat_identity(tmp_path / 'trainer.pem')
+    import numpy as np
+
+    snapshot = module.build_autonomous_snapshot(np.array([0.3, 0.4]), 1.2)
+
+    assert snapshot['identity']['did'].startswith('did:zttato:')
+    assert snapshot['compute_economy']['staked'] >= 100.0
+    assert 'avg_capital' in snapshot['civilization']


### PR DESCRIPTION
### Motivation
- Introduce end-to-end primitives for sovereign agent identity, a tokenized compute economy, and a signed marketplace to enable verifiable agent ops and programmatic market interactions within the RL stack. 
- Provide a lightweight civilization simulation to surface macro signals and close the loop into policy snapshots for richer autonomous training traces. 

### Description
- Added Ed25519 DID utilities and a rotating keystore at `services/identity/` implementing key generation, DID derivation, signing and verification (`did.py`, `keystore.py`).
- Implemented a signed orderbook exchange with in-memory matching, replay protection and rate limiting at `services/exchange/src/` (`orderbook.py`, `main.py`, `security.py`).
- Added compute-economy primitives and a pausable role-based ERC20 contract: `contracts/ComputeToken.sol` and a simple `ComputeTokenEngine` at `services/rl-trainer/src/token_engine.py` for stake/reward/slash flows.
- Added a self-evolving civilization simulator at `services/rl-trainer/src/civilization.py` and a sovereign identity helper for RL trainer (`sovereign_identity.py`), and integrated identity, staking and simulation metrics into `services/rl-trainer/src/main.py` snapshots.
- Added supporting hardening helpers for cross-chain nonces and messaging: `services/blockchain/bridge_secure.py`, Kafka DLQ/idempotent producer helper `services/shared/kafka_secure.py`, and basic schema validation `services/shared/schema.py`.
- Fixed an RTB engine bid expression and wired in `RTBEngine` so the RTB service runs cleanly (`services/rtb-engine/src/main.py`) and updated RL-trainer requirements to include `cryptography`, `fastapi`, and `pydantic`.

### Testing
- Ran the service unit tests with `pytest -q tests/test_autonomous_rl_services.py -q` and the suite completed successfully. 
- Added new tests covering DID sign/verify round-trip, signed-order matching with replay protection, and RL trainer snapshot inclusion of identity/compute/simulation subsystems, all of which passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf82d01a448321aca333aca298cf12)