### PR TITLE
Infra hardening: Redis cluster, Patroni Postgres, KMS signing, payment circuit & service scaffolds

### DIFF
--- a/infrastructure/docker/redis-cluster.yml
+++ b/infrastructure/docker/redis-cluster.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+services:
+  redis-node-1:
+    image: redis:7
+    command:
+      - redis-server
+      - --appendonly
+      - yes
+      - --cluster-enabled
+      - yes
+      - --cluster-config-file
+      - nodes.conf
+      - --cluster-node-timeout
+      - '5000'
+      - --cluster-announce-port
+      - '6379'
+    ports:
+      - '7001:6379'
+  redis-node-2:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes", "--cluster-enabled", "yes", "--cluster-config-file", "nodes.conf", "--cluster-node-timeout", "5000", "--cluster-announce-port", "6379"]
+    ports:
+      - '7002:6379'
+  redis-node-3:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes", "--cluster-enabled", "yes", "--cluster-config-file", "nodes.conf", "--cluster-node-timeout", "5000", "--cluster-announce-port", "6379"]
+    ports:
+      - '7003:6379'
+  redis-node-4:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes", "--cluster-enabled", "yes", "--cluster-config-file", "nodes.conf", "--cluster-node-timeout", "5000", "--cluster-announce-port", "6379"]
+    ports:
+      - '7004:6379'
+  redis-node-5:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes", "--cluster-enabled", "yes", "--cluster-config-file", "nodes.conf", "--cluster-node-timeout", "5000", "--cluster-announce-port", "6379"]
+    ports:
+      - '7005:6379'
+  redis-node-6:
+    image: redis:7
+    command: ["redis-server", "--appendonly", "yes", "--cluster-enabled", "yes", "--cluster-config-file", "nodes.conf", "--cluster-node-timeout", "5000", "--cluster-announce-port", "6379"]
+    ports:
+      - '7006:6379'

--- a/infrastructure/k8s/jobs/self-modifier-job.yaml
+++ b/infrastructure/k8s/jobs/self-modifier-job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: self-modifier
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        app: self-modifier
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 1000
+      containers:
+        - name: runner
+          image: zttato-self-modifier:latest
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "engine"]
+          env:
+            - name: KMS_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: platform-config
+                  key: kms_endpoint
+          securityContext:
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]

--- a/infrastructure/k8s/kustomization.yaml
+++ b/infrastructure/k8s/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - deployments/click-tracker.yaml
   - deployments/admin-panel.yaml
   - deployments/postgres.yaml
+  - postgres/patroni.yaml
   - deployments/jwt-auth.yaml
   - deployments/gpu-renderer.yaml
   - services/analytics.yaml
@@ -15,6 +16,7 @@ resources:
   - services/jwt-auth.yaml
   - kafka/kafka.yaml
   - monitoring/prometheus.yaml
+  - jobs/self-modifier-job.yaml
   - mesh/service-mesh.yaml
   - mesh/rate-limit.yaml
   - spire/spire-server.yaml

--- a/infrastructure/k8s/postgres/patroni.yaml
+++ b/infrastructure/k8s/postgres/patroni.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: patroni
+spec:
+  clusterIP: None
+  selector:
+    app: patroni
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: patroni
+spec:
+  serviceName: patroni
+  replicas: 3
+  selector:
+    matchLabels:
+      app: patroni
+  template:
+    metadata:
+      labels:
+        app: patroni
+    spec:
+      containers:
+        - name: patroni
+          image: ghcr.io/zalando/spilo-15:3.2-p1
+          ports:
+            - containerPort: 5432
+              name: postgres
+            - containerPort: 8008
+              name: patroni
+          env:
+            - name: PATRONI_SCOPE
+              value: zttato-postgres
+            - name: PATRONI_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: PATRONI_POSTGRESQL_DATA_DIR
+              value: /home/postgres/pgdata/pgroot/data
+            - name: PATRONI_REPLICATION_USERNAME
+              value: replicator
+            - name: PATRONI_REPLICATION_PASSWORD
+              value: replicator-password
+            - name: PATRONI_SUPERUSER_USERNAME
+              value: postgres
+            - name: PATRONI_SUPERUSER_PASSWORD
+              value: postgres-password
+            - name: PATRONI_etcd3_host
+              value: etcd.platform.svc.cluster.local:2379
+          volumeMounts:
+            - name: data
+              mountPath: /home/postgres/pgdata
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi

--- a/infrastructure/monitoring/prometheus.yml
+++ b/infrastructure/monitoring/prometheus.yml
@@ -26,3 +26,13 @@ scrape_configs:
     metrics_path: /metrics
     static_configs:
       - targets: ["zttato-gpu-renderer:9300"]
+
+  - job_name: zttato-model-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["zttato-model-service:8000"]
+
+  - job_name: zttato-analytics
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["zttato-analytics:3000"]

--- a/services/auto-ml/loop.py
+++ b/services/auto-ml/loop.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+MODEL_DIR = Path(os.getenv("MODEL_DIR", "/models"))
+THRESHOLD = float(os.getenv("PROMOTE_DELTA", "0.02"))
+
+
+
+def train() -> bool:
+    return subprocess.call("python train.py", shell=True) == 0
+
+
+
+def evaluate() -> float:
+    output = subprocess.check_output("python eval.py", shell=True).decode().strip()
+    return float(output)
+
+
+
+def load_metric(path: Path) -> float:
+    try:
+        return float(path.read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, ValueError):
+        return 0.0
+
+
+
+def save_metric(path: Path, value: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(value), encoding="utf-8")
+
+
+
+def deploy() -> bool:
+    return subprocess.call("bash deploy_model.sh", shell=True) == 0
+
+
+
+def loop() -> dict[str, float | str]:
+    previous_metric_path = MODEL_DIR / "metric.txt"
+    previous = load_metric(previous_metric_path)
+    if not train():
+        return {"status": "train_failed"}
+
+    score = evaluate()
+    if score >= previous + THRESHOLD:
+        if deploy():
+            save_metric(previous_metric_path, score)
+            return {"status": "promoted", "score": score}
+        return {"status": "deploy_failed"}
+
+    return {"status": "rejected", "score": score, "prev": previous}
+
+
+if __name__ == "__main__":
+    print(json.dumps(loop()))

--- a/services/cost/control.py
+++ b/services/cost/control.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+MAX_DAILY = float(os.getenv("MAX_DAILY_COST", "1000"))
+spent = 0.0
+
+
+
+def allow(cost: float) -> bool:
+    global spent
+    if spent + cost > MAX_DAILY:
+        return False
+    spent += cost
+    return True
+
+
+
+def reset() -> None:
+    global spent
+    spent = 0.0

--- a/services/data/pipeline.py
+++ b/services/data/pipeline.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import os
+
+from confluent_kafka import Consumer, Producer
+
+BOOT = os.getenv("KAFKA_BOOT", "redpanda:9092")
+
+producer = Producer({"bootstrap.servers": BOOT, "enable.idempotence": True})
+consumer = Consumer(
+    {
+        "bootstrap.servers": BOOT,
+        "group.id": "pipeline",
+        "auto.offset.reset": "earliest",
+    }
+)
+
+SCHEMA = {"title": str, "media_url": str}
+
+
+
+def validate(item: dict) -> bool:
+    return all(key in item for key in SCHEMA)
+
+
+
+def label(item: dict) -> dict:
+    item["label"] = 1 if item.get("engagement", 0) > 0.3 else 0
+    return item
+
+
+
+def run() -> None:
+    consumer.subscribe(["raw"])
+    while True:
+        message = consumer.poll(1.0)
+        if not message:
+            continue
+        data = json.loads(message.value())
+        if validate(data):
+            producer.produce("clean", json.dumps(label(data)).encode())

--- a/services/gpu/adapter.py
+++ b/services/gpu/adapter.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import os
+
+import requests
+
+API = "https://api.runpod.io/graphql"
+KEY = os.getenv("RUNPOD_KEY")
+
+
+
+def create_pod() -> dict:
+    query = {"query": "mutation { podFindAndDeployOnDemand(input:{gpuCount:1}){id}}"}
+    return requests.post(API, json=query, headers={"Authorization": KEY}, timeout=10).json()

--- a/services/market-creator/engine.py
+++ b/services/market-creator/engine.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import time
+import uuid
+
+import requests
+
+DISCOVERY_API = "http://market-crawler:8000/trending"
+LAUNCH_API = "http://tiktok-uploader:3000/upload"
+
+
+
+def discover() -> list[dict]:
+    try:
+        return requests.get(DISCOVERY_API, timeout=3).json()
+    except requests.RequestException:
+        return []
+
+
+
+def validate(item: dict) -> bool:
+    return item.get("engagement", 0) > 0.2
+
+
+
+def launch(item: dict) -> bool:
+    payload = {
+        "id": str(uuid.uuid4()),
+        "title": item["title"],
+        "media_url": item["media_url"],
+    }
+    return requests.post(LAUNCH_API, json=payload, timeout=5).status_code == 200
+
+
+
+def loop() -> dict[str, int]:
+    launched = 0
+    for item in discover():
+        if validate(item) and launch(item):
+            launched += 1
+    return {"launched": launched, "ts": int(time.time())}

--- a/services/org/legal_gate.py
+++ b/services/org/legal_gate.py
@@ -1,0 +1,6 @@
+ALLOWED_JURISDICTIONS = {"SG", "US", "EU", "TH"}
+
+
+
+def check(jurisdiction: str) -> bool:
+    return jurisdiction in ALLOWED_JURISDICTIONS

--- a/services/org/treasury.py
+++ b/services/org/treasury.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+
+CAP = float(os.getenv("DAILY_CAP", "10000"))
+
+
+class Treasury:
+    def __init__(self) -> None:
+        self.spent = 0.0
+
+    def can_spend(self, amount: float) -> bool:
+        return (self.spent + amount) <= CAP
+
+    def spend(self, amount: float) -> bool:
+        if self.can_spend(amount):
+            self.spent += amount
+            return True
+        return False

--- a/services/p2p/libp2p_bridge.py
+++ b/services/p2p/libp2p_bridge.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+BIN = os.getenv("LIBP2P_BIN", "/usr/local/bin/libp2p-node")
+
+
+
+def start() -> subprocess.Popen:
+    return subprocess.Popen([BIN, "--port", "9100"])
+
+
+if __name__ == "__main__":
+    start().wait()

--- a/services/payment/adapter.py
+++ b/services/payment/adapter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+
+from audit import log
+from circuit import allow, fail, success
+
+TIMEOUT = float(os.getenv("PAYMENT_TIMEOUT", "3"))
+DEFAULT_HEADERS = {"Content-Type": "application/json"}
+
+
+
+def send(endpoint: str, payload: dict[str, Any], retries: int = 3) -> dict[str, Any]:
+    if not allow():
+        log("payment_circuit_open", payload)
+        return {"status": "circuit_open"}
+
+    for attempt in range(retries):
+        try:
+            response = requests.post(endpoint, json=payload, headers=DEFAULT_HEADERS, timeout=TIMEOUT)
+            if response.status_code == 200:
+                success()
+                log("payment_success", payload)
+                return response.json()
+        except requests.RequestException:
+            pass
+
+        fail()
+        log("payment_fail", payload)
+        time.sleep(2**attempt)
+
+    return {"status": "failed"}

--- a/services/payment/audit.py
+++ b/services/payment/audit.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+AUDIT_LOG_PATH = Path(os.getenv("PAYMENT_AUDIT_LOG", "/tmp/payment_audit.log"))
+
+
+
+def log(event: str, data: dict[str, Any]) -> None:
+    AUDIT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with AUDIT_LOG_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "ts": int(time.time()),
+                    "event": event,
+                    "data": data,
+                },
+                sort_keys=True,
+            )
+            + "\n"
+        )

--- a/services/payment/circuit.py
+++ b/services/payment/circuit.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import time
+
+FAILS = 0
+OPEN = False
+LAST_FAIL = 0.0
+RESET_AFTER_SECONDS = 30
+MAX_FAILURES = 3
+
+
+
+def allow(now: float | None = None) -> bool:
+    global OPEN
+    current = time.time() if now is None else now
+    if OPEN and current - LAST_FAIL < RESET_AFTER_SECONDS:
+        return False
+    if OPEN:
+        OPEN = False
+    return True
+
+
+
+def success() -> None:
+    global FAILS, OPEN
+    FAILS = 0
+    OPEN = False
+
+
+
+def fail(now: float | None = None) -> None:
+    global FAILS, OPEN, LAST_FAIL
+    FAILS += 1
+    LAST_FAIL = time.time() if now is None else now
+    if FAILS > MAX_FAILURES:
+        OPEN = True

--- a/services/payment/stripe_adapter.py
+++ b/services/payment/stripe_adapter.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import os
+
+import stripe
+
+stripe.api_key = os.getenv("STRIPE_KEY")
+
+
+
+def charge(amount: float, currency: str = "usd"):
+    return stripe.PaymentIntent.create(amount=int(amount * 100), currency=currency)

--- a/services/self-modifier/engine.py
+++ b/services/self-modifier/engine.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+from kms_verify import verify
+
+
+
+def apply_patch_request(patch_b64: str, sig_b64: str) -> dict[str, Any]:
+    if not verify(patch_b64, sig_b64):
+        return {"status": "invalid_signature"}
+
+    patch_bytes = base64.b64decode(patch_b64)
+    return {"status": "verified", "patch_size_bytes": len(patch_bytes)}

--- a/services/self-modifier/kms_verify.py
+++ b/services/self-modifier/kms_verify.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+
+import requests
+
+KMS_ENDPOINT = os.getenv("KMS_ENDPOINT", "")
+REQUEST_TIMEOUT = float(os.getenv("KMS_TIMEOUT", "5"))
+
+
+
+def verify(patch: str, signature: str) -> bool:
+    if not KMS_ENDPOINT:
+        return False
+
+    response = requests.post(
+        f"{KMS_ENDPOINT.rstrip('/')}/verify",
+        json={"data": patch, "signature": signature},
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    return bool(response.json().get("valid", False))

--- a/services/tiktok-uploader/src/api.ts
+++ b/services/tiktok-uploader/src/api.ts
@@ -1,0 +1,8 @@
+import axios from "axios";
+
+export async function uploadVideo(payload: { title: string; media_url: string }) {
+  const response = await axios.post(process.env.TIKTOK_API as string, payload, {
+    headers: { Authorization: `Bearer ${process.env.TIKTOK_TOKEN}` },
+  });
+  return response.data;
+}

--- a/tests/test_infra_hardening_modules.py
+++ b/tests/test_infra_hardening_modules.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, relative_path: str):
+    path = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_payment_circuit_opens_after_repeated_failures():
+    circuit = load_module('payment_circuit_test', 'services/payment/circuit.py')
+    circuit.success()
+    base = 100.0
+    for offset in range(4):
+        circuit.fail(now=base + offset)
+    assert circuit.allow(now=base + 5) is False
+    assert circuit.allow(now=base + 34) is True
+
+
+def test_payment_audit_writes_json_line(tmp_path, monkeypatch):
+    monkeypatch.setenv('PAYMENT_AUDIT_LOG', str(tmp_path / 'audit.log'))
+    audit = load_module('payment_audit_test', 'services/payment/audit.py')
+    audit.log('payment_success', {'id': 'abc'})
+    payload = json.loads((tmp_path / 'audit.log').read_text().strip())
+    assert payload['event'] == 'payment_success'
+    assert payload['data'] == {'id': 'abc'}
+
+
+def test_cost_control_enforces_daily_budget(monkeypatch):
+    monkeypatch.setenv('MAX_DAILY_COST', '10')
+    control = load_module('cost_control_test', 'services/cost/control.py')
+    control.reset()
+    assert control.allow(4) is True
+    assert control.allow(6) is True
+    assert control.allow(1) is False
+
+
+def test_legal_gate_filters_jurisdictions():
+    legal_gate = load_module('legal_gate_test', 'services/org/legal_gate.py')
+    assert legal_gate.check('US') is True
+    assert legal_gate.check('CN') is False
+
+
+def test_treasury_caps_spending(monkeypatch):
+    monkeypatch.setenv('DAILY_CAP', '100')
+    treasury_mod = load_module('treasury_test', 'services/org/treasury.py')
+    treasury = treasury_mod.Treasury()
+    assert treasury.spend(60) is True
+    assert treasury.spend(50) is False


### PR DESCRIPTION
### Motivation

- Harden production infra by introducing a sharded Redis cluster and a Patroni-backed Postgres HA topology for fault tolerance and failover. 
- Isolate the self-modifying component by running it as an ephemeral, non-root Kubernetes Job and remove reliance on local private keys by delegating patch signature verification to KMS. 
- Improve payment resiliency and observability by adding a circuit breaker, append-only audit logging, and a safe retrying adapter. 
- Provide repository-aligned scaffolding for autonomous services (auto-ML promotion loop, market creation, P2P bridge, Kafka labeling pipeline, GPU provisioning, cost controls and basic integrations) to support higher-level automation and monitoring.

### Description

- Added a six-node Redis cluster compose file at `infrastructure/docker/redis-cluster.yml` to enable sharded Redis testing/launch. 
- Added Patroni/Postgres StatefulSet and headless Service at `infrastructure/k8s/postgres/patroni.yaml` and wired the manifest into `infrastructure/k8s/kustomization.yaml`. 
- Added an isolated, non-root Kubernetes job manifest for the self-modifier at `infrastructure/k8s/jobs/self-modifier-job.yaml` and updated Prometheus targets in `infrastructure/monitoring/prometheus.yml`. 
- Replaced local verification with an external KMS verifier by adding `services/self-modifier/kms_verify.py` and updating `services/self-modifier/engine.py` to gate patch application via `verify`. 
- Implemented payment resilience and audit: `services/payment/circuit.py` (circuit breaker), `services/payment/audit.py` (append-only JSON audit log), `services/payment/adapter.py` (retrying adapter that uses the circuit and audit), and `services/payment/stripe_adapter.py` (Stripe scaffold). 
- Added autonomous-service scaffolding under `services/` including `services/auto-ml/loop.py`, `services/market-creator/engine.py`, `services/org/treasury.py`, `services/org/legal_gate.py`, `services/p2p/libp2p_bridge.py`, `services/data/pipeline.py`, `services/gpu/adapter.py`, `services/cost/control.py`, and a small `services/tiktok-uploader/src/api.ts`. 
- Added focused regression tests in `tests/test_infra_hardening_modules.py` that validate the circuit behavior, audit logging, cost control, legal gate, and treasury cap.

### Testing

- Ran `pytest tests/test_infra_hardening_modules.py` which completed successfully (`5 passed`).
- Ran Python byte-compile checks via `python -m py_compile` against the new/modified Python modules which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9ccff5448321948555a3a190ca94)