### PR TITLE
Harden enterprise discovery stack

### DIFF
--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -71,10 +71,6 @@ services:
       - "3100:3100"
     restart: always
 
-volumes:
-  postgres-data:
-  grafana-data:
-
   ai-orchestrator:
     build: ./services/ai-orchestrator
     container_name: zttato-ai-orchestrator
@@ -88,6 +84,17 @@ volumes:
   product-discovery:
     build: ./services/product-discovery
     container_name: zttato-product-discovery
+    environment:
+      MARKET_CRAWLER_URL: http://market-crawler:8000/products
+      HTTP_TIMEOUT: 5
+      HTTP_RETRIES: 3
+      HTTP_BACKOFF: 0.5
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     networks:
       - zttato-net
 
@@ -96,3 +103,11 @@ volumes:
     container_name: zttato-campaign-optimizer
     networks:
       - zttato-net
+
+volumes:
+  postgres-data:
+  grafana-data:
+
+networks:
+  zttato-net:
+    driver: bridge

--- a/docs/operations/endgame-roadmap.md
+++ b/docs/operations/endgame-roadmap.md
@@ -1,0 +1,78 @@
+# zTTato Endgame Roadmap (Reality-Based Execution Order)
+
+เอกสารนี้แปลง roadmap แบบ “endgame” ให้เป็นลำดับลงมือทำที่ผูกกับ repo ปัจจุบัน โดยเน้น production-first และเงินเข้าได้จริงก่อนฝันไกล.
+
+## Stage 0 — Right now: stabilize the existing stack
+
+**Goal:** ให้ stack ที่มีอยู่รันซ้ำได้, debug ได้, และไม่พังง่าย.
+
+### Action checklist
+- Validate both compose files in CI (`docker-compose.yml` and `docker-compose.enterprise.yml`).
+- Ensure every HTTP-facing service exposes `/healthz` and Compose health checks.
+- Standardize external API calls with timeout, retry, and backoff.
+- Emit structured JSON logs so Loki/Promtail can ingest all services consistently.
+- Add global exception handlers on services that are still returning raw tracebacks.
+
+### Exit criteria
+- Compose files parse cleanly and do not hide services under the wrong YAML section.
+- Health checks can tell apart `ok` vs `degraded`.
+- A failing upstream call returns a controlled 502/5xx instead of hanging forever.
+
+## Stage 1 — Real data before real AI
+
+**Goal:** replace mock/fake loops with a measurable data pipeline.
+
+### First production tickets
+1. Create Kafka topics: `raw_events`, `cleaned_events`, `training_data`.
+2. Define JSON schema for each topic and reject invalid payloads.
+3. Add deduplication keys for crawled items and click/conversion events.
+4. Store labeled outcomes that tie content -> traffic -> conversion -> payout.
+5. Build a daily data-quality report: freshness, null rate, duplicate rate, schema drift.
+
+### Exit criteria
+- Every model-training row is traceable back to a real campaign or content event.
+- The team can answer: “which source created this revenue signal?”
+
+## Stage 2 — Profit mode before scale mode
+
+**Goal:** prove one funnel can generate revenue with controlled CAC before scaling automation.
+
+### Required path
+1. Pick one channel and one monetization path only.
+2. Instrument the funnel end-to-end: impression -> click -> landing -> conversion -> payout.
+3. Enforce budget caps per campaign and a global kill switch.
+4. Track margin, refund rate, and payback window daily.
+5. Pause any campaign that lacks attributable ROI.
+
+### Recommended rule
+> No scaling to 100 campaigns until 1 campaign shows repeatable positive unit economics.
+
+## Stage 3 — Real AI only after data + ROI proof
+
+**Goal:** upgrade from heuristics to models that improve an already-working funnel.
+
+### Build order
+1. Feature store for ranking/trend/payout features.
+2. Offline training pipeline with versioned datasets.
+3. Online inference service with rollbackable model versions.
+4. Evaluation gates: baseline comparison, canary, rollback, audit trail.
+
+### Exit criteria
+- A model deployment is reversible and measurable.
+- "AI improvement" means better revenue, margin, or conversion — not just a smarter demo.
+
+## Stage 4 — Everything else is conditional
+
+Long-horizon phases such as multi-region, self-improving agents, DAO/governance, decentralization, and autonomous-org ideas only make sense **after**:
+- the stack is stable,
+- data is trustworthy,
+- one funnel makes money,
+- cost controls are enforced,
+- deployment and rollback are boring.
+
+## What changed in this repository now
+
+This repository update supports Stage 0 directly:
+- `docker-compose.enterprise.yml` now keeps enterprise services under `services:` instead of accidentally nesting them under `volumes:`.
+- `product-discovery` now has `/healthz`, retry/timeout handling, structured JSON logging, and global exception handling.
+- The service Dockerfile now installs pinned dependencies from `requirements.txt` for repeatable builds.

--- a/docs/operations/health-checks.md
+++ b/docs/operations/health-checks.md
@@ -11,6 +11,7 @@
 | arbitrage-engine | 9500 | `/healthz` | PostgreSQL (`select 1`) |
 | gpu-renderer | 9300 | `/healthz` | Redis (`PING`) |
 | nginx (edge proxy) | 80 | `/` | Proxy process alive |
+| product-discovery | 8000 | `/healthz` | market-crawler reachability with retry/timeout |
 
 ## Quick checks
 
@@ -42,3 +43,8 @@ docker compose exec -T nginx wget -qO- http://gpu-renderer:9300/healthz
 1. รัน `docker compose up -d` (เฉพาะบริการหลัก)
 2. ตรวจว่า services สำคัญอยู่ในสถานะ `running`
 3. ยิง smoke tests ที่ endpoint proxy (`/`, `/predict`, `/crawl`, `/arbitrage`)
+
+
+## Enterprise stack note
+
+สำหรับ `docker-compose.enterprise.yml` ตอนนี้ `product-discovery` มี health endpoint และ Compose healthcheck แล้ว ดังนั้นสามารถใช้ `docker compose -f docker-compose.enterprise.yml ps` เพื่อตรวจสถานะได้โดยตรง.

--- a/docs/operations/logging.md
+++ b/docs/operations/logging.md
@@ -3,3 +3,14 @@
 Use centralized logging with structured JSON logs where possible.
 
 Recommended: ELK or Loki stack.
+
+## Current baseline
+
+- Services should emit single-line JSON per event so Promtail/Loki can ingest logs without custom parsing.
+- Include at least: `timestamp`, `level`, `service`, `message`, and `request_id`.
+- Log upstream retry attempts separately from final failures so operators can distinguish flaky dependencies from hard outages.
+- Application-level request logs should include path, method, and latency.
+
+## Implemented example
+
+`services/product-discovery` now emits structured JSON logs and attaches `x-request-id` to responses, which provides a reference implementation for other lightweight FastAPI services.

--- a/services/product-discovery/Dockerfile
+++ b/services/product-discovery/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
 COPY src /app
-RUN pip install fastapi uvicorn requests
-CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/product-discovery/requirements.txt
+++ b/services/product-discovery/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+requests==2.32.3

--- a/services/product-discovery/src/main.py
+++ b/services/product-discovery/src/main.py
@@ -1,20 +1,151 @@
-from fastapi import FastAPI
-import requests
+import json
+import logging
+import os
 import random
+import sys
+import time
+from contextvars import ContextVar
+from typing import Any
+from uuid import uuid4
 
-app = FastAPI()
+import requests
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+SERVICE_NAME = "product-discovery"
+MARKET_CRAWLER_URL = os.getenv("MARKET_CRAWLER_URL", "http://market-crawler:8000/products")
+HTTP_TIMEOUT = float(os.getenv("HTTP_TIMEOUT", "5"))
+HTTP_RETRIES = int(os.getenv("HTTP_RETRIES", "3"))
+HTTP_BACKOFF = float(os.getenv("HTTP_BACKOFF", "0.5"))
+REQUEST_ID_CTX: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "service": SERVICE_NAME,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": REQUEST_ID_CTX.get(),
+        }
+        if hasattr(record, "event"):
+            payload["event"] = record.event
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
+
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(JsonFormatter())
+root_logger = logging.getLogger()
+root_logger.handlers.clear()
+root_logger.addHandler(handler)
+root_logger.setLevel(os.getenv("LOG_LEVEL", "INFO").upper())
+log = logging.getLogger(SERVICE_NAME)
+
+app = FastAPI(title="Product Discovery")
+
+
+def fetch_products() -> list[dict[str, Any]]:
+    last_error: str | None = None
+    for attempt in range(1, HTTP_RETRIES + 1):
+        try:
+            response = requests.get(MARKET_CRAWLER_URL, timeout=HTTP_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                raise ValueError("market-crawler response must be a JSON array")
+            return payload
+        except (requests.RequestException, ValueError) as exc:
+            last_error = str(exc)
+            log.warning(
+                "market crawler request failed",
+                extra={"event": {"attempt": attempt, "target": MARKET_CRAWLER_URL, "error": last_error}},
+            )
+            if attempt < HTTP_RETRIES:
+                time.sleep(HTTP_BACKOFF * (2 ** (attempt - 1)))
+    raise HTTPException(status_code=502, detail=f"market-crawler unavailable after retries: {last_error}")
+
+
+@app.middleware("http")
+async def request_logging_middleware(request: Request, call_next):
+    request_id = request.headers.get("x-request-id", str(uuid4()))
+    token = REQUEST_ID_CTX.set(request_id)
+    started = time.perf_counter()
+    try:
+        response = await call_next(request)
+    except Exception:
+        log.exception(
+            "unhandled request error",
+            extra={"event": {"method": request.method, "path": request.url.path}},
+        )
+        raise
+    finally:
+        elapsed_ms = round((time.perf_counter() - started) * 1000, 2)
+        log.info(
+            "request completed",
+            extra={
+                "event": {
+                    "method": request.method,
+                    "path": request.url.path,
+                    "duration_ms": elapsed_ms,
+                }
+            },
+        )
+        REQUEST_ID_CTX.reset(token)
+
+    response.headers["x-request-id"] = request_id
+    return response
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
+    return JSONResponse(status_code=exc.status_code, content={"ok": False, "detail": exc.detail})
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+    log.exception("unhandled application exception", extra={"event": {"error": str(exc)}})
+    return JSONResponse(status_code=500, content={"ok": False, "detail": "internal server error"})
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    ok = True
+    detail = "ok"
+    try:
+        fetch_products()
+    except HTTPException as exc:
+        ok = False
+        detail = str(exc.detail)
+
+    return {
+        "status": "ok" if ok else "degraded",
+        "service": SERVICE_NAME,
+        "market_crawler_url": MARKET_CRAWLER_URL,
+        "timeout": HTTP_TIMEOUT,
+        "retries": HTTP_RETRIES,
+        "detail": detail,
+    }
+
 
 @app.get("/discover")
-def discover():
+def discover() -> dict[str, Any]:
+    products = fetch_products()
+    scored: list[dict[str, Any]] = []
 
-    products = requests.get("http://market-crawler:8000/products").json()
+    for product in products:
+        candidate = dict(product)
+        candidate["score"] = random.random()
+        scored.append(candidate)
 
-    scored = []
+    scored.sort(key=lambda item: item["score"], reverse=True)
+    top_products = scored[:10]
 
-    for p in products:
-        p["score"] = random.random()
-        scored.append(p)
-
-    scored.sort(key=lambda x:x["score"],reverse=True)
-
-    return scored[:10]
+    log.info(
+        "discovery completed",
+        extra={"event": {"input_count": len(products), "selected_count": len(top_products)}},
+    )
+    return {"ok": True, "count": len(top_products), "items": top_products}


### PR DESCRIPTION
### Motivation

- Fix a YAML layout bug in `docker-compose.enterprise.yml` that accidentally nested enterprise services under `volumes` and to add explicit networking for predictable compose behavior. 
- Bring `services/product-discovery` to Phase‑1 production readiness by adding health checks, stable upstream call patterns (timeout/retry/backoff), structured logging, request IDs, and safer error handling. 
- Provide a small, repo-specific roadmap and update operations docs so the team has a concrete, production-first stabilization plan.

### Description

- Adjusted `docker-compose.enterprise.yml` to ensure `ai-orchestrator`, `product-discovery`, and `campaign-optimizer` are declared under `services`, added a `zttato-net` network, and added env + `healthcheck` for `product-discovery`.
- Replaced the lightweight `product-discovery` implementation with a hardened `services/product-discovery/src/main.py` that implements structured JSON logging, a request-id middleware, upstream `market-crawler` calls with configurable `HTTP_TIMEOUT`/`HTTP_RETRIES`/`HTTP_BACKOFF`, global exception handlers, a `/healthz` endpoint reporting `ok`/`degraded`, and a safer `/discover` response shape.
- Made the `product-discovery` image reproducible by switching `Dockerfile` to install pinned dependencies from `services/product-discovery/requirements.txt` and added that `requirements.txt`.
- Added `docs/operations/endgame-roadmap.md` and updated `docs/operations/logging.md` and `docs/operations/health-checks.md` to document the changes and provide actionable stabilization guidance.

### Testing

- Ran `python -m py_compile services/product-discovery/src/main.py` and it succeeded.
- Performed YAML validation via `yaml.safe_load` on `docker-compose.enterprise.yml`, `docker-compose.yml`, and `infrastructure/monitoring/docker-compose.monitoring.yml` and confirmed expected `services` and `networks` entries in the enterprise compose file.
- Dynamically imported `services/product-discovery/src/main.py` and executed `healthz()` to verify degraded-health behavior and observed retry warnings in the logs when `market-crawler` was unavailable.
- Note: `docker compose` could not be exercised here because Docker is not installed in the environment, so runtime container bring-up and live integration tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf9f3037408321b64550de4aeb9b3a)