### PR TITLE
Profit-mode revenue pipeline: feature store, affiliate conversion, payment gateway & orchestration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -748,6 +748,8 @@ services:
         condition: service_healthy
       model-service:
         condition: service_healthy
+      payment-gateway:
+        condition: service_healthy
       rl-trainer:
         condition: service_started
       rl-coordinator:
@@ -857,6 +859,22 @@ services:
     volumes:
       - model_registry_data:/models
       - shared_model_data:/shared-models
+    networks:
+      - zttato-net
+
+  payment-gateway:
+    build:
+      context: ./services/payment
+      dockerfile: Dockerfile
+    container_name: zttato-payment-gateway
+    restart: always
+    env_file: .env
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('127.0.0.1',8000),2); s.close()"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
     networks:
       - zttato-net
 

--- a/services/affiliate-webhook/src/main.py
+++ b/services/affiliate-webhook/src/main.py
@@ -8,17 +8,26 @@ import psycopg2
 import requests
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Affiliate Webhook (Verified)")
 
 SECRET = os.getenv("AFFILIATE_WEBHOOK_SECRET", "")
-DB_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql://zttato:zttato@postgres:5432/zttato",
-)
 DB_URL = os.getenv("DATABASE_URL", "postgresql://zttato:zttato@postgres:5432/zttato")
 REWARD_COLLECTOR_URL = os.getenv("REWARD_COLLECTOR_URL", "http://reward-collector:8000/reward")
+FEATURE_STORE_URL = os.getenv("FEATURE_STORE_URL", "http://feature-store:8000")
 TIMEOUT = int(os.getenv("HTTP_TIMEOUT", "10"))
+
+
+class ConversionEvent(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    revenue: float = Field(default=0.0, ge=0.0)
+    clicks: int = Field(default=0, ge=0)
+    views: int = Field(default=0, ge=0)
+    conversions: int = Field(default=1, ge=1)
+    source: str = Field(default="affiliate")
+    affiliate_account_id: str | None = None
+    order_id: str | None = None
 
 
 def verify(signature: str, body: bytes) -> bool:
@@ -56,35 +65,46 @@ async def conversion(req: Request) -> dict[str, bool]:
     if not verify(signature, body):
         raise HTTPException(status_code=401, detail="invalid signature")
 
-    data = json.loads(body.decode())
-    campaign_id = data["campaign_id"]
-    revenue = float(data.get("revenue", 0))
+    event = ConversionEvent.model_validate(json.loads(body.decode()))
 
     with db_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(
                 """
                 INSERT INTO campaign_metrics (campaign_id, views, clicks, conversions, revenue)
-                VALUES (%s, 0, 0, 1, %s)
+                VALUES (%s, %s, %s, %s, %s)
                 """,
-                (campaign_id, revenue),
+                (event.campaign_id, event.views, event.clicks, event.conversions, event.revenue),
             )
 
     try:
+        feature_response = requests.post(
+            f"{FEATURE_STORE_URL}/features/{event.campaign_id}",
+            json={
+                "views": event.views,
+                "clicks": event.clicks,
+                "conversions": event.conversions,
+                "revenue": event.revenue,
+                "mode": "increment",
+            },
+            timeout=TIMEOUT,
+        )
+        feature_response.raise_for_status()
+
         response = requests.post(
             REWARD_COLLECTOR_URL,
             json={
-                "campaign_id": campaign_id,
-                "revenue": revenue,
-                "conversions": 1,
-                "clicks": int(data.get("clicks", 0)),
-                "views": int(data.get("views", 0)),
+                "campaign_id": event.campaign_id,
+                "revenue": event.revenue,
+                "conversions": event.conversions,
+                "clicks": event.clicks,
+                "views": event.views,
             },
             timeout=TIMEOUT,
         )
         response.raise_for_status()
     except requests.RequestException as exc:
-        raise HTTPException(status_code=502, detail=f"reward collector unavailable: {exc}") from exc
+        raise HTTPException(status_code=502, detail=f"downstream service unavailable: {exc}") from exc
 
     return {"ok": True}
 

--- a/services/feature-store/src/main.py
+++ b/services/feature-store/src/main.py
@@ -4,7 +4,7 @@ from typing import Any
 import redis
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Feature Store")
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
@@ -15,6 +15,41 @@ class CampaignFeatures(BaseModel):
     views: int = 0
     clicks: int = 0
     conversions: int = 0
+    revenue: float = 0.0
+    spend: float = 0.0
+    max_budget: float = 100.0
+    daily_cap: float = 100.0
+    base_bid: float = 0.1
+
+
+class FeatureUpdate(BaseModel):
+    views: int = Field(default=0)
+    clicks: int = Field(default=0)
+    conversions: int = Field(default=0)
+    revenue: float = Field(default=0.0)
+    spend: float | None = None
+    max_budget: float | None = None
+    daily_cap: float | None = None
+    base_bid: float | None = None
+    mode: str = Field(default="increment")
+
+
+def _load_features(campaign_id: str) -> CampaignFeatures:
+    try:
+        data = REDIS.hgetall(f"campaign:{campaign_id}:features")
+    except redis.RedisError as exc:
+        raise HTTPException(status_code=503, detail=f"redis unavailable: {exc}") from exc
+
+    return CampaignFeatures(
+        views=int(data.get("views", 0)),
+        clicks=int(data.get("clicks", 0)),
+        conversions=int(data.get("conv", 0)),
+        revenue=float(data.get("revenue", 0.0)),
+        spend=float(data.get("spend", 0.0)),
+        max_budget=float(data.get("max_budget", 100.0)),
+        daily_cap=float(data.get("daily_cap", data.get("max_budget", 100.0))),
+        base_bid=float(data.get("base_bid", 0.1)),
+    )
 
 
 @app.get("/healthz")
@@ -31,17 +66,59 @@ def healthz() -> dict[str, Any]:
 def get_features(campaign_id: str) -> CampaignFeatures:
     if not campaign_id:
         raise HTTPException(status_code=400, detail="campaign_id is required")
+    return _load_features(campaign_id)
+
+
+@app.post("/features/{campaign_id}", response_model=CampaignFeatures)
+def update_features(campaign_id: str, request: FeatureUpdate) -> CampaignFeatures:
+    if not campaign_id:
+        raise HTTPException(status_code=400, detail="campaign_id is required")
+
+    current = _load_features(campaign_id)
+    if request.mode not in {"increment", "replace"}:
+        raise HTTPException(status_code=400, detail="mode must be increment or replace")
+
+    if request.mode == "replace":
+        updated = CampaignFeatures(
+            views=request.views,
+            clicks=request.clicks,
+            conversions=request.conversions,
+            revenue=request.revenue,
+            spend=request.spend if request.spend is not None else current.spend,
+            max_budget=request.max_budget if request.max_budget is not None else current.max_budget,
+            daily_cap=request.daily_cap if request.daily_cap is not None else current.daily_cap,
+            base_bid=request.base_bid if request.base_bid is not None else current.base_bid,
+        )
+    else:
+        updated = CampaignFeatures(
+            views=current.views + request.views,
+            clicks=current.clicks + request.clicks,
+            conversions=current.conversions + request.conversions,
+            revenue=current.revenue + request.revenue,
+            spend=request.spend if request.spend is not None else current.spend,
+            max_budget=request.max_budget if request.max_budget is not None else current.max_budget,
+            daily_cap=request.daily_cap if request.daily_cap is not None else current.daily_cap,
+            base_bid=request.base_bid if request.base_bid is not None else current.base_bid,
+        )
 
     try:
-        data = REDIS.hgetall(f"campaign:{campaign_id}:features")
+        REDIS.hset(
+            f"campaign:{campaign_id}:features",
+            mapping={
+                "views": updated.views,
+                "clicks": updated.clicks,
+                "conv": updated.conversions,
+                "revenue": updated.revenue,
+                "spend": updated.spend,
+                "max_budget": updated.max_budget,
+                "daily_cap": updated.daily_cap,
+                "base_bid": updated.base_bid,
+            },
+        )
     except redis.RedisError as exc:
         raise HTTPException(status_code=503, detail=f"redis unavailable: {exc}") from exc
 
-    return CampaignFeatures(
-        views=int(data.get("views", 0)),
-        clicks=int(data.get("clicks", 0)),
-        conversions=int(data.get("conv", 0)),
-    )
+    return updated
 
 
 if __name__ == "__main__":

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -1,9 +1,10 @@
-from typing import Any
+from typing import Any, Literal
+from urllib.parse import quote
 
 import requests
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, HttpUrl
 
 from distributed_loop import run_cycle
 from economy_loop import run_economy
@@ -12,6 +13,47 @@ from kafka_producer import emit_decision
 
 app = FastAPI(title="Master Orchestrator")
 TIMEOUT = 10
+
+
+CLICK_TRACKER_URL = "http://click-tracker:8080"
+PAYMENT_GATEWAY_URL = "http://payment-gateway:8000"
+
+
+class PaymentConfig(BaseModel):
+    provider: Literal["stripe", "crypto"] = "stripe"
+    amount: float = Field(gt=0)
+    currency: str = Field(default="usd", min_length=3, max_length=8)
+    success_url: HttpUrl
+    cancel_url: HttpUrl
+    wallet_address: str | None = None
+
+
+class ProfitModeRequest(BaseModel):
+    campaign_id: str = Field(min_length=1)
+    video_url: HttpUrl
+    caption: str = Field(min_length=1, max_length=2200)
+    landing_url: HttpUrl
+    affiliate_product_id: str | None = Field(default=None, min_length=1)
+    tenant_id: str = Field(default="default", min_length=1)
+    region: str = Field(default="global", min_length=2)
+    market: str = Field(default="US", min_length=2, max_length=8)
+    payment: PaymentConfig
+    max_budget: float = Field(default=100.0, gt=0)
+    daily_cap: float = Field(default=50.0, gt=0)
+    base_bid: float = Field(default=0.25, gt=0)
+
+
+class ProfitModeResponse(BaseModel):
+    campaign_id: str
+    tracked_destination_url: str
+    features: dict[str, Any]
+    model: dict[str, Any]
+    rl: dict[str, Any]
+    budget: dict[str, Any]
+    bid: dict[str, Any]
+    execution: dict[str, Any]
+    payment: dict[str, Any]
+    audit: dict[str, Any]
 
 
 def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
@@ -82,6 +124,31 @@ def run_federated_task_endpoint(request: FederatedTaskRequest) -> dict[str, Any]
     return run_global_task(request.campaign_id, request.tenant_id, request.region)
 
 
+def build_tracked_destination(campaign_id: str, landing_url: str, affiliate_product_id: str | None = None) -> str:
+    if affiliate_product_id:
+        return f"{CLICK_TRACKER_URL}/go/{campaign_id}/{quote(affiliate_product_id)}"
+    return f"{CLICK_TRACKER_URL}/r/{campaign_id}?to={quote(landing_url, safe='')}"
+
+
+def create_checkout(request: ProfitModeRequest, tracked_destination_url: str) -> dict[str, Any]:
+    payload = {
+        "provider": request.payment.provider,
+        "campaign_id": request.campaign_id,
+        "amount": request.payment.amount,
+        "currency": request.payment.currency.lower(),
+        "success_url": str(request.payment.success_url),
+        "cancel_url": str(request.payment.cancel_url),
+        "wallet_address": request.payment.wallet_address,
+        "metadata": {
+            "campaign_id": request.campaign_id,
+            "tenant_id": request.tenant_id,
+            "market": request.market,
+            "tracked_destination_url": tracked_destination_url,
+        },
+    }
+    return safe_call(requests.post, f"{PAYMENT_GATEWAY_URL}/checkout", json=payload)
+
+
 @app.post("/campaign/run", response_model=CampaignDecision)
 def run_campaign(offer: Offer) -> CampaignDecision:
     cycle = run_cycle(offer.id)
@@ -120,6 +187,71 @@ def run_campaign(offer: Offer) -> CampaignDecision:
         bid=cycle["bid"],
         scaling=cycle["scale"],
         execution=execution,
+    )
+
+
+@app.post("/profit-mode/activate", response_model=ProfitModeResponse)
+def activate_profit_mode(request: ProfitModeRequest) -> ProfitModeResponse:
+    safe_call(
+        requests.post,
+        f"http://feature-store:8000/features/{request.campaign_id}",
+        json={
+            "max_budget": request.max_budget,
+            "daily_cap": request.daily_cap,
+            "base_bid": request.base_bid,
+            "mode": "increment",
+        },
+    )
+    cycle = run_cycle(request.campaign_id)
+    model = safe_call(requests.post, "http://model-service:8000/predict", json=cycle["features"])
+    tracked_destination_url = build_tracked_destination(
+        request.campaign_id,
+        str(request.landing_url),
+        request.affiliate_product_id,
+    )
+    execution = safe_call(
+        requests.post,
+        "http://execution-engine:9600/publish",
+        json={
+            "campaign_id": request.campaign_id,
+            "video_url": str(request.video_url),
+            "caption": request.caption,
+            "destination_url": tracked_destination_url,
+        },
+    )
+    payment = create_checkout(request, tracked_destination_url)
+    audit = {
+        "tenant_id": request.tenant_id,
+        "region": request.region,
+        "market": request.market,
+        "payment_provider": request.payment.provider,
+        "tracked_destination_url": tracked_destination_url,
+        "profit_mode": True,
+    }
+    emit_decision(
+        {
+            "campaign_id": request.campaign_id,
+            "features": cycle["features"],
+            "model": model,
+            "rl": cycle["rl"],
+            "budget": cycle["budget"],
+            "bid": cycle["bid"],
+            "execution": execution,
+            "payment": payment,
+            "audit": audit,
+        }
+    )
+    return ProfitModeResponse(
+        campaign_id=request.campaign_id,
+        tracked_destination_url=tracked_destination_url,
+        features=cycle["features"],
+        model=model,
+        rl=cycle["rl"],
+        budget=cycle["budget"],
+        bid=cycle["bid"],
+        execution=execution,
+        payment=payment,
+        audit=audit,
     )
 
 

--- a/services/payment/Dockerfile
+++ b/services/payment/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir fastapi uvicorn requests pydantic
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/payment/main.py
+++ b/services/payment/main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any, Literal
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, HttpUrl
+
+from adapter import send
+from audit import log
+
+app = FastAPI(title="Payment Gateway")
+STRIPE_ENDPOINT = os.getenv("PAYMENT_STRIPE_ENDPOINT", "https://payments.example/stripe")
+CRYPTO_ENDPOINT = os.getenv("PAYMENT_CRYPTO_ENDPOINT", "https://payments.example/crypto")
+
+
+class CheckoutRequest(BaseModel):
+    provider: Literal["stripe", "crypto"]
+    campaign_id: str = Field(min_length=1)
+    amount: float = Field(gt=0)
+    currency: str = Field(default="usd", min_length=3, max_length=8)
+    success_url: HttpUrl
+    cancel_url: HttpUrl
+    wallet_address: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "payment-gateway"}
+
+
+@app.post("/checkout")
+def checkout(request: CheckoutRequest) -> dict[str, Any]:
+    endpoint = STRIPE_ENDPOINT if request.provider == "stripe" else CRYPTO_ENDPOINT
+    payload = request.model_dump(mode="json")
+    if request.provider == "crypto" and not request.wallet_address:
+        invoice_id = hashlib.sha256(f"{request.campaign_id}:{request.amount}:{request.currency}".encode("utf-8")).hexdigest()[:16]
+        response = {
+            "status": "pending",
+            "provider": "crypto",
+            "invoice_id": invoice_id,
+            "pay_to_address": f"wallet://{invoice_id}",
+            "amount": request.amount,
+            "currency": request.currency.lower(),
+        }
+        log("payment_checkout_created", response)
+        return response
+
+    response = send(endpoint, payload)
+    if response.get("status") in {"failed", "circuit_open"}:
+        raise HTTPException(status_code=502, detail=response)
+    log("payment_checkout_created", {"campaign_id": request.campaign_id, "provider": request.provider})
+    return response
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/test_profit_mode_pipeline.py
+++ b/tests/test_profit_mode_pipeline.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+import types
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(module_name: str, relative_path: str):
+    module_path = ROOT / relative_path
+    spec = spec_from_file_location(module_name, module_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store: dict[str, dict[str, str]] = {}
+
+    def ping(self):
+        return True
+
+    def hgetall(self, key: str):
+        return dict(self.store.get(key, {}))
+
+    def hset(self, key: str, mapping: dict[str, object]):
+        current = self.store.setdefault(key, {})
+        current.update({field: str(value) for field, value in mapping.items()})
+        return 1
+
+
+def test_feature_store_supports_budget_and_revenue_updates(monkeypatch):
+    redis_stub = FakeRedis()
+    import redis
+
+    monkeypatch.setattr(redis.Redis, 'from_url', staticmethod(lambda *args, **kwargs: redis_stub))
+    module = load_module('test_feature_store_profit', 'services/feature-store/src/main.py')
+    client = TestClient(module.app)
+
+    response = client.post('/features/cmp-profit', json={
+        'views': 100,
+        'clicks': 10,
+        'conversions': 2,
+        'revenue': 12.5,
+        'max_budget': 150,
+        'daily_cap': 45,
+        'base_bid': 0.35,
+    })
+    assert response.status_code == 200
+    assert response.json() == {
+        'views': 100,
+        'clicks': 10,
+        'conversions': 2,
+        'revenue': 12.5,
+        'spend': 0.0,
+        'max_budget': 150.0,
+        'daily_cap': 45.0,
+        'base_bid': 0.35,
+    }
+
+    latest = client.get('/features/cmp-profit')
+    assert latest.status_code == 200
+    assert latest.json()['revenue'] == 12.5
+    assert latest.json()['max_budget'] == 150.0
+
+
+def test_affiliate_webhook_updates_feature_store_and_reward_collector(monkeypatch):
+    monkeypatch.setenv('AFFILIATE_WEBHOOK_SECRET', 'topsecret')
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def cursor(self):
+            return self
+
+        def execute(self, *args, **kwargs):
+            return None
+
+    psycopg_stub = types.SimpleNamespace(connect=lambda *args, **kwargs: DummyConn())
+    sys.modules['psycopg2'] = psycopg_stub
+    module = load_module('test_affiliate_webhook_profit', 'services/affiliate-webhook/src/main.py')
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append((url, json))
+        return types.SimpleNamespace(raise_for_status=lambda: None)
+
+    monkeypatch.setattr(module.requests, 'post', fake_post)
+    client = TestClient(module.app)
+    payload = {'campaign_id': 'cmp-1', 'revenue': 9.5, 'clicks': 3, 'views': 100, 'conversions': 1}
+    body = json.dumps(payload).encode('utf-8')
+    signature = hmac.new(b'topsecret', body, hashlib.sha256).hexdigest()
+
+    response = client.post('/conversion', data=body, headers={'X-Signature': signature, 'Content-Type': 'application/json'})
+    assert response.status_code == 200
+    assert calls[0][0].endswith('/features/cmp-1')
+    assert calls[0][1]['revenue'] == 9.5
+    assert calls[1][0].endswith('/reward')
+
+
+def test_profit_mode_activation_wires_tracking_payment_and_execution(monkeypatch):
+    sys.path.insert(0, str(ROOT / 'services/master-orchestrator/src'))
+    sys.modules['distributed_loop'] = types.SimpleNamespace(run_cycle=lambda campaign_id: {
+        'features': {'views': 100, 'clicks': 10, 'conversions': 2, 'max_budget': 120, 'daily_cap': 40, 'base_bid': 0.2},
+        'rl': {'selected_campaign_id': campaign_id, 'score': 0.82},
+        'budget': {'target_budget': 40.0},
+        'bid': {'bid_price': 0.7},
+        'scale': {'action': 'hold'},
+    })
+    sys.modules['economy_loop'] = types.SimpleNamespace(run_economy=lambda *args, **kwargs: {'ok': True})
+    sys.modules['federated_loop'] = types.SimpleNamespace(run_global_task=lambda *args, **kwargs: {'ok': True})
+    emitted: list[dict[str, object]] = []
+    sys.modules['kafka_producer'] = types.SimpleNamespace(emit_decision=lambda payload: emitted.append(payload))
+
+    module = load_module('test_master_orchestrator_profit', 'services/master-orchestrator/src/main.py')
+
+    def fake_safe_call(method, url, **kwargs):
+        if 'feature-store:8000/features' in url:
+            return {'ok': True}
+        if 'model-service:8000/predict' in url:
+            return {'score': 0.91, 'ctr': 0.1, 'cvr': 0.2, 'model_version': 'policy-v2'}
+        if 'execution-engine:9600/publish' in url:
+            return {'ok': True, 'status': 'submitted', 'id': 'pub-1'}
+        if 'payment-gateway:8000/checkout' in url:
+            return {'status': 'pending', 'provider': 'stripe', 'checkout_url': 'https://pay.example/checkout/abc'}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(module, 'safe_call', fake_safe_call)
+    client = TestClient(module.app)
+
+    response = client.post('/profit-mode/activate', json={
+        'campaign_id': 'cmp-77',
+        'video_url': 'https://cdn.example/video.mp4',
+        'caption': 'Profit mode creative',
+        'landing_url': 'https://affiliate.example/product',
+        'affiliate_product_id': 'sku-77',
+        'tenant_id': 'tenant-a',
+        'region': 'us-east',
+        'market': 'US',
+        'max_budget': 150,
+        'daily_cap': 55,
+        'base_bid': 0.3,
+        'payment': {
+            'provider': 'stripe',
+            'amount': 49.99,
+            'currency': 'usd',
+            'success_url': 'https://app.example/success',
+            'cancel_url': 'https://app.example/cancel',
+        },
+    })
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload['tracked_destination_url'].endswith('/go/cmp-77/sku-77')
+    assert payload['payment']['provider'] == 'stripe'
+    assert emitted[0]['audit']['profit_mode'] is True


### PR DESCRIPTION
### Motivation
- Provide a concrete, runnable profit-mode slice that wires conversions to revenue, feature storage, model/RL decisions, execution and payments so the platform can exercise an end-to-end revenue loop. 
- Tighten conversion → reward feedback by ensuring affiliate conversion events update the feature store and notify the reward collector for RL training and budget decisions. 
- Add a minimal, auditable payment checkout path so campaigns can be activated with tracked destinations and a payment handshake without assuming external integration is already present.

### Description
- Expanded the feature store to persist richer campaign state (`revenue`, `spend`, `max_budget`, `daily_cap`, `base_bid`) and added a `POST /features/{campaign_id}` update API with `increment`/`replace` semantics (`services/feature-store/src/main.py`).
- Upgraded `affiliate-webhook` to validate signed conversion events, persist conversions to the DB, update the feature store, and forward to the reward collector (`services/affiliate-webhook/src/main.py`).
- Added a lightweight `payment-gateway` service with a schema-validated `/checkout` API (Stripe passthrough + crypto fallback), audit logging and a Dockerfile, and wired it into `docker-compose.yml` (`services/payment/main.py`, `services/payment/Dockerfile`, `docker-compose.yml`).
- Added a `POST /profit-mode/activate` endpoint in the master orchestrator that seeds budget controls, builds tracked click URLs, triggers execution, requests a payment checkout, and emits audit/decision metadata (`services/master-orchestrator/src/main.py`).
- Added integration tests that exercise the feature updates, affiliate conversion propagation, and profit-mode activation (`tests/test_profit_mode_pipeline.py`).

### Testing
- Ran `pytest -q tests/test_profit_mode_pipeline.py tests/test_autonomous_rl_services.py tests/test_infra_hardening_modules.py` and the suite completed successfully with the new tests (overall tests: 12 passed, 5 skipped). 
- Verified Python sources compile with `python -m py_compile services/feature-store/src/main.py services/affiliate-webhook/src/main.py services/master-orchestrator/src/main.py services/payment/main.py` without syntax errors. 
- Validated `docker-compose.yml` wiring via a small script that confirmed the `payment-gateway` service is present and `master-orchestrator` depends on it, and the compose checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa25194508321a41d87e9f36ce15b)