### PR TITLE
Add zttato platform lifecycle manager and installer/start/upgrade/deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ Or use the repository bootstrap helper:
 bash start.sh
 ```
 
+Or use the new platform manager flows:
+
+```bash
+bash scripts/zttato-manager.sh install
+bash scripts/zttato-manager.sh upgrade
+bash scripts/zttato-manager.sh deploy
+```
+
 ### 3) Verify health
 
 ```bash
@@ -121,6 +129,13 @@ docker compose restart <service-name>
 
 ```bash
 docker compose up -d --scale crawler-worker=3 --scale renderer-worker=2 --scale arbitrage-worker=2
+```
+
+### Use the zTTato manager
+
+```bash
+bash scripts/zttato-manager.sh status
+bash scripts/zttato-manager.sh logs nginx
 ```
 
 ### Use the Node-service wrapper

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,6 +137,16 @@ bash start.sh
 
 This helper will create `.env` if needed, validate Compose config, and start the stack with build enabled.
 
+### Managed installer / upgrade / deploy flow
+
+```bash
+bash scripts/zttato-manager.sh install
+bash scripts/zttato-manager.sh upgrade
+bash scripts/zttato-manager.sh deploy
+```
+
+Use these commands when you want a clearer lifecycle split between preparing the workstation, refreshing images, and doing a full local deployment.
+
 ### Full bootstrap script
 
 ```bash

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -41,6 +41,13 @@ If you prefer the helper script:
 bash start.sh
 ```
 
+If you want the managed lifecycle wrapper:
+
+```bash
+bash scripts/zttato-manager.sh install
+bash scripts/zttato-manager.sh start
+```
+
 ## 4) Check container state
 
 ```bash

--- a/scripts/deploy-zttato-platform.sh
+++ b/scripts/deploy-zttato-platform.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log(){ printf '[deploy] %s\n' "$*"; }
+
+log "Installing prerequisites and generating .env when needed"
+bash "$ROOT_DIR/scripts/install-zttato-platform.sh"
+
+log "Upgrading runtime assets"
+bash "$ROOT_DIR/scripts/upgrade-zttato-platform.sh"
+
+log "Starting stack and running smoke checks"
+bash "$ROOT_DIR/scripts/start-zttato-platform.sh"
+
+log "Deployment completed"

--- a/scripts/install-zttato-platform.sh
+++ b/scripts/install-zttato-platform.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log(){ printf '[install] %s\n' "$*"; }
+fail(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+require_cmd(){
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+ensure_env(){
+  if [[ -f .env ]]; then
+    log ".env already exists"
+    return
+  fi
+
+  if [[ -f configs/env/production.env ]]; then
+    cp configs/env/production.env .env
+    log "Created .env from configs/env/production.env"
+    return
+  fi
+
+  cat > .env <<'ENVEOF'
+DB_NAME=zttato
+DB_USER=zttato
+DB_PASSWORD=zttato
+DB_PORT=5432
+REDIS_HOST=redis
+REDIS_PORT=6379
+FFMPEG_HWACCEL=none
+FFMPEG_CPU_PRESET=veryfast
+FFMPEG_CPU_CRF=23
+PLATFORM_API_BASE=https://api.partner.example
+PLATFORM_API_KEY=
+AFFILIATE_WEBHOOK_SECRET=change-me
+DEFAULT_DAILY_SPEND_LIMIT=100.0
+HTTP_TIMEOUT=10
+RATE_TOKENS=60
+RATE_MAX_TOKENS=120
+RATE_REFILL_PER_SEC=1
+ENVEOF
+  log "Created .env with local defaults"
+}
+
+install_node_dependencies(){
+  if ! command -v npm >/dev/null 2>&1; then
+    log "npm not found; skipping Node dependency installation"
+    return
+  fi
+
+  log "Installing Node service dependencies"
+  bash "$ROOT_DIR/scripts/install-node-services.sh"
+}
+
+validate_compose(){
+  if docker compose version >/dev/null 2>&1; then
+    docker compose config >/dev/null
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose config >/dev/null
+  else
+    fail "docker compose or docker-compose is required"
+  fi
+}
+
+require_cmd docker
+require_cmd python3
+ensure_env
+validate_compose
+install_node_dependencies
+
+log "zTTato platform install completed"

--- a/scripts/start-zttato-platform.sh
+++ b/scripts/start-zttato-platform.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log(){ printf '[start] %s\n' "$*"; }
+fail(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+compose_cmd(){
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    fail "docker compose or docker-compose is required"
+  fi
+}
+
+ensure_env(){
+  [[ -f .env ]] || bash "$ROOT_DIR/scripts/install-zttato-platform.sh"
+}
+
+smoke_check(){
+  local url="$1"
+  local name="$2"
+  if curl -fsS "$url" >/dev/null 2>&1; then
+    log "$name OK"
+  else
+    log "$name not ready yet"
+  fi
+}
+
+ensure_env
+log "Validating compose configuration"
+compose_cmd config >/dev/null
+log "Building and starting compose stack"
+compose_cmd up -d --build --remove-orphans
+log "Current compose status"
+compose_cmd ps
+
+sleep 3
+smoke_check "http://localhost/" "gateway"
+smoke_check "http://localhost:9100/docs" "viral-predictor"
+smoke_check "http://localhost:9400/docs" "market-crawler"
+smoke_check "http://localhost:9500/docs" "arbitrage-engine"
+smoke_check "http://localhost:9300/docs" "gpu-renderer"
+
+log "zTTato platform start completed"

--- a/scripts/upgrade-zttato-platform.sh
+++ b/scripts/upgrade-zttato-platform.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log(){ printf '[upgrade] %s\n' "$*"; }
+fail(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+compose_cmd(){
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    fail "docker compose or docker-compose is required"
+  fi
+}
+
+log "Running installer prerequisites"
+bash "$ROOT_DIR/scripts/install-zttato-platform.sh"
+
+log "Pulling published base images when available"
+compose_cmd pull --ignore-pull-failures || true
+
+log "Rebuilding local images"
+compose_cmd build
+
+log "Refreshing stack"
+compose_cmd up -d --build --remove-orphans
+
+if command -v npm >/dev/null 2>&1; then
+  log "Refreshing Node dependencies"
+  bash "$ROOT_DIR/scripts/install-node-services.sh"
+fi
+
+log "Upgrade completed"

--- a/scripts/zttato
+++ b/scripts/zttato
@@ -1,94 +1,62 @@
 #!/usr/bin/env bash
-# zttato
-
 set -Eeuo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMMAND="${1:-}"
 
-case "${1:-}" in
-
-up)
-bash "$ROOT/scripts/start-zttato.sh"
-;;
-
-down)
-bash "$ROOT/scripts/stop-zttato.sh"
-;;
-
-restart)
-bash "$ROOT/scripts/stop-zttato.sh"
-sleep 2
-bash "$ROOT/scripts/start-zttato.sh"
-;;
-
-status)
-
-docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
-
-echo
-echo "API status"
-
-curl -s localhost:9100/docs >/dev/null && echo "viral OK"
-curl -s localhost:9400/docs >/dev/null && echo "crawler OK"
-curl -s localhost:9500/docs >/dev/null && echo "arbitrage OK"
-curl -s localhost:9300/docs >/dev/null && echo "renderer OK"
-;;
-
-logs)
-
-SERVICE="${2:-}"
-
-if [ -z "$SERVICE" ]; then
-ls "$ROOT/logs"
-else
-tail -f "$ROOT/logs/$SERVICE.log"
-fi
-;;
-
-edge)
-
-curl -I https://api.zeaz.dev || true
-curl -I https://gpu.zeaz.dev || true
-;;
-
-node-install)
-bash "$ROOT/scripts/install-node-services.sh"
-;;
-
-node-start)
-bash "$ROOT/scripts/run-node-services.sh"
-;;
-
-node-stop)
-bash "$ROOT/scripts/stop-node-services.sh"
-;;
-
-node-restart)
-bash "$ROOT/scripts/zttato-node.sh" restart
-;;
-
-node-status)
-bash "$ROOT/scripts/zttato-node.sh" status
-;;
-
-node-logs)
-bash "$ROOT/scripts/zttato-node.sh" logs "${2:-}"
-;;
-
-*)
-echo "Usage:"
-echo "zttato up"
-echo "zttato down"
-echo "zttato restart"
-echo "zttato status"
-echo "zttato logs [service]"
-echo "zttato edge"
-echo "zttato node-install"
-echo "zttato node-start"
-echo "zttato node-stop"
-echo "zttato node-status"
-echo "zttato node-restart"
-echo "zttato node-logs [service]"
-;;
-
+case "$COMMAND" in
+  up)
+    exec bash "$ROOT/scripts/zttato-manager.sh" start
+    ;;
+  down)
+    exec bash "$ROOT/scripts/zttato-manager.sh" stop
+    ;;
+  restart)
+    exec bash "$ROOT/scripts/zttato-manager.sh" restart
+    ;;
+  status)
+    exec bash "$ROOT/scripts/zttato-manager.sh" status
+    ;;
+  logs)
+    exec bash "$ROOT/scripts/zttato-manager.sh" logs "${2:-}"
+    ;;
+  deploy)
+    exec bash "$ROOT/scripts/zttato-manager.sh" deploy
+    ;;
+  upgrade)
+    exec bash "$ROOT/scripts/zttato-manager.sh" upgrade
+    ;;
+  install)
+    exec bash "$ROOT/scripts/zttato-manager.sh" install
+    ;;
+  node-install|node-start|node-stop|node-restart|node-status)
+    SUBCOMMAND="${COMMAND#node-}"
+    exec bash "$ROOT/scripts/zttato-node.sh" "$SUBCOMMAND"
+    ;;
+  node-logs)
+    exec bash "$ROOT/scripts/zttato-node.sh" logs "${2:-}"
+    ;;
+  edge)
+    exec bash "$ROOT/scripts/zttato-edge-doctor.sh"
+    ;;
+  *)
+    cat <<'USAGE'
+Usage:
+  zttato up
+  zttato down
+  zttato restart
+  zttato status
+  zttato logs [service]
+  zttato install
+  zttato upgrade
+  zttato deploy
+  zttato edge
+  zttato node-install
+  zttato node-start
+  zttato node-stop
+  zttato node-status
+  zttato node-restart
+  zttato node-logs [service]
+USAGE
+    ;;
 esac

--- a/scripts/zttato-manager.sh
+++ b/scripts/zttato-manager.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+compose_cmd(){
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    fail "docker compose or docker-compose is required"
+  fi
+}
+
+status_cmd(){
+  compose_cmd ps || true
+  echo
+  docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' || true
+}
+
+logs_cmd(){
+  if [[ -n "${1:-}" ]]; then
+    compose_cmd logs --tail=200 "$1"
+  else
+    compose_cmd logs --tail=200
+  fi
+}
+
+usage(){
+  cat <<'USAGE'
+Usage: bash scripts/zttato-manager.sh <command> [args]
+
+Commands:
+  install         Prepare .env and install local dependencies
+  start           Build and start the compose stack
+  stop            Stop the compose stack
+  restart         Restart the compose stack
+  deploy          Run install + upgrade + start
+  upgrade         Refresh images and restart the stack
+  status          Show compose and docker status
+  logs [service]  Show compose logs
+  node            Show node-service usage helper
+USAGE
+}
+
+case "${1:-}" in
+  install)
+    bash "$ROOT_DIR/scripts/install-zttato-platform.sh"
+    ;;
+  start)
+    bash "$ROOT_DIR/scripts/start-zttato-platform.sh"
+    ;;
+  stop)
+    compose_cmd down
+    ;;
+  restart)
+    compose_cmd down
+    bash "$ROOT_DIR/scripts/start-zttato-platform.sh"
+    ;;
+  deploy)
+    bash "$ROOT_DIR/scripts/deploy-zttato-platform.sh"
+    ;;
+  upgrade)
+    bash "$ROOT_DIR/scripts/upgrade-zttato-platform.sh"
+    ;;
+  status)
+    status_cmd
+    ;;
+  logs)
+    logs_cmd "${2:-}"
+    ;;
+  node)
+    echo 'Use: bash scripts/zttato-node.sh {install|start|stop|restart|status|logs [service]}'
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/start.sh
+++ b/start.sh
@@ -1,48 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$ROOT_DIR"
-
-if ! command -v docker >/dev/null 2>&1; then
-  echo 'ERROR: docker is required to start the platform.' >&2
-  exit 1
-fi
-
-if docker compose version >/dev/null 2>&1; then
-  COMPOSE_CMD=(docker compose)
-elif command -v docker-compose >/dev/null 2>&1; then
-  COMPOSE_CMD=(docker-compose)
-else
-  echo 'ERROR: docker compose or docker-compose is required.' >&2
-  exit 1
-fi
-
-if [[ ! -f .env ]]; then
-  if [[ -f configs/env/production.env ]]; then
-    cp configs/env/production.env .env
-    echo 'Created .env from configs/env/production.env'
-  else
-    cat > .env <<'ENVEOF'
-DB_NAME=zttato
-DB_USER=zttato
-DB_PASSWORD=zttato
-DB_PORT=5432
-REDIS_HOST=redis
-REDIS_PORT=6379
-FFMPEG_HWACCEL=none
-FFMPEG_CPU_PRESET=veryfast
-FFMPEG_CPU_CRF=23
-ENVEOF
-    echo 'Created .env with local defaults'
-  fi
-fi
-
-echo 'Validating compose configuration...'
-"${COMPOSE_CMD[@]}" config >/dev/null
-
-echo 'Starting zTTato Platform (production profile)...'
-"${COMPOSE_CMD[@]}" up -d --build --remove-orphans
-
-echo 'Platform started.'
-"${COMPOSE_CMD[@]}" ps
+exec bash "$ROOT_DIR/scripts/start-zttato-platform.sh"


### PR DESCRIPTION
### Motivation

- Provide a single, opinionated lifecycle for local and production-style runs (install, start, upgrade, deploy) to reduce duplication across scripts.\
- Make workstation preparation idempotent and scriptable by adding an installer that creates `.env`, validates Compose, and optionally installs Node deps.\
- Add an explicit upgrade and deploy flow so image refresh, dependency refresh, and stack orchestration are separated and repeatable.\
- Simplify the existing helpers so the root `start.sh` and CLI wrapper delegate to the new manager for a consistent entrypoint.

### Description

- Added an installer script `scripts/install-zttato-platform.sh` that prepares `.env`, validates Compose availability, and installs Node dependencies when present.\
- Added a starter script `scripts/start-zttato-platform.sh` that validates Compose, builds and starts the stack, and performs basic smoke checks against gateway and core APIs.\
- Added an upgrade script `scripts/upgrade-zttato-platform.sh` that pulls published images, rebuilds local images, refreshes Node deps, and restarts the stack.\
- Added a deploy helper `scripts/deploy-zttato-platform.sh` that composes the installer, upgrade, and starter into a one-step deployment flow.\
- Added a unified manager CLI `scripts/zttato-manager.sh` providing `install`, `start`, `stop`, `restart`, `deploy`, `upgrade`, `status`, and `logs` commands.\
- Updated the lightweight CLI wrapper `scripts/zttato` to delegate lifecycle commands to `scripts/zttato-manager.sh` and preserved Node and edge helper actions.\
- Updated `start.sh` to forward to the new managed starter flow and documented the new commands in `README.md`, `docs/installation.md`, and `docs/quick-start.md`.

### Testing

- Ran shell syntax checks with `bash -n` against `start.sh` and all new manager/install/start/upgrade/deploy scripts and they passed.\
- Executed `bash scripts/zttato-manager.sh` to verify CLI usage and subcommand dispatch output, which produced the expected usage text.\
- Attempted `docker compose config` validation as part of the installer, but Docker/Compose is not available in the execution environment so end-to-end Compose validation and smoke-checking could not be performed here.\
- All new scripts are executable and were exercised locally in this environment to the extent allowed by host tooling availability.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa508bec48321a226b033304249ec)