### PR TITLE
Add deployment control-plane state machine and lifecycle API to master-orchestrator

### DIFF
--- a/docs/services/master-orchestrator.md
+++ b/docs/services/master-orchestrator.md
@@ -1,0 +1,67 @@
+# Master Orchestrator Service
+
+## Purpose
+
+The master orchestrator is the control-plane entrypoint for deployment lifecycle management and campaign operations.
+
+## Deployment Control-Plane Endpoints
+
+### `POST /deployments`
+Creates (or reuses) a deployment request using an `idempotency_key`.
+
+Request body:
+
+```json
+{
+  "project_id": "my-app",
+  "commit_sha": "a1b2c3d4",
+  "environment": "production",
+  "idempotency_key": "deploy-my-app-a1b2c3d4"
+}
+```
+
+Behavior:
+- Deterministic create: the same idempotency key always returns the same deployment record.
+- Emits a `deploy.requested` decision event.
+
+### `POST /deployments/events`
+Applies a state transition event to an existing deployment.
+
+Request body:
+
+```json
+{
+  "deployment_id": "<uuid>",
+  "event_type": "build.started",
+  "source": "ci-worker",
+  "metadata": {
+    "job_id": "1234"
+  }
+}
+```
+
+Behavior:
+- Validates transitions against the control-plane state machine.
+- Rejects invalid transitions with HTTP `409`.
+- Emits state transition events through the existing Kafka decision emitter.
+
+### `GET /deployments/{deployment_id}`
+Returns current deployment state and full transition history.
+
+## State Machine
+
+| Current State | Allowed Events | Next State |
+| --- | --- | --- |
+| `queued` | `build.started` | `building` |
+| `building` | `build.failed`, `build.succeeded` | `failed`, `deploying` |
+| `failed` | `ai.fix.started` | `fixing` |
+| `fixing` | `ai.fix.applied` | `building` |
+| `deploying` | `deploy.failed`, `deploy.succeeded` | `failed`, `succeeded` |
+| `succeeded` | _(none)_ | terminal |
+
+## Security and Reliability Notes
+
+- Input is schema-validated with Pydantic.
+- Idempotency key prevents duplicate deployment creation.
+- State transitions are guarded and deterministic.
+- Structured JSON logging is used for deployment events.

--- a/services/master-orchestrator/src/deployment_controller.py
+++ b/services/master-orchestrator/src/deployment_controller.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from threading import Lock
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger("deployment-controller")
+
+
+class DeploymentState(str, Enum):
+    queued = "queued"
+    building = "building"
+    failed = "failed"
+    fixing = "fixing"
+    deploying = "deploying"
+    succeeded = "succeeded"
+
+
+ALLOWED_TRANSITIONS: dict[DeploymentState, dict[str, DeploymentState]] = {
+    DeploymentState.queued: {
+        "build.started": DeploymentState.building,
+    },
+    DeploymentState.building: {
+        "build.failed": DeploymentState.failed,
+        "build.succeeded": DeploymentState.deploying,
+    },
+    DeploymentState.failed: {
+        "ai.fix.started": DeploymentState.fixing,
+    },
+    DeploymentState.fixing: {
+        "ai.fix.applied": DeploymentState.building,
+    },
+    DeploymentState.deploying: {
+        "deploy.failed": DeploymentState.failed,
+        "deploy.succeeded": DeploymentState.succeeded,
+    },
+    DeploymentState.succeeded: {},
+}
+
+
+class DeploymentCreateRequest(BaseModel):
+    project_id: str = Field(min_length=1, max_length=120)
+    commit_sha: str = Field(min_length=7, max_length=64)
+    environment: str = Field(default="production", min_length=2, max_length=32)
+    idempotency_key: str = Field(min_length=8, max_length=120)
+
+
+class DeploymentEventRequest(BaseModel):
+    deployment_id: str = Field(min_length=1)
+    event_type: str = Field(min_length=3, max_length=64)
+    source: str = Field(default="system", min_length=2, max_length=64)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class DeploymentRecord(BaseModel):
+    deployment_id: str
+    project_id: str
+    commit_sha: str
+    environment: str
+    state: DeploymentState
+    created_at: str
+    updated_at: str
+    history: list[dict[str, Any]] = Field(default_factory=list)
+
+
+@dataclass
+class DeploymentStore:
+    _deployments: dict[str, DeploymentRecord] = field(default_factory=dict)
+    _idempotency_index: dict[str, str] = field(default_factory=dict)
+    _lock: Lock = field(default_factory=Lock)
+
+    def _now_iso(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def create(self, payload: DeploymentCreateRequest) -> DeploymentRecord:
+        with self._lock:
+            if payload.idempotency_key in self._idempotency_index:
+                deployment_id = self._idempotency_index[payload.idempotency_key]
+                return self._deployments[deployment_id]
+
+            deployment_id = str(uuid4())
+            timestamp = self._now_iso()
+            record = DeploymentRecord(
+                deployment_id=deployment_id,
+                project_id=payload.project_id,
+                commit_sha=payload.commit_sha,
+                environment=payload.environment.lower(),
+                state=DeploymentState.queued,
+                created_at=timestamp,
+                updated_at=timestamp,
+                history=[
+                    {
+                        "event_type": "deployment.created",
+                        "source": "platform-core",
+                        "timestamp": timestamp,
+                        "metadata": {
+                            "project_id": payload.project_id,
+                            "commit_sha": payload.commit_sha,
+                            "environment": payload.environment.lower(),
+                        },
+                    }
+                ],
+            )
+            self._deployments[deployment_id] = record
+            self._idempotency_index[payload.idempotency_key] = deployment_id
+            self._log("deployment.created", deployment_id, {"state": record.state})
+            return record
+
+    def apply_event(self, payload: DeploymentEventRequest) -> DeploymentRecord:
+        with self._lock:
+            if payload.deployment_id not in self._deployments:
+                raise KeyError("deployment not found")
+
+            record = self._deployments[payload.deployment_id]
+            allowed = ALLOWED_TRANSITIONS.get(record.state, {})
+            if payload.event_type not in allowed:
+                raise ValueError(
+                    f"event {payload.event_type} is invalid when deployment is in state {record.state}"
+                )
+
+            next_state = allowed[payload.event_type]
+            timestamp = self._now_iso()
+            record.state = next_state
+            record.updated_at = timestamp
+            record.history.append(
+                {
+                    "event_type": payload.event_type,
+                    "source": payload.source,
+                    "timestamp": timestamp,
+                    "metadata": payload.metadata,
+                    "next_state": next_state,
+                }
+            )
+            self._log(payload.event_type, payload.deployment_id, {"next_state": next_state})
+            return record
+
+    def get(self, deployment_id: str) -> DeploymentRecord:
+        with self._lock:
+            if deployment_id not in self._deployments:
+                raise KeyError("deployment not found")
+            return self._deployments[deployment_id]
+
+    def _log(self, event_type: str, deployment_id: str, context: dict[str, Any]) -> None:
+        message = {
+            "event_type": event_type,
+            "deployment_id": deployment_id,
+            "context": context,
+            "timestamp": self._now_iso(),
+        }
+        logger.info(json.dumps(message, sort_keys=True))

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Literal
 from urllib.parse import quote
 
@@ -6,6 +7,11 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, HttpUrl
 
+from deployment_controller import (
+    DeploymentCreateRequest,
+    DeploymentEventRequest,
+    DeploymentStore,
+)
 from distributed_loop import run_cycle
 from economy_loop import run_economy
 from federated_loop import run_global_task
@@ -13,10 +19,12 @@ from kafka_producer import emit_decision
 
 app = FastAPI(title="Master Orchestrator")
 TIMEOUT = 10
+logging.basicConfig(level=logging.INFO)
 
 
 CLICK_TRACKER_URL = "http://click-tracker:8080"
 PAYMENT_GATEWAY_URL = "http://payment-gateway:8000"
+deployment_store = DeploymentStore()
 
 
 class PaymentConfig(BaseModel):
@@ -105,6 +113,54 @@ class FederatedTaskRequest(BaseModel):
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
     return {"status": "ok", "service": "master-orchestrator"}
+
+
+@app.post("/deployments")
+def create_deployment(payload: DeploymentCreateRequest) -> dict[str, Any]:
+    deployment = deployment_store.create(payload)
+    emit_decision(
+        {
+            "event_type": "deploy.requested",
+            "deployment_id": deployment.deployment_id,
+            "project_id": deployment.project_id,
+            "environment": deployment.environment,
+            "state": deployment.state,
+            "created_at": deployment.created_at,
+        }
+    )
+    return deployment.model_dump()
+
+
+@app.get("/deployments/{deployment_id}")
+def get_deployment(deployment_id: str) -> dict[str, Any]:
+    try:
+        deployment = deployment_store.get(deployment_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="deployment not found") from exc
+    return deployment.model_dump()
+
+
+@app.post("/deployments/events")
+def handle_deployment_event(payload: DeploymentEventRequest) -> dict[str, Any]:
+    try:
+        deployment = deployment_store.apply_event(payload)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="deployment not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    emit_decision(
+        {
+            "event_type": payload.event_type,
+            "deployment_id": deployment.deployment_id,
+            "project_id": deployment.project_id,
+            "environment": deployment.environment,
+            "state": deployment.state,
+            "updated_at": deployment.updated_at,
+            "source": payload.source,
+        }
+    )
+    return deployment.model_dump()
 
 
 


### PR DESCRIPTION
### Motivation
- Introduce a central, deterministic control plane to track deployment lifecycle and unify CI/deploy/AI-fix workers into a single orchestration flow.
- Prevent duplicate requests and invalid state transitions by enforcing idempotency and guarded transitions to improve reliability and auditability.
- Provide structured event hooks so other services (workers, analytics, AI fixers) can subscribe to deployment lifecycle events.

### Description
- Added a new `deployment_controller` module with Pydantic request/record schemas, an in-memory `DeploymentStore`, an explicit `DeploymentState` enum, and a guarded `ALLOWED_TRANSITIONS` state machine (`services/master-orchestrator/src/deployment_controller.py`).
- Extended `master-orchestrator` with new endpoints `POST /deployments`, `GET /deployments/{deployment_id}`, and `POST /deployments/events` that create idempotent deployments, apply validated state events, and emit decision events via the existing `emit_decision` emitter (`services/master-orchestrator/src/main.py`).
- Added operator documentation describing the API, transition table, and security/reliability notes (`docs/services/master-orchestrator.md`).
- Implemented structured JSON logging for deployment events and ensured operations are deterministic and thread-safe with a `Lock` protecting the in-memory store.

### Testing
- Compiled Python sources with `python -m py_compile services/master-orchestrator/src/main.py services/master-orchestrator/src/deployment_controller.py` and the command completed successfully.
- Performed a smoke test using `PYTHONPATH=services/master-orchestrator/src` to create a deployment and apply the transitions `build.started` → `build.succeeded` → `deploy.succeeded`, which reached `DeploymentState.succeeded` successfully.
- All automated validations executed during the rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0b3f4fad8832c8a521ab2d4f2cd5a)