### PR TITLE
Add free-tier microservice stack, Terraform deploy, and React dashboard

### DIFF
--- a/apps/api-gateway/Dockerfile
+++ b/apps/api-gateway/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+COPY src ./src
+RUN npm install
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@zttato/api-gateway",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "express": "^4.21.2",
+    "http-proxy-middleware": "^3.0.3",
+    "pino": "^9.7.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/api-gateway/src/index.ts
+++ b/apps/api-gateway/src/index.ts
@@ -1,0 +1,37 @@
+import express from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+import pino from "pino";
+
+const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
+const port = Number(process.env.API_GATEWAY_PORT ?? "3000");
+
+const coreTarget = process.env.PLATFORM_CORE_URL ?? "http://platform-core:4000";
+const workerAiTarget = process.env.WORKER_AI_URL ?? "http://worker-ai:5000";
+
+const app = express();
+
+app.get("/healthz", (_req, res) => {
+  res.status(200).json({ ok: true, service: "api-gateway" });
+});
+
+app.use(
+  "/core",
+  createProxyMiddleware({
+    target: coreTarget,
+    changeOrigin: true,
+    pathRewrite: { "^/core": "" },
+  }),
+);
+
+app.use(
+  "/ai",
+  createProxyMiddleware({
+    target: workerAiTarget,
+    changeOrigin: true,
+    pathRewrite: { "^/ai": "" },
+  }),
+);
+
+app.listen(port, () => {
+  logger.info({ port, coreTarget, workerAiTarget }, "api-gateway started");
+});

--- a/apps/api-gateway/tsconfig.json
+++ b/apps/api-gateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json vite.config.ts index.html ./
+COPY src ./src
+RUN npm install
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZTTATO Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@zttato/frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.23",
+    "@types/react-dom": "^18.3.7",
+    "@vitejs/plugin-react": "^4.6.0",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.5"
+  }
+}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+
+type DeployResponse = {
+  ok: boolean;
+  status?: string;
+  error?: string;
+};
+
+export default function App() {
+  const [project, setProject] = useState("");
+  const [status, setStatus] = useState("Idle");
+  const [isDeploying, setIsDeploying] = useState(false);
+
+  const deploy = async () => {
+    if (!project.trim()) {
+      setStatus("Project ID is required");
+      return;
+    }
+
+    setIsDeploying(true);
+    try {
+      const res = await fetch("/core/deploy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId: project.trim() }),
+      });
+
+      const data = (await res.json()) as DeployResponse;
+      if (!res.ok || !data.ok) {
+        setStatus(data.error ?? "Deployment request failed");
+        return;
+      }
+
+      setStatus(data.status ?? "QUEUED");
+    } catch {
+      setStatus("Network error while triggering deploy");
+    } finally {
+      setIsDeploying(false);
+    }
+  };
+
+  return (
+    <div style={{ padding: "2rem", fontFamily: "Arial, sans-serif", maxWidth: 680 }}>
+      <h1 style={{ fontSize: "1.8rem" }}>ZTTATO Dashboard</h1>
+      <p>Deploy your project to the platform orchestration pipeline.</p>
+
+      <input
+        style={{ width: "100%", padding: "0.6rem", marginTop: "1rem" }}
+        placeholder="Project ID"
+        onChange={(e) => setProject(e.target.value)}
+      />
+
+      <button
+        style={{ marginTop: "1rem", padding: "0.6rem 1rem" }}
+        onClick={deploy}
+        disabled={isDeploying}
+      >
+        {isDeploying ? "Deploying..." : "Deploy"}
+      </button>
+
+      <div style={{ marginTop: "1rem" }}>
+        <strong>Status:</strong> {status}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: "0.0.0.0",
+    port: 5173,
+  },
+});

--- a/apps/platform-core/Dockerfile
+++ b/apps/platform-core/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+COPY src ./src
+RUN npm install
+EXPOSE 4000
+CMD ["npm", "run", "dev"]

--- a/apps/platform-core/package.json
+++ b/apps/platform-core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@zttato/platform-core",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "express": "^4.21.2",
+    "kafkajs": "^2.2.4",
+    "pino": "^9.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/platform-core/src/index.ts
+++ b/apps/platform-core/src/index.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import { Kafka } from "kafkajs";
+import pino from "pino";
+import { z } from "zod";
+
+const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
+const port = Number(process.env.PLATFORM_CORE_PORT ?? "4000");
+const kafkaBrokers = (process.env.KAFKA_BROKERS ?? "kafka:9092")
+  .split(",")
+  .map((broker) => broker.trim())
+  .filter(Boolean);
+
+if (kafkaBrokers.length === 0) {
+  throw new Error("KAFKA_BROKERS must include at least one broker");
+}
+
+const deployPayloadSchema = z.object({
+  projectId: z.string().min(1).max(128),
+  branch: z.string().min(1).max(128).optional(),
+  actor: z.string().min(1).max(128).optional(),
+});
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+const kafka = new Kafka({ brokers: kafkaBrokers });
+const producer = kafka.producer();
+
+app.get("/healthz", (_req, res) => {
+  res.status(200).json({ ok: true, service: "platform-core" });
+});
+
+app.post("/deploy", async (req, res) => {
+  const parsed = deployPayloadSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: "Invalid request payload",
+      details: parsed.error.flatten(),
+    });
+  }
+
+  await producer.send({
+    topic: process.env.DEPLOY_TOPIC ?? "deploy.started",
+    messages: [{ value: JSON.stringify(parsed.data) }],
+  });
+
+  logger.info({ projectId: parsed.data.projectId }, "Deployment event published");
+  return res.status(202).json({ ok: true, status: "QUEUED" });
+});
+
+async function start() {
+  try {
+    await producer.connect();
+
+    const server = app.listen(port, () => {
+      logger.info({ port }, "platform-core started");
+    });
+
+    const shutdown = async (signal: string) => {
+      logger.info({ signal }, "Shutting down platform-core");
+      await producer.disconnect();
+      server.close(() => process.exit(0));
+    };
+
+    process.on("SIGTERM", () => {
+      void shutdown("SIGTERM");
+    });
+    process.on("SIGINT", () => {
+      void shutdown("SIGINT");
+    });
+  } catch (error) {
+    logger.error({ error }, "Failed to start platform-core");
+    process.exit(1);
+  }
+}
+
+void start();

--- a/apps/platform-core/tsconfig.json
+++ b/apps/platform-core/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apps/worker-ai/Dockerfile
+++ b/apps/worker-ai/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+COPY src ./src
+RUN npm install
+EXPOSE 5000
+CMD ["npm", "run", "dev"]

--- a/apps/worker-ai/package.json
+++ b/apps/worker-ai/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@zttato/worker-ai",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "express": "^4.21.2",
+    "openai": "^5.20.1",
+    "pino": "^9.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "tsx": "^4.20.5",
+    "typescript": "^5.9.2"
+  }
+}

--- a/apps/worker-ai/src/index.ts
+++ b/apps/worker-ai/src/index.ts
@@ -1,0 +1,61 @@
+import express from "express";
+import OpenAI from "openai";
+import pino from "pino";
+import { z } from "zod";
+
+const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
+const port = Number(process.env.WORKER_AI_PORT ?? "5000");
+const requestSchema = z.object({
+  logs: z.string().min(1).max(100_000),
+});
+
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) {
+  throw new Error("OPENAI_API_KEY is required");
+}
+
+const client = new OpenAI({ apiKey });
+
+const app = express();
+app.use(express.json({ limit: "2mb" }));
+
+app.get("/healthz", (_req, res) => {
+  res.status(200).json({ ok: true, service: "worker-ai" });
+});
+
+app.post("/fix", async (req, res) => {
+  const parsed = requestSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      ok: false,
+      error: "Invalid request payload",
+      details: parsed.error.flatten(),
+    });
+  }
+
+  const response = await client.chat.completions.create({
+    model: process.env.OPENAI_FIX_MODEL ?? "gpt-4.1-mini",
+    temperature: 0,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a software reliability assistant. Return concise remediation steps for the given logs.",
+      },
+      { role: "user", content: parsed.data.logs },
+    ],
+  });
+
+  const fix = response.choices[0]?.message?.content?.trim();
+  if (!fix) {
+    logger.warn("Model returned empty content");
+    return res.status(502).json({ ok: false, error: "No remediation output generated" });
+  }
+
+  return res.status(200).json({ ok: true, fix });
+});
+
+app.listen(port, () => {
+  logger.info({ port }, "worker-ai started");
+});

--- a/apps/worker-ai/tsconfig.json
+++ b/apps/worker-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.9"
+services:
+  kafka:
+    image: bitnami/kafka:3.7
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "echo > /dev/tcp/127.0.0.1/9092"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  platform-core:
+    build: ../apps/platform-core
+    ports:
+      - "4000:4000"
+    depends_on:
+      kafka:
+        condition: service_healthy
+    environment:
+      - KAFKA_BROKERS=kafka:9092
+
+  worker-ai:
+    build: ../apps/worker-ai
+    ports:
+      - "5000:5000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+
+  api-gateway:
+    build: ../apps/api-gateway
+    ports:
+      - "3000:3000"
+    depends_on:
+      - platform-core
+      - worker-ai
+
+  frontend:
+    build: ../apps/frontend
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api-gateway

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region for resources"
+  type        = string
+  default     = "us-central1"
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "zttato-free"
+  machine_type = "e2-micro"
+  zone         = "${var.region}-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-12"
+    }
+  }
+
+  network_interface {
+    network = "default"
+    access_config {}
+  }
+
+  tags = ["http-server"]
+
+  metadata_startup_script = <<-EOF
+    #!/bin/bash
+    set -eux
+    apt update
+    apt install -y docker.io docker-compose-v2 git
+    systemctl enable docker
+    systemctl start docker
+    cd /opt
+    rm -rf zttato-platform
+    git clone https://github.com/ZeaZDev/zttato-platform.git
+    cd zttato-platform
+    docker compose -f infra/docker-compose.yml up -d
+  EOF
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "zttato-platform",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "concurrently \"npm:dev:*\"",
+    "dev:platform-core": "npm --workspace apps/platform-core run dev",
+    "dev:worker-ai": "npm --workspace apps/worker-ai run dev",
+    "dev:api-gateway": "npm --workspace apps/api-gateway run dev",
+    "dev:frontend": "npm --workspace apps/frontend run dev",
+    "build": "npm run build -ws"
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.1"
+  }
+}

--- a/zttato-all-in.patch
+++ b/zttato-all-in.patch
@@ -1,0 +1,690 @@
+diff --git a/apps/api-gateway/Dockerfile b/apps/api-gateway/Dockerfile
+new file mode 100644
+index 0000000..d154269
+--- /dev/null
++++ b/apps/api-gateway/Dockerfile
+@@ -0,0 +1,7 @@
++FROM node:20-alpine
++WORKDIR /app
++COPY package.json tsconfig.json ./
++COPY src ./src
++RUN npm install
++EXPOSE 3000
++CMD ["npm", "run", "dev"]
+diff --git a/apps/api-gateway/package.json b/apps/api-gateway/package.json
+new file mode 100644
+index 0000000..32b3018
+--- /dev/null
++++ b/apps/api-gateway/package.json
+@@ -0,0 +1,19 @@
++{
++  "name": "@zttato/api-gateway",
++  "private": true,
++  "type": "module",
++  "scripts": {
++    "dev": "tsx watch src/index.ts",
++    "build": "tsc -p tsconfig.json"
++  },
++  "dependencies": {
++    "express": "^4.21.2",
++    "http-proxy-middleware": "^3.0.3",
++    "pino": "^9.7.0"
++  },
++  "devDependencies": {
++    "@types/express": "^4.17.21",
++    "tsx": "^4.20.5",
++    "typescript": "^5.9.2"
++  }
++}
+diff --git a/apps/api-gateway/src/index.ts b/apps/api-gateway/src/index.ts
+new file mode 100644
+index 0000000..238a8a6
+--- /dev/null
++++ b/apps/api-gateway/src/index.ts
+@@ -0,0 +1,37 @@
++import express from "express";
++import { createProxyMiddleware } from "http-proxy-middleware";
++import pino from "pino";
++
++const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
++const port = Number(process.env.API_GATEWAY_PORT ?? "3000");
++
++const coreTarget = process.env.PLATFORM_CORE_URL ?? "http://platform-core:4000";
++const workerAiTarget = process.env.WORKER_AI_URL ?? "http://worker-ai:5000";
++
++const app = express();
++
++app.get("/healthz", (_req, res) => {
++  res.status(200).json({ ok: true, service: "api-gateway" });
++});
++
++app.use(
++  "/core",
++  createProxyMiddleware({
++    target: coreTarget,
++    changeOrigin: true,
++    pathRewrite: { "^/core": "" },
++  }),
++);
++
++app.use(
++  "/ai",
++  createProxyMiddleware({
++    target: workerAiTarget,
++    changeOrigin: true,
++    pathRewrite: { "^/ai": "" },
++  }),
++);
++
++app.listen(port, () => {
++  logger.info({ port, coreTarget, workerAiTarget }, "api-gateway started");
++});
+diff --git a/apps/api-gateway/tsconfig.json b/apps/api-gateway/tsconfig.json
+new file mode 100644
+index 0000000..406f69d
+--- /dev/null
++++ b/apps/api-gateway/tsconfig.json
+@@ -0,0 +1,12 @@
++{
++  "compilerOptions": {
++    "target": "ES2022",
++    "module": "NodeNext",
++    "moduleResolution": "NodeNext",
++    "strict": true,
++    "esModuleInterop": true,
++    "skipLibCheck": true,
++    "outDir": "dist"
++  },
++  "include": ["src"]
++}
+diff --git a/apps/frontend/Dockerfile b/apps/frontend/Dockerfile
+new file mode 100644
+index 0000000..dfd2bd1
+--- /dev/null
++++ b/apps/frontend/Dockerfile
+@@ -0,0 +1,7 @@
++FROM node:20-alpine
++WORKDIR /app
++COPY package.json tsconfig.json vite.config.ts index.html ./
++COPY src ./src
++RUN npm install
++EXPOSE 5173
++CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]
+diff --git a/apps/frontend/index.html b/apps/frontend/index.html
+new file mode 100644
+index 0000000..71e5ed4
+--- /dev/null
++++ b/apps/frontend/index.html
+@@ -0,0 +1,12 @@
++<!doctype html>
++<html lang="en">
++  <head>
++    <meta charset="UTF-8" />
++    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
++    <title>ZTTATO Dashboard</title>
++  </head>
++  <body>
++    <div id="root"></div>
++    <script type="module" src="/src/main.tsx"></script>
++  </body>
++</html>
+diff --git a/apps/frontend/package.json b/apps/frontend/package.json
+new file mode 100644
+index 0000000..1a0e651
+--- /dev/null
++++ b/apps/frontend/package.json
+@@ -0,0 +1,20 @@
++{
++  "name": "@zttato/frontend",
++  "private": true,
++  "type": "module",
++  "scripts": {
++    "dev": "vite",
++    "build": "tsc -b && vite build"
++  },
++  "dependencies": {
++    "react": "^18.3.1",
++    "react-dom": "^18.3.1"
++  },
++  "devDependencies": {
++    "@types/react": "^18.3.23",
++    "@types/react-dom": "^18.3.7",
++    "@vitejs/plugin-react": "^4.6.0",
++    "typescript": "^5.9.2",
++    "vite": "^7.1.5"
++  }
++}
+diff --git a/apps/frontend/src/App.tsx b/apps/frontend/src/App.tsx
+new file mode 100644
+index 0000000..7ecc519
+--- /dev/null
++++ b/apps/frontend/src/App.tsx
+@@ -0,0 +1,66 @@
++import { useState } from "react";
++
++type DeployResponse = {
++  ok: boolean;
++  status?: string;
++  error?: string;
++};
++
++export default function App() {
++  const [project, setProject] = useState("");
++  const [status, setStatus] = useState("Idle");
++  const [isDeploying, setIsDeploying] = useState(false);
++
++  const deploy = async () => {
++    if (!project.trim()) {
++      setStatus("Project ID is required");
++      return;
++    }
++
++    setIsDeploying(true);
++    try {
++      const res = await fetch("/core/deploy", {
++        method: "POST",
++        headers: { "Content-Type": "application/json" },
++        body: JSON.stringify({ projectId: project.trim() }),
++      });
++
++      const data = (await res.json()) as DeployResponse;
++      if (!res.ok || !data.ok) {
++        setStatus(data.error ?? "Deployment request failed");
++        return;
++      }
++
++      setStatus(data.status ?? "QUEUED");
++    } catch {
++      setStatus("Network error while triggering deploy");
++    } finally {
++      setIsDeploying(false);
++    }
++  };
++
++  return (
++    <div style={{ padding: "2rem", fontFamily: "Arial, sans-serif", maxWidth: 680 }}>
++      <h1 style={{ fontSize: "1.8rem" }}>ZTTATO Dashboard</h1>
++      <p>Deploy your project to the platform orchestration pipeline.</p>
++
++      <input
++        style={{ width: "100%", padding: "0.6rem", marginTop: "1rem" }}
++        placeholder="Project ID"
++        onChange={(e) => setProject(e.target.value)}
++      />
++
++      <button
++        style={{ marginTop: "1rem", padding: "0.6rem 1rem" }}
++        onClick={deploy}
++        disabled={isDeploying}
++      >
++        {isDeploying ? "Deploying..." : "Deploy"}
++      </button>
++
++      <div style={{ marginTop: "1rem" }}>
++        <strong>Status:</strong> {status}
++      </div>
++    </div>
++  );
++}
+diff --git a/apps/frontend/src/main.tsx b/apps/frontend/src/main.tsx
+new file mode 100644
+index 0000000..3854929
+--- /dev/null
++++ b/apps/frontend/src/main.tsx
+@@ -0,0 +1,9 @@
++import React from "react";
++import ReactDOM from "react-dom/client";
++import App from "./App";
++
++ReactDOM.createRoot(document.getElementById("root")!).render(
++  <React.StrictMode>
++    <App />
++  </React.StrictMode>,
++);
+diff --git a/apps/frontend/tsconfig.json b/apps/frontend/tsconfig.json
+new file mode 100644
+index 0000000..6c0d67d
+--- /dev/null
++++ b/apps/frontend/tsconfig.json
+@@ -0,0 +1,12 @@
++{
++  "compilerOptions": {
++    "target": "ES2022",
++    "module": "ESNext",
++    "moduleResolution": "Bundler",
++    "jsx": "react-jsx",
++    "strict": true,
++    "skipLibCheck": true,
++    "types": ["vite/client"]
++  },
++  "include": ["src", "vite.config.ts"]
++}
+diff --git a/apps/frontend/vite.config.ts b/apps/frontend/vite.config.ts
+new file mode 100644
+index 0000000..6df0a78
+--- /dev/null
++++ b/apps/frontend/vite.config.ts
+@@ -0,0 +1,10 @@
++import { defineConfig } from "vite";
++import react from "@vitejs/plugin-react";
++
++export default defineConfig({
++  plugins: [react()],
++  server: {
++    host: "0.0.0.0",
++    port: 5173,
++  },
++});
+diff --git a/apps/platform-core/Dockerfile b/apps/platform-core/Dockerfile
+new file mode 100644
+index 0000000..e0efd83
+--- /dev/null
++++ b/apps/platform-core/Dockerfile
+@@ -0,0 +1,7 @@
++FROM node:20-alpine
++WORKDIR /app
++COPY package.json tsconfig.json ./
++COPY src ./src
++RUN npm install
++EXPOSE 4000
++CMD ["npm", "run", "dev"]
+diff --git a/apps/platform-core/package.json b/apps/platform-core/package.json
+new file mode 100644
+index 0000000..5241fee
+--- /dev/null
++++ b/apps/platform-core/package.json
+@@ -0,0 +1,20 @@
++{
++  "name": "@zttato/platform-core",
++  "private": true,
++  "type": "module",
++  "scripts": {
++    "dev": "tsx watch src/index.ts",
++    "build": "tsc -p tsconfig.json"
++  },
++  "dependencies": {
++    "express": "^4.21.2",
++    "kafkajs": "^2.2.4",
++    "pino": "^9.7.0",
++    "zod": "^3.24.2"
++  },
++  "devDependencies": {
++    "@types/express": "^4.17.21",
++    "tsx": "^4.20.5",
++    "typescript": "^5.9.2"
++  }
++}
+diff --git a/apps/platform-core/src/index.ts b/apps/platform-core/src/index.ts
+new file mode 100644
+index 0000000..3bfa926
+--- /dev/null
++++ b/apps/platform-core/src/index.ts
+@@ -0,0 +1,79 @@
++import express from "express";
++import { Kafka } from "kafkajs";
++import pino from "pino";
++import { z } from "zod";
++
++const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
++const port = Number(process.env.PLATFORM_CORE_PORT ?? "4000");
++const kafkaBrokers = (process.env.KAFKA_BROKERS ?? "kafka:9092")
++  .split(",")
++  .map((broker) => broker.trim())
++  .filter(Boolean);
++
++if (kafkaBrokers.length === 0) {
++  throw new Error("KAFKA_BROKERS must include at least one broker");
++}
++
++const deployPayloadSchema = z.object({
++  projectId: z.string().min(1).max(128),
++  branch: z.string().min(1).max(128).optional(),
++  actor: z.string().min(1).max(128).optional(),
++});
++
++const app = express();
++app.use(express.json({ limit: "1mb" }));
++
++const kafka = new Kafka({ brokers: kafkaBrokers });
++const producer = kafka.producer();
++
++app.get("/healthz", (_req, res) => {
++  res.status(200).json({ ok: true, service: "platform-core" });
++});
++
++app.post("/deploy", async (req, res) => {
++  const parsed = deployPayloadSchema.safeParse(req.body);
++
++  if (!parsed.success) {
++    return res.status(400).json({
++      ok: false,
++      error: "Invalid request payload",
++      details: parsed.error.flatten(),
++    });
++  }
++
++  await producer.send({
++    topic: process.env.DEPLOY_TOPIC ?? "deploy.started",
++    messages: [{ value: JSON.stringify(parsed.data) }],
++  });
++
++  logger.info({ projectId: parsed.data.projectId }, "Deployment event published");
++  return res.status(202).json({ ok: true, status: "QUEUED" });
++});
++
++async function start() {
++  try {
++    await producer.connect();
++
++    const server = app.listen(port, () => {
++      logger.info({ port }, "platform-core started");
++    });
++
++    const shutdown = async (signal: string) => {
++      logger.info({ signal }, "Shutting down platform-core");
++      await producer.disconnect();
++      server.close(() => process.exit(0));
++    };
++
++    process.on("SIGTERM", () => {
++      void shutdown("SIGTERM");
++    });
++    process.on("SIGINT", () => {
++      void shutdown("SIGINT");
++    });
++  } catch (error) {
++    logger.error({ error }, "Failed to start platform-core");
++    process.exit(1);
++  }
++}
++
++void start();
+diff --git a/apps/platform-core/tsconfig.json b/apps/platform-core/tsconfig.json
+new file mode 100644
+index 0000000..406f69d
+--- /dev/null
++++ b/apps/platform-core/tsconfig.json
+@@ -0,0 +1,12 @@
++{
++  "compilerOptions": {
++    "target": "ES2022",
++    "module": "NodeNext",
++    "moduleResolution": "NodeNext",
++    "strict": true,
++    "esModuleInterop": true,
++    "skipLibCheck": true,
++    "outDir": "dist"
++  },
++  "include": ["src"]
++}
+diff --git a/apps/worker-ai/Dockerfile b/apps/worker-ai/Dockerfile
+new file mode 100644
+index 0000000..197385c
+--- /dev/null
++++ b/apps/worker-ai/Dockerfile
+@@ -0,0 +1,7 @@
++FROM node:20-alpine
++WORKDIR /app
++COPY package.json tsconfig.json ./
++COPY src ./src
++RUN npm install
++EXPOSE 5000
++CMD ["npm", "run", "dev"]
+diff --git a/apps/worker-ai/package.json b/apps/worker-ai/package.json
+new file mode 100644
+index 0000000..ad0a7cd
+--- /dev/null
++++ b/apps/worker-ai/package.json
+@@ -0,0 +1,20 @@
++{
++  "name": "@zttato/worker-ai",
++  "private": true,
++  "type": "module",
++  "scripts": {
++    "dev": "tsx watch src/index.ts",
++    "build": "tsc -p tsconfig.json"
++  },
++  "dependencies": {
++    "express": "^4.21.2",
++    "openai": "^5.20.1",
++    "pino": "^9.7.0",
++    "zod": "^3.24.2"
++  },
++  "devDependencies": {
++    "@types/express": "^4.17.21",
++    "tsx": "^4.20.5",
++    "typescript": "^5.9.2"
++  }
++}
+diff --git a/apps/worker-ai/src/index.ts b/apps/worker-ai/src/index.ts
+new file mode 100644
+index 0000000..c5ace27
+--- /dev/null
++++ b/apps/worker-ai/src/index.ts
+@@ -0,0 +1,61 @@
++import express from "express";
++import OpenAI from "openai";
++import pino from "pino";
++import { z } from "zod";
++
++const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
++const port = Number(process.env.WORKER_AI_PORT ?? "5000");
++const requestSchema = z.object({
++  logs: z.string().min(1).max(100_000),
++});
++
++const apiKey = process.env.OPENAI_API_KEY;
++if (!apiKey) {
++  throw new Error("OPENAI_API_KEY is required");
++}
++
++const client = new OpenAI({ apiKey });
++
++const app = express();
++app.use(express.json({ limit: "2mb" }));
++
++app.get("/healthz", (_req, res) => {
++  res.status(200).json({ ok: true, service: "worker-ai" });
++});
++
++app.post("/fix", async (req, res) => {
++  const parsed = requestSchema.safeParse(req.body);
++
++  if (!parsed.success) {
++    return res.status(400).json({
++      ok: false,
++      error: "Invalid request payload",
++      details: parsed.error.flatten(),
++    });
++  }
++
++  const response = await client.chat.completions.create({
++    model: process.env.OPENAI_FIX_MODEL ?? "gpt-4.1-mini",
++    temperature: 0,
++    messages: [
++      {
++        role: "system",
++        content:
++          "You are a software reliability assistant. Return concise remediation steps for the given logs.",
++      },
++      { role: "user", content: parsed.data.logs },
++    ],
++  });
++
++  const fix = response.choices[0]?.message?.content?.trim();
++  if (!fix) {
++    logger.warn("Model returned empty content");
++    return res.status(502).json({ ok: false, error: "No remediation output generated" });
++  }
++
++  return res.status(200).json({ ok: true, fix });
++});
++
++app.listen(port, () => {
++  logger.info({ port }, "worker-ai started");
++});
+diff --git a/apps/worker-ai/tsconfig.json b/apps/worker-ai/tsconfig.json
+new file mode 100644
+index 0000000..406f69d
+--- /dev/null
++++ b/apps/worker-ai/tsconfig.json
+@@ -0,0 +1,12 @@
++{
++  "compilerOptions": {
++    "target": "ES2022",
++    "module": "NodeNext",
++    "moduleResolution": "NodeNext",
++    "strict": true,
++    "esModuleInterop": true,
++    "skipLibCheck": true,
++    "outDir": "dist"
++  },
++  "include": ["src"]
++}
+diff --git a/infra/docker-compose.yml b/infra/docker-compose.yml
+new file mode 100644
+index 0000000..c718372
+--- /dev/null
++++ b/infra/docker-compose.yml
+@@ -0,0 +1,51 @@
++version: "3.9"
++services:
++  kafka:
++    image: bitnami/kafka:3.7
++    environment:
++      - KAFKA_CFG_NODE_ID=1
++      - KAFKA_CFG_PROCESS_ROLES=broker,controller
++      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
++      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
++      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
++      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
++      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
++      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
++      - ALLOW_PLAINTEXT_LISTENER=yes
++    healthcheck:
++      test: ["CMD", "bash", "-lc", "echo > /dev/tcp/127.0.0.1/9092"]
++      interval: 10s
++      timeout: 5s
++      retries: 5
++
++  platform-core:
++    build: ../apps/platform-core
++    ports:
++      - "4000:4000"
++    depends_on:
++      kafka:
++        condition: service_healthy
++    environment:
++      - KAFKA_BROKERS=kafka:9092
++
++  worker-ai:
++    build: ../apps/worker-ai
++    ports:
++      - "5000:5000"
++    environment:
++      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
++
++  api-gateway:
++    build: ../apps/api-gateway
++    ports:
++      - "3000:3000"
++    depends_on:
++      - platform-core
++      - worker-ai
++
++  frontend:
++    build: ../apps/frontend
++    ports:
++      - "5173:5173"
++    depends_on:
++      - api-gateway
+diff --git a/infra/terraform/main.tf b/infra/terraform/main.tf
+new file mode 100644
+index 0000000..5164550
+--- /dev/null
++++ b/infra/terraform/main.tf
+@@ -0,0 +1,59 @@
++terraform {
++  required_version = ">= 1.6.0"
++
++  required_providers {
++    google = {
++      source  = "hashicorp/google"
++      version = "~> 5.0"
++    }
++  }
++}
++
++provider "google" {
++  project = var.project_id
++  region  = var.region
++}
++
++variable "project_id" {
++  description = "GCP project ID"
++  type        = string
++}
++
++variable "region" {
++  description = "GCP region for resources"
++  type        = string
++  default     = "us-central1"
++}
++
++resource "google_compute_instance" "vm" {
++  name         = "zttato-free"
++  machine_type = "e2-micro"
++  zone         = "${var.region}-a"
++
++  boot_disk {
++    initialize_params {
++      image = "debian-cloud/debian-12"
++    }
++  }
++
++  network_interface {
++    network = "default"
++    access_config {}
++  }
++
++  tags = ["http-server"]
++
++  metadata_startup_script = <<-EOF
++    #!/bin/bash
++    set -eux
++    apt update
++    apt install -y docker.io docker-compose-v2 git
++    systemctl enable docker
++    systemctl start docker
++    cd /opt
++    rm -rf zttato-platform
++    git clone https://github.com/ZeaZDev/zttato-platform.git
++    cd zttato-platform
++    docker compose -f infra/docker-compose.yml up -d
++  EOF
++}
+diff --git a/package.json b/package.json
+new file mode 100644
+index 0000000..f0140cf
+--- /dev/null
++++ b/package.json
+@@ -0,0 +1,19 @@
++{
++  "name": "zttato-platform",
++  "private": true,
++  "workspaces": [
++    "apps/*",
++    "packages/*"
++  ],
++  "scripts": {
++    "dev": "concurrently \"npm:dev:*\"",
++    "dev:platform-core": "npm --workspace apps/platform-core run dev",
++    "dev:worker-ai": "npm --workspace apps/worker-ai run dev",
++    "dev:api-gateway": "npm --workspace apps/api-gateway run dev",
++    "dev:frontend": "npm --workspace apps/frontend run dev",
++    "build": "npm run build -ws"
++  },
++  "devDependencies": {
++    "concurrently": "^9.2.1"
++  }
++}


### PR DESCRIPTION
### Motivation
- Provide a zero-cost MVP stack that boots a minimal event-driven platform, AI worker, API gateway, and frontend dashboard for demos and development. 
- Enable simple one-command local orchestration via `docker compose` and a free‑tier GCP VM bootstrap for cloud demo deployments. 
- Ship a workspace monorepo layout so the new apps can be run and built together. 

### Description
- Added workspace root `package.json` with dev scripts for running individual apps and the whole monorepo via `concurrently`. 
- Added four apps under `apps/`: `platform-core` (Express + Kafka producer, input schema validation, `/healthz` and `/deploy`), `worker-ai` (OpenAI client, structured logging, `/healthz` and `/fix` with strict payload validation), `api-gateway` (proxying `/core` and `/ai`), and `frontend` (React Vite dashboard to trigger deploys). 
- Added Dockerfiles for each app and an `infra/docker-compose.yml` that includes a Kafka service and composes the 4 services for local runs. 
- Added free-tier oriented Terraform at `infra/terraform/main.tf` which provisions a GCP `e2-micro` VM and bootstraps the repository via a startup script. 
- Generated `zttato-all-in.patch` containing the unified diff of all changes and committed the new files. 

### Testing
- Ran `git diff --check` which completed with no issues. 
- Attempted `docker compose -f infra/docker-compose.yml config` but it failed in this environment because the `docker` binary is not installed (`/bin/bash: line 1: docker: command not found`). 
- Attempted `terraform -chdir=infra/terraform fmt -check` but it failed because `terraform` is not installed in this environment (`/bin/bash: line 1: terraform: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0b6b364f8832cb7bf1c4d98542361)