### PR TITLE
Add full-stack installer, env template, and installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ bash scripts/zttato-manager.sh upgrade
 bash scripts/zttato-manager.sh deploy
 ```
 
+Or use the full-stack installer workflow:
+
+```bash
+bash installer/full-stack-installer.sh deploy
+```
+
 ### 3) Verify health
 
 ```bash
@@ -154,6 +160,7 @@ bash scripts/zttato-node.sh status
 - Installation: `docs/installation.md`
 - Quick start: `docs/quick-start.md`
 - Configuration: `docs/configuration.md`
+- Full-stack installer guide: `docs/full-stack-installation.md`
 
 ### Manuals
 - User manual: `docs/manuals/user-manual.md`

--- a/configs/env/full-stack.env.example
+++ b/configs/env/full-stack.env.example
@@ -1,0 +1,31 @@
+# Core database
+DB_NAME=zttato
+DB_USER=zttato
+DB_PASSWORD=replace-with-strong-password
+DB_PORT=5432
+
+# Cache and queue
+REDIS_HOST=redis
+REDIS_PORT=6379
+
+# Rendering defaults (CPU-safe)
+FFMPEG_HWACCEL=none
+FFMPEG_CPU_PRESET=veryfast
+FFMPEG_CPU_CRF=23
+
+# External execution integrations
+PLATFORM_API_BASE=https://api.partner.example
+PLATFORM_API_KEY=
+AFFILIATE_WEBHOOK_SECRET=change-me
+
+# Guardrails and runtime limits
+DEFAULT_DAILY_SPEND_LIMIT=100.0
+HTTP_TIMEOUT=10
+RATE_TOKENS=60
+RATE_MAX_TOKENS=120
+RATE_REFILL_PER_SEC=1
+
+# Optional platform ports
+NGINX_PORT=80
+POSTGRES_PORT=5432
+REDIS_PORT_HOST=6379

--- a/docs/full-stack-installation.md
+++ b/docs/full-stack-installation.md
@@ -1,0 +1,103 @@
+# Full-Stack Install + Config + Starter + Deploy Guide
+
+This guide provides a single deterministic workflow to install, configure, start, verify, and manage the zTTato full stack locally using Docker Compose.
+
+## What this includes
+
+- **Installer**: `installer/full-stack-installer.sh`
+- **Config template**: `configs/env/full-stack.env.example`
+- **Starter flow**: Compose build + up + health checks
+- **Deploy flow**: prerequisite checks + config + startup + verification
+- **Operations**: stop and uninstall commands
+
+## 1) Prerequisites
+
+Required commands:
+
+- `bash`
+- `docker`
+- Docker Compose v2 plugin (`docker compose`) or `docker-compose`
+- `curl`
+- `python3`
+- `git`
+
+Verify quickly:
+
+```bash
+bash installer/full-stack-installer.sh prereq
+```
+
+## 2) Configure environment
+
+Generate a root `.env` from the secure template:
+
+```bash
+bash installer/full-stack-installer.sh config
+```
+
+Then update `.env` values before deployment.
+
+Mandatory security changes:
+
+- Set `DB_PASSWORD` to a strong value.
+- Set `AFFILIATE_WEBHOOK_SECRET` to a strong value.
+- Set `PLATFORM_API_KEY` if execution integrations are needed.
+
+## 3) Full deployment (one command)
+
+```bash
+bash installer/full-stack-installer.sh deploy
+```
+
+The deploy command performs:
+
+1. Host prerequisite validation
+2. `.env` creation (if missing)
+3. Environment security checks
+4. `docker compose up -d --build --remove-orphans`
+5. Critical service health probes
+
+## 4) Starter-only mode
+
+If `.env` already exists and is valid:
+
+```bash
+bash installer/full-stack-installer.sh starter
+```
+
+## 5) Verify stack health
+
+```bash
+bash installer/full-stack-installer.sh verify
+```
+
+Health probes include:
+
+- `http://localhost/`
+- `http://localhost:9100/healthz`
+- `http://localhost:9400/healthz`
+- `http://localhost:9500/healthz`
+- `http://localhost:9300/healthz`
+
+## 6) Stop or uninstall
+
+Stop (preserve data volumes):
+
+```bash
+bash installer/full-stack-installer.sh stop
+```
+
+Stop and delete all volumes:
+
+```bash
+bash installer/full-stack-installer.sh uninstall
+```
+
+## 7) Recommended production adaptation
+
+For production-like deployments:
+
+- Run with dedicated secrets management (vault/external secret store).
+- Keep `.env` outside source control.
+- Front services with TLS-enabled ingress/reverse proxy.
+- Run security scanning and tests in CI before deployment.

--- a/installer/full-stack-installer.sh
+++ b/installer/full-stack-installer.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_TEMPLATE="$ROOT_DIR/configs/env/full-stack.env.example"
+ENV_FILE="$ROOT_DIR/.env"
+COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
+
+LOG_PREFIX="[full-stack-installer]"
+
+log() {
+  printf '%s %s\n' "$LOG_PREFIX" "$*"
+}
+
+fail() {
+  printf '%s ERROR: %s\n' "$LOG_PREFIX" "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash installer/full-stack-installer.sh <command>
+
+Commands:
+  prereq      Validate host requirements for full-stack installation.
+  config      Create .env from full-stack template if it does not exist.
+  starter     Build and start the Docker Compose stack.
+  deploy      Install dependencies, configure environment, and start stack.
+  verify      Run health checks for gateway and critical services.
+  stop        Stop the stack (preserve volumes).
+  uninstall   Stop stack and delete persistent volumes.
+  help        Show this help message.
+
+Examples:
+  bash installer/full-stack-installer.sh deploy
+  bash installer/full-stack-installer.sh verify
+USAGE
+}
+
+require_cmd() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || fail "Missing required command: $cmd"
+}
+
+compose_cmd() {
+  if docker compose version >/dev/null 2>&1; then
+    docker compose "$@"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose "$@"
+  else
+    fail "Docker Compose is required. Install Docker Compose v2 plugin or docker-compose."
+  fi
+}
+
+check_prereqs() {
+  require_cmd bash
+  require_cmd docker
+  require_cmd curl
+  require_cmd python3
+  require_cmd git
+
+  if ! docker info >/dev/null 2>&1; then
+    fail "Docker daemon is not reachable. Start Docker and rerun."
+  fi
+
+  [[ -f "$COMPOSE_FILE" ]] || fail "Missing docker-compose.yml at repository root."
+  [[ -f "$ENV_TEMPLATE" ]] || fail "Missing template env file: $ENV_TEMPLATE"
+
+  log "Prerequisite validation passed."
+}
+
+create_env_if_needed() {
+  if [[ -f "$ENV_FILE" ]]; then
+    log ".env already exists; keeping existing values."
+    return
+  fi
+
+  cp "$ENV_TEMPLATE" "$ENV_FILE"
+  log "Created .env from template: configs/env/full-stack.env.example"
+  log "Edit .env before production deployment, especially secrets and external API endpoints."
+}
+
+validate_env_security() {
+  if [[ ! -f "$ENV_FILE" ]]; then
+    fail "Missing .env. Run 'config' command first."
+  fi
+
+  if rg -q '^AFFILIATE_WEBHOOK_SECRET=change-me$' "$ENV_FILE"; then
+    fail "AFFILIATE_WEBHOOK_SECRET is using default 'change-me'. Update .env before deploy."
+  fi
+
+  if rg -q '^PLATFORM_API_KEY=$' "$ENV_FILE"; then
+    log "PLATFORM_API_KEY is empty; external execution-engine integrations may fail until configured."
+  fi
+
+  log "Environment validation passed."
+}
+
+start_stack() {
+  log "Validating compose configuration."
+  compose_cmd config >/dev/null
+
+  log "Building and starting the full stack."
+  compose_cmd up -d --build --remove-orphans
+
+  log "Current stack status."
+  compose_cmd ps
+}
+
+health_probe() {
+  local name="$1"
+  local url="$2"
+
+  if curl --fail --silent --show-error --max-time 10 "$url" >/dev/null; then
+    log "Health OK: $name ($url)"
+  else
+    fail "Health FAILED: $name ($url)"
+  fi
+}
+
+verify_stack() {
+  health_probe "gateway" "http://localhost/"
+  health_probe "viral-predictor" "http://localhost:9100/healthz"
+  health_probe "market-crawler" "http://localhost:9400/healthz"
+  health_probe "arbitrage-engine" "http://localhost:9500/healthz"
+  health_probe "gpu-renderer" "http://localhost:9300/healthz"
+  log "All critical health probes passed."
+}
+
+stop_stack() {
+  log "Stopping stack (volumes preserved)."
+  compose_cmd down
+}
+
+uninstall_stack() {
+  log "Stopping stack and deleting volumes."
+  compose_cmd down -v --remove-orphans
+}
+
+run_deploy() {
+  check_prereqs
+  create_env_if_needed
+  validate_env_security
+  start_stack
+  verify_stack
+  log "Full-stack deployment completed successfully."
+}
+
+main() {
+  local cmd="${1:-help}"
+
+  case "$cmd" in
+    prereq)
+      check_prereqs
+      ;;
+    config)
+      check_prereqs
+      create_env_if_needed
+      ;;
+    starter)
+      check_prereqs
+      validate_env_security
+      start_stack
+      ;;
+    deploy)
+      run_deploy
+      ;;
+    verify)
+      verify_stack
+      ;;
+    stop)
+      stop_stack
+      ;;
+    uninstall)
+      uninstall_stack
+      ;;
+    help|-h|--help)
+      usage
+      ;;
+    *)
+      usage
+      fail "Unknown command: $cmd"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
### Motivation
- Provide a single, deterministic path to deploy, configure, start, verify, and manage the full zTTato stack locally with production-safe guardrails.
- Make it trivial for operators to bootstrap a repeatable environment and surface required security edits before deployment.

### Description
- Add a shell installer entrypoint `installer/full-stack-installer.sh` implementing lifecycle commands `prereq`, `config`, `starter`, `deploy`, `verify`, `stop`, and `uninstall` with compose validation and health probes.
- Add a reusable environment template at `configs/env/full-stack.env.example` used to generate a repository root `.env` safely.
- Add a user-facing guide `docs/full-stack-installation.md` documenting the installer commands, required edits, and operational workflows.
- Update `README.md` to reference the new one-command full-stack deploy flow and the new installation guide.

### Testing
- Performed a shell syntax check: `bash -n installer/full-stack-installer.sh scripts/install-zttato-platform.sh scripts/start-zttato-platform.sh scripts/deploy-zttato-platform.sh` which passed.
- Verified the installer help output with `bash installer/full-stack-installer.sh help` which produced the expected usage text.
- Executed `bash installer/full-stack-installer.sh prereq` which intentionally failed in the CI/container environment due to missing `docker`, confirming prerequisite guardrails are enforced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c35b5018832cbc4ee4be76c578bb)