### PR TITLE
Harden model-service Dockerfile APT install with retry/backoff

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -11,9 +11,15 @@ ENV OMP_NUM_THREADS=1 \
     PYTHONUNBUFFERED=1 \
     ENABLE_SGX=${ENABLE_SGX}
 
-RUN apt-get update && apt-get install -y \
-    libgomp1 \
-    && rm -rf /var/lib/apt/lists/*
+RUN set -eux; \
+    attempts=0; \
+    until [ "$attempts" -ge 5 ]; do \
+      apt-get update && break; \
+      attempts=$((attempts + 1)); \
+      sleep $((attempts * 2)); \
+    done; \
+    apt-get install -y --no-install-recommends libgomp1; \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 


### PR DESCRIPTION
### Motivation
- Prevent transient `apt-get update` failures from causing Docker build errors (exit code 100) during image creation for `services/model-service`.

### Description
- Replace single-shot `apt-get update && apt-get install -y libgomp1` with a retry/backoff loop (up to 5 attempts), add `set -eux`, use `--no-install-recommends` for a minimal install, and preserve `rm -rf /var/lib/apt/lists/*` cleanup in `services/model-service/Dockerfile`.

### Testing
- Attempted to build the image with `docker build -t model-service-test -f services/model-service/Dockerfile services/model-service`, which could not run in this environment because the Docker CLI/daemon is unavailable (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c72784c4832ca004639ad96c0b5c)