### PR TITLE
Use temporary apt cache in model-service Dockerfile to avoid /var/cache space errors

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -18,8 +18,9 @@ RUN set -eux; \
       attempts=$((attempts + 1)); \
       sleep $((attempts * 2)); \
     done; \
-    apt-get install -y --no-install-recommends libgomp1; \
-    rm -rf /var/lib/apt/lists/*
+    mkdir -p /tmp/apt-cache/archives/partial; \
+    apt-get -o Dir::Cache::archives=/tmp/apt-cache/archives install -y --no-install-recommends libgomp1; \
+    rm -rf /var/lib/apt/lists/* /tmp/apt-cache
 
 COPY requirements.txt .
 


### PR DESCRIPTION
### Motivation
- Image builds for `services/model-service` were failing with `You don't have enough free space in /var/cache/apt/archives` when installing `libgomp1`, so the Dockerfile must avoid writing apt archives to `/var/cache` in constrained build environments.

### Description
- Updated `services/model-service/Dockerfile` to create `/tmp/apt-cache/archives/partial`, install `libgomp1` using `apt-get -o Dir::Cache::archives=/tmp/apt-cache/archives`, and clean up `/tmp/apt-cache` and `/var/lib/apt/lists` after install while preserving the existing `apt-get update` retry loop.

### Testing
- Attempted automated image build with `docker build -f services/model-service/Dockerfile services/model-service -t zttato-model-service:test`, which could not be executed in this environment because the Docker CLI is unavailable (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0c7f6c42c832cafd26dab7a491f82)