### PR TITLE
Fix model-service apt install retry logic in Dockerfile

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -12,14 +12,22 @@ ENV OMP_NUM_THREADS=1 \
     ENABLE_SGX=${ENABLE_SGX}
 
 RUN set -eux; \
-    attempts=0; \
-    until [ "$attempts" -ge 5 ]; do \
-      apt-get update && break; \
-      attempts=$((attempts + 1)); \
+    mkdir -p /tmp/apt-cache/archives/partial; \
+    install_ok=0; \
+    for attempts in 1 2 3 4 5; do \
+      if apt-get update \
+        && apt-get -o Dir::Cache::archives=/tmp/apt-cache/archives install -y --no-install-recommends libgomp1; then \
+        install_ok=1; \
+        break; \
+      fi; \
+      echo "apt-get failed on attempt ${attempts}; retrying..."; \
+      rm -rf /var/lib/apt/lists/*; \
       sleep $((attempts * 2)); \
     done; \
-    mkdir -p /tmp/apt-cache/archives/partial; \
-    apt-get -o Dir::Cache::archives=/tmp/apt-cache/archives install -y --no-install-recommends libgomp1; \
+    if [ "$install_ok" -ne 1 ]; then \
+      echo "Failed to install libgomp1 after 5 attempts"; \
+      exit 1; \
+    fi; \
     rm -rf /var/lib/apt/lists/* /tmp/apt-cache
 
 COPY requirements.txt .


### PR DESCRIPTION
### Motivation
- The original Dockerfile retried only `apt-get update` but proceeded to `apt-get install` regardless of update success, which could produce opaque `exit code: 100` failures during image builds. 
- Transient network or apt mirror issues during CI/CD image builds need deterministic retry behavior to improve reliability. 
- Clear failure semantics are required so build pipelines fail loudly and predictably when package installation cannot be completed.

### Description
- Replaced the previous `until` loop with a bounded `for attempts in 1 2 3 4 5` loop that runs both `apt-get update` and `apt-get install` together in a single conditional. 
- Added an `install_ok` guard and an explicit `exit 1` after five unsuccessful attempts to ensure deterministic failure when installation cannot succeed. 
- Preserved and improved cleanup of apt metadata by removing `/var/lib/apt/lists/*` between retries and at completion, and added an informational `echo` on retry attempts. 
- Kept the apt cache path (`/tmp/apt-cache/archives/partial`) usage to minimize repeated downloads and match original behavior.

### Testing
- Attempted to run `docker build -f services/model-service/Dockerfile services/model-service -t zttato-model-service:test`, which failed in this environment because the `docker` binary is not available (automated build could not be executed here). 
- Ran repository/file checks to confirm the `services/model-service/Dockerfile` was updated as intended and the new logic is present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0ca078520832cabae8833a3045d19)