### PR TITLE
fix(model-service): switch to bullseye base and simplify libgomp install

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.11-slim-bullseye
 
 WORKDIR /app
 
@@ -12,23 +12,11 @@ ENV OMP_NUM_THREADS=1 \
     ENABLE_SGX=${ENABLE_SGX}
 
 RUN set -eux; \
-    mkdir -p /tmp/apt-cache/archives/partial; \
-    install_ok=0; \
-    for attempts in 1 2 3 4 5; do \
-      if apt-get update \
-        && apt-get -o Dir::Cache::archives=/tmp/apt-cache/archives install -y --no-install-recommends libgomp1; then \
-        install_ok=1; \
-        break; \
-      fi; \
-      echo "apt-get failed on attempt ${attempts}; retrying..."; \
-      rm -rf /var/lib/apt/lists/*; \
-      sleep $((attempts * 2)); \
-    done; \
-    if [ "$install_ok" -ne 1 ]; then \
-      echo "Failed to install libgomp1 after 5 attempts"; \
-      exit 1; \
-    fi; \
-    rm -rf /var/lib/apt/lists/* /tmp/apt-cache
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      libgomp1; \
+    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 


### PR DESCRIPTION
### Motivation
- Builds were hard-failing when installing `libgomp1` via a 5-retry apt loop, indicating an underlying base-image or network issue that retries were masking.
- Use a known Debian variant and a deterministic, minimal install step to make failures actionable and easier to debug in CI.

### Description
- Changed `services/model-service/Dockerfile` base from `python:3.12-slim` to `python:3.11-slim-bullseye` for predictable Debian package availability.
- Removed the custom retry/cache loop and replaced it with a straightforward sequence: `export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install -y --no-install-recommends libgomp1; rm -rf /var/lib/apt/lists/*`.
- Kept package installation minimal to reduce image size and retained apt metadata cleanup for parity with production-safe images.

### Testing
- Attempted `docker build --no-cache -f services/model-service/Dockerfile services/model-service`, which could not be executed in this environment because the `docker` binary is not available (build not run locally); CI should validate the image build and downstream compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d1afe1f8832c841ed5b1e0205918)