### PR TITLE
fix(model-service): switch to Debian bookworm Python base image

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
### Motivation
- Resolve Docker build failure where `apt-get install libgomp1` returned exit code 100 on the older `python:3.11-slim-bullseye` base by using a newer Debian base.

### Description
- Update `services/model-service/Dockerfile` to use `FROM python:3.11-slim-bookworm` in place of `python:3.11-slim-bullseye`, leaving the rest of the Dockerfile unchanged.

### Testing
- Attempted `docker build` could not be executed in this environment because Docker is not installed (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d31c225c832c910297588d8eed90)