### PR TITLE
fix(model-service): stabilize Docker build by removing apt dependency

### DIFF
--- a/services/model-service/Dockerfile
+++ b/services/model-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm
+FROM python:3.11-bookworm
 
 WORKDIR /app
 
@@ -10,13 +10,6 @@ ENV OMP_NUM_THREADS=1 \
     ORT_ENABLE_CPU_MEM_ARENA=1 \
     PYTHONUNBUFFERED=1 \
     ENABLE_SGX=${ENABLE_SGX}
-
-RUN set -eux; \
-    export DEBIAN_FRONTEND=noninteractive; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends \
-      libgomp1; \
-    rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 


### PR DESCRIPTION
### Motivation
- The model-service image build was failing during `apt-get update` with Debian InRelease signature validation errors in constrained/mirrored build environments, so the Dockerfile should avoid relying on `apt` during build.

### Description
- Switched `services/model-service/Dockerfile` base image from `python:3.11-slim-bookworm` to `python:3.11-bookworm` and removed the `apt-get update && apt-get install libgomp1` layer so the image no longer depends on external apt repository operations at build time.

### Testing
- Attempted to build the image with `docker build -f services/model-service/Dockerfile services/model-service -t zttato-model-service:test`, but the runtime environment does not have Docker installed (`docker: command not found`), so no automated image build or CI tests were executed here and validation should be performed in CI or on the target host.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e2a93dc0832cb2c8a120e3ebc8fb)