### PR TITLE
fix(model-service): resolve numpy dependency conflict during image build

### DIFF
--- a/services/model-service/requirements.txt
+++ b/services/model-service/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.116.1
 uvicorn==0.35.0
 pydantic==2.11.7
-numpy==1.26.4
+numpy==2.0.2
 torch==2.8.0
 confluent-kafka==2.5.0
 redis==5.0.4


### PR DESCRIPTION
### Motivation
- Docker image build for `model-service` failed with a pip `ResolutionImpossible` due to the pinned `numpy` version not satisfying `feast==0.54.0`'s `numpy>=2.0.0,<3` constraint.

### Description
- Update `services/model-service/requirements.txt` to change `numpy==1.26.4` to `numpy==2.0.2` so the requirements satisfy both `feast==0.54.0` and `onnxruntime==1.18.0`.

### Testing
- Attempted a dry-run install with `pip install --dry-run -r services/model-service/requirements.txt` inside an isolated venv, but full dependency resolution could not complete due to proxy/network restrictions in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f5617b68832c9a025dd118b43053)