### PR TITLE
fix(model-service): align pydantic version with feast 0.54.0

### DIFF
--- a/services/model-service/requirements.txt
+++ b/services/model-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.116.1
 uvicorn==0.35.0
-pydantic==2.11.7
+pydantic==2.10.6
 numpy==2.0.2
 torch==2.8.0
 confluent-kafka==2.5.0


### PR DESCRIPTION
### Motivation
- Resolve dependency resolution failure during `model-service` image build caused by `feast==0.54.0` requiring `pydantic==2.10.6` while `requirements.txt` pinned `pydantic==2.11.7`.

### Description
- Updated `services/model-service/requirements.txt` to pin `pydantic==2.10.6` (replacing `2.11.7`) to make pip dependency resolution consistent and committed the change.

### Testing
- Ran `python3 -m pip install --dry-run -r services/model-service/requirements.txt` which failed due to proxy/network restrictions so dependency resolution could not be fully validated, and an attempted `docker build` could not be executed because the `docker` CLI was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0fb9e968c832c8ef63cd6f6ad5681)