### PR TITLE
fix(model-service): pin uvicorn to 0.34.0 for feast compatibility

### DIFF
--- a/services/model-service/requirements.txt
+++ b/services/model-service/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.116.1
-uvicorn==0.35.0
+uvicorn==0.34.0
 pydantic==2.10.6
 numpy==2.0.2
 torch==2.2.2


### PR DESCRIPTION
### Motivation
- Align the model-service dependency set with the most restrictive transitive constraint (Feast `feast==0.54.0`) to immediately resolve resolver drift and unblock deterministic builds by matching the highest common `uvicorn` version.

### Description
- Update `services/model-service/requirements.txt` to change `uvicorn==0.35.0` to `uvicorn==0.34.0` to satisfy Feast compatibility and avoid runtime dependency poisoning.

### Testing
- Attempted an automated dependency verification with `python -m pip install --dry-run -r services/model-service/requirements.txt`, which could not complete due to outbound package-index network/proxy restrictions (`403 Forbidden`), so install verification did not succeed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1003ccacc832cbad65b9af14094b3)