### PR TITLE
Fix RTB Engine startup by vendoring RL/analytics helpers

### DIFF
--- a/services/rtb-engine/src/causal_rl.py
+++ b/services/rtb-engine/src/causal_rl.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def doubly_robust(reward: float, propensity: float, model_pred: float) -> float:
+    safe_propensity = max(float(propensity), 1e-6)
+    baseline = float(model_pred)
+    observed_reward = float(reward)
+    return baseline + ((observed_reward - baseline) / safe_propensity)

--- a/services/rtb-engine/src/hierarchical_rl.py
+++ b/services/rtb-engine/src/hierarchical_rl.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class HierarchicalRL:
+    def __init__(self, dim: int = 2, lr: float = 0.01) -> None:
+        self.lr = float(lr)
+        self.campaign_w = [0.1 * (index + 1) for index in range(dim)]
+        self.adset_w = [0.05 * (index + 1) for index in range(dim)]
+        self.creative_w = [0.2 * (index + 1) for index in range(dim)]
+
+    @staticmethod
+    def _dot(lhs: list[float], rhs: list[float]) -> float:
+        return float(sum(a * b for a, b in zip(lhs, rhs)))
+
+    @staticmethod
+    def _vector(values: Iterable[float]) -> list[float]:
+        return [float(value) for value in values]
+
+    def select(self, x: Iterable[float]) -> dict[str, int]:
+        vector = self._vector(x)
+        return {
+            "campaign": int(self._dot(self.campaign_w, vector) > 0.0),
+            "adset": int(self._dot(self.adset_w, vector) > 0.0),
+            "creative": int(self._dot(self.creative_w, vector) > 0.0),
+        }
+
+    def update(self, x: Iterable[float], reward: float, lr: float | None = None) -> None:
+        vector = self._vector(x)
+        step = self.lr if lr is None else float(lr)
+        delta = [step * float(reward) * value for value in vector]
+        self.campaign_w = [weight + change for weight, change in zip(self.campaign_w, delta)]
+        self.adset_w = [weight + change for weight, change in zip(self.adset_w, delta)]
+        self.creative_w = [weight + change for weight, change in zip(self.creative_w, delta)]

--- a/services/rtb-engine/src/long_term_reward.py
+++ b/services/rtb-engine/src/long_term_reward.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def long_term_reward(short_term: float, ltv: float, discount: float = 0.9) -> float:
+    return float(short_term) + (float(discount) * float(ltv))

--- a/services/rtb-engine/src/ltv_model.py
+++ b/services/rtb-engine/src/ltv_model.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+class LTVModel:
+    def predict(self, features: Iterable[float]) -> float:
+        vector = [float(value) for value in features]
+        coeffs = [1.2, 0.8]
+        return float(sum(value * coeff for value, coeff in zip(vector, coeffs)))

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -1,23 +1,17 @@
 from __future__ import annotations
 
-from pathlib import Path
-import sys
 from typing import Any
 
-import uvicorn
-from fastapi import FastAPI
-from pydantic import BaseModel, Field
+from pathlib import Path
+import sys
 
 CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
     sys.path.insert(0, str(CURRENT_DIR))
 
-REPO_ROOT = CURRENT_DIR.parents[2]
-RL_TRAINER_SRC = REPO_ROOT / "services" / "rl-trainer" / "src"
-ANALYTICS_DIR = REPO_ROOT / "services" / "analytics"
-for extra_path in (RL_TRAINER_SRC, ANALYTICS_DIR):
-    if str(extra_path) not in sys.path:
-        sys.path.insert(0, str(extra_path))
+import uvicorn
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
 
 from causal_rl import doubly_robust
 from hierarchical_rl import HierarchicalRL


### PR DESCRIPTION
### Motivation
- The RTB engine container failed health checks because it imported helper modules from sibling services that are not available inside its Docker build context. 
- Startup behavior used non-deterministic initialization for the hierarchical RL component which is undesirable for reproducible service boot. 

### Description
- Removed repository-root path stitching in `services/rtb-engine/src/main.py` and made the service import helpers from its own `src` folder. 
- Vendored runtime helpers into `services/rtb-engine/src`: `causal_rl.py`, `hierarchical_rl.py`, `long_term_reward.py`, and `ltv_model.py`. 
- Replaced random weight initialization in `HierarchicalRL` with fixed deterministic coefficients to avoid non-reproducible startup state. 

### Testing
- Ran unit/integration tests with `pytest -q tests/test_advanced_rl_features.py tests/test_distributed_rl_stack.py tests/test_autonomous_rl_services.py` which completed successfully (`10 passed, 5 skipped`). 
- Attempted to validate the container with `docker compose up -d --build rtb-engine`, but this could not be executed in the CI environment because the Docker CLI was not available (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c10decdbb4832cb5e27eb14bd1acbb)