### PR TITLE
Add core-mode startup to reduce Docker disk usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ Or use the repository bootstrap helper:
 
 ```bash
 bash start.sh
+bash scripts/start-zttato-platform.sh --core   # reduced footprint mode
 ```
+
+> `--core` starts only the essential runtime services (postgres, redis, API edge and workers) so low-disk hosts avoid building the full 30+ image stack.
 
 Or use the new platform manager flows:
 

--- a/scripts/start-zttato-platform.sh
+++ b/scripts/start-zttato-platform.sh
@@ -7,6 +7,19 @@ cd "$ROOT_DIR"
 log(){ printf '[start] %s\n' "$*"; }
 fail(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
+readonly CORE_SERVICES=(
+  postgres
+  redis
+  viral-predictor
+  market-crawler
+  arbitrage-engine
+  gpu-renderer
+  crawler-worker
+  arbitrage-worker
+  renderer-worker
+  nginx
+)
+
 compose_cmd(){
   if docker compose version >/dev/null 2>&1; then
     docker compose "$@"
@@ -21,6 +34,45 @@ ensure_env(){
   [[ -f .env ]] || bash "$ROOT_DIR/scripts/install-zttato-platform.sh"
 }
 
+print_usage(){
+  cat <<'USAGE'
+Usage: start-zttato-platform.sh [--core|--full]
+
+Modes:
+  --core  Start only core runtime services to reduce build/storage usage.
+  --full  Start the full platform stack (default).
+
+Environment override:
+  ZTTATO_STACK_MODE=core|full
+USAGE
+}
+
+STACK_MODE=""
+
+resolve_mode(){
+  STACK_MODE="${ZTTATO_STACK_MODE:-full}"
+
+  while (($#)); do
+    case "$1" in
+      --core) STACK_MODE="core" ;;
+      --full) STACK_MODE="full" ;;
+      -h|--help)
+        print_usage
+        exit 0
+        ;;
+      *)
+        fail "unknown argument: $1 (use --help)"
+        ;;
+    esac
+    shift
+  done
+
+  case "$STACK_MODE" in
+    core|full) ;;
+    *) fail "invalid ZTTATO_STACK_MODE '$STACK_MODE' (allowed: core|full)" ;;
+  esac
+}
+
 smoke_check(){
   local url="$1"
   local name="$2"
@@ -31,11 +83,17 @@ smoke_check(){
   fi
 }
 
+resolve_mode "$@"
 ensure_env
 log "Validating compose configuration"
 compose_cmd config >/dev/null
-log "Building and starting compose stack"
-compose_cmd up -d --build --remove-orphans
+if [[ "$STACK_MODE" == "core" ]]; then
+  log "Building and starting CORE compose stack (reduced footprint)"
+  compose_cmd up -d --build --remove-orphans "${CORE_SERVICES[@]}"
+else
+  log "Building and starting FULL compose stack"
+  compose_cmd up -d --build --remove-orphans
+fi
 log "Current compose status"
 compose_cmd ps
 


### PR DESCRIPTION
### Motivation

- Full `docker compose up --build` builds 30+ service images and can fail on low-disk hosts with errors like `no space left on device`, so a reduced-footprint startup path is needed. 
- Provide a deterministic way to start only essential runtime services for development/CI on constrained machines while preserving the existing full-stack behavior.

### Description

- Added a `--core`/`--full` startup mode to `scripts/start-zttato-platform.sh` with `ZTTATO_STACK_MODE` environment override and `--help` text for deterministic control. 
- Introduced a `CORE_SERVICES` list and conditional logic that runs `docker compose up -d --build --remove-orphans` for only the core services when `--core` is selected. 
- Kept full-stack behavior as the default when no mode is provided. 
- Updated `README.md` quick-start to document the reduced-footprint command `bash scripts/start-zttato-platform.sh --core` and explain its purpose.

### Testing

- `bash -n scripts/start-zttato-platform.sh` completed with no syntax errors. 
- `bash scripts/start-zttato-platform.sh --help` displayed the usage/help text as expected. 
- `git diff --check` passed with no whitespace/format issues detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11d3b56c4832c9289dbbf06aef9a7)