### PR TITLE
Add affiliate automation architecture doc and deterministic repo cleanup auditor

### DIFF
--- a/configs/repo_cleanup_entrypoints.json
+++ b/configs/repo_cleanup_entrypoints.json
@@ -1,0 +1,23 @@
+{
+  "include_roots": [
+    "apps",
+    "packages",
+    "services",
+    "scripts"
+  ],
+  "entrypoints": [
+    "apps/api-gateway/src/index.ts",
+    "apps/auth-service/src/index.ts",
+    "apps/billing-service/src/index.ts",
+    "apps/platform-core/src/index.ts",
+    "apps/worker-ai/src/index.ts",
+    "services/ai-video-generator/src/index.js",
+    "services/market-orchestrator/src/index.py",
+    "scripts/repo_cleanup_audit.py"
+  ],
+  "protected_files": [
+    "apps/frontend/src/main.tsx",
+    "apps/frontend/src/App.tsx",
+    "scripts/start.ts"
+  ]
+}

--- a/docs/manuals/affiliate-video-platform-th.md
+++ b/docs/manuals/affiliate-video-platform-th.md
@@ -1,0 +1,119 @@
+# ระบบ Web Application สำหรับ Affiliate Video Automation (TikTok/Shopee/Lazada)
+
+เอกสารนี้สรุปสถาปัตยกรรมและขอบเขตการพัฒนาระบบตามโจทย์: ดึงข้อมูลสินค้า affiliate จาก TikTok Shop/TikTok Affiliate รวม Shopee/Lazada, สร้างวิดีโอไวรัลอัตโนมัติ, โพสต์วิดีโออัตโนมัติ, เก็บฐานข้อมูลสินค้าและคอนเทนต์, มีแดชบอร์ดแยกบทบาท (Admin/User/Developer), รองรับระบบเช่าใช้งานรายเดือน/รายปี/ถาวร, เชื่อมระบบสต็อก, และมีเครื่องมือจัดกลุ่ม source code ที่ยังไม่จำเป็น.
+
+## 1) สถาปัตยกรรมหลัก
+
+- **Ingestion Layer**
+  - TikTok Shop API Connector
+  - TikTok Affiliate API Connector
+  - Shopee API Connector
+  - Lazada API Connector
+- **Normalization Layer**
+  - แปลงข้อมูลสินค้าเป็น schema กลาง (`product_catalog`)
+  - ตรวจสอบข้อมูลซ้ำด้วย `source_platform + source_product_id`
+- **Content Intelligence Layer**
+  - คำนวณ Viral Score จาก CTR/CVR/Margin/Trend/Stock
+  - สร้าง Script/Hook/CTA ต่อสินค้า
+- **Video Generation Layer**
+  - Template-based Render (ไม่สุ่มใน logic หลัก)
+  - Multi-format output (9:16, 1:1)
+- **Publishing Layer**
+  - Scheduler จำกัดไม่เกิน `30 videos/day` ต่อ account
+  - Auto-post queue พร้อม retry และ rate-limit
+- **Analytics Layer**
+  - Dashboard แยกบทบาท: Admin / User / Developer
+  - รายงาน conversion, ROI, inventory impact
+- **SaaS & Billing Layer**
+  - แผนเช่าใช้งาน: Monthly / Yearly / Lifetime
+  - License validation + tenant isolation
+
+## 2) โครงสร้างฐานข้อมูลแนะนำ
+
+ตารางหลักที่ต้องมี:
+
+1. `tenants`
+2. `users`
+3. `products`
+4. `product_inventory`
+5. `content_blueprints`
+6. `generated_videos`
+7. `publish_jobs`
+8. `affiliate_metrics`
+9. `subscriptions`
+10. `dashboard_snapshots`
+
+หลักการสำคัญ:
+- ใช้ `tenant_id` ในทุกตารางธุรกิจ (multi-tenant isolation)
+- บังคับ unique key สำหรับแหล่งข้อมูลสินค้า
+- เก็บ audit trail (`created_by`, `updated_by`, `source`, `trace_id`)
+
+## 3) Workflow การทำงานรายวัน (Route 30 Video/Day)
+
+1. ดึงข้อมูลสินค้าใหม่ + อัปเดตสต็อก
+2. คำนวณคะแนนสินค้า (viral candidate scoring)
+3. เลือกสินค้า Top-N ตามงบและ stock
+4. Generate content blueprint ต่อสินค้า
+5. Render วิดีโอ
+6. บันทึกวิดีโอลงฐานข้อมูล
+7. ส่งเข้า Auto-post queue
+8. Scheduler กระจายโพสต์สูงสุด 30 วิดีโอ/วัน
+9. เก็บผลลัพธ์ (views/click/order/revenue)
+10. สรุปรายงานบน dashboard
+
+## 4) Dashboard ตามบทบาท
+
+- **Admin Dashboard**
+  - Tenant overview
+  - Revenue by subscription plan
+  - System health + queue health + SLA
+- **User Dashboard**
+  - Product performance
+  - Video performance
+  - Conversion funnel
+- **Developer Dashboard**
+  - API error rate
+  - Retry queue depth
+  - Latency และ job throughput
+
+## 5) รองรับหลายแพลตฟอร์มการใช้งาน
+
+- **Windows**: ผ่าน Web + Desktop wrapper (optional)
+- **Android/iOS**: ผ่าน Mobile App หรือ PWA
+- **Web Control Center**: จัดการสต็อกสินค้า บริการ และสถานะโพสต์
+
+## 6) ระบบตรวจจับและแยกโค้ดที่ยังไม่จำเป็น
+
+ใน repository นี้เพิ่มสคริปต์:
+- `scripts/repo_cleanup_audit.py`
+- config: `configs/repo_cleanup_entrypoints.json`
+
+ความสามารถ:
+1. วิเคราะห์ dependency graph (Python + JS/TS local imports)
+2. หาไฟล์ที่ไม่ reachable จาก entrypoint
+3. สร้างรายงาน JSON
+4. ย้ายไฟล์ที่ยังไม่จำเป็นไป `feature_repo/unused_candidates` แบบ deterministic
+
+ตัวอย่างคำสั่ง:
+
+```bash
+python3 scripts/repo_cleanup_audit.py
+python3 scripts/repo_cleanup_audit.py --apply
+```
+
+## 7) Security Baseline (บังคับ)
+
+- เก็บ secret ใน ENV เท่านั้น
+- ทุก API ใช้ schema validation
+- JWT ต้องมี expiration และ signature validation
+- ใส่ rate limiter ทุก endpoint public
+- เก็บ structured logs (JSON) สำหรับ audit
+
+## 8) Next Implementation Steps
+
+1. สร้าง service `affiliate-automation` (API + Scheduler + Publisher)
+2. เพิ่ม migrations สำหรับตาราง affiliate/video/subscription
+3. เชื่อม API connectors ของ TikTok/Shopee/Lazada
+4. เชื่อม renderer และ uploader จริง
+5. เชื่อม billing gateway และ license enforcement
+6. เพิ่ม integration tests ครอบคลุม flow ทั้งระบบ

--- a/scripts/repo_cleanup_audit.py
+++ b/scripts/repo_cleanup_audit.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Deterministic repository cleanup audit and quarantine tool.
+
+This tool discovers potentially-unused source files from configured entrypoints.
+It supports Python and JavaScript/TypeScript local imports and can quarantine
+unreachable files into a single archive folder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONFIG = REPO_ROOT / "configs" / "repo_cleanup_entrypoints.json"
+DEFAULT_REPORT_DIR = REPO_ROOT / "feature_repo" / "cleanup_reports"
+DEFAULT_QUARANTINE_DIR = REPO_ROOT / "feature_repo" / "unused_candidates"
+
+SOURCE_EXTENSIONS = {".py", ".js", ".mjs", ".cjs", ".ts", ".tsx"}
+EXCLUDED_PARTS = {
+    ".git",
+    ".idea",
+    ".vscode",
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    "__pycache__",
+}
+
+PY_IMPORT_RE = re.compile(r"^\s*(?:from\s+([\.\w/]+)\s+import|import\s+([\w\.]+))", re.MULTILINE)
+JS_IMPORT_RE = re.compile(
+    r"(?:import\s+(?:[^\"']+\s+from\s+)?|require\()\s*[\"']([^\"']+)[\"']",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class GraphResult:
+    sources: dict[Path, set[Path]]
+    reachable: set[Path]
+    unreachable: set[Path]
+    entrypoints: set[Path]
+
+
+class ConfigError(ValueError):
+    pass
+
+
+def load_config(path: Path) -> dict:
+    if not path.exists():
+        raise ConfigError(f"Config file not found: {path}")
+
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    required = {"include_roots", "entrypoints", "protected_files"}
+    missing = required - set(data.keys())
+    if missing:
+        raise ConfigError(f"Missing config keys: {sorted(missing)}")
+
+    return data
+
+
+def is_excluded(path: Path) -> bool:
+    return any(part in EXCLUDED_PARTS for part in path.parts)
+
+
+def list_source_files(include_roots: Iterable[str]) -> list[Path]:
+    files: list[Path] = []
+    for rel_root in include_roots:
+        root = (REPO_ROOT / rel_root).resolve()
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            rel_path = path.relative_to(REPO_ROOT)
+            if is_excluded(rel_path):
+                continue
+            if path.suffix in SOURCE_EXTENSIONS:
+                files.append(path)
+
+    files.sort()
+    return files
+
+
+def candidate_local_module_targets(base_file: Path, spec: str) -> list[Path]:
+    base_dir = base_file.parent
+    targets: list[Path] = []
+
+    if spec.startswith("."):
+        module_path = (base_dir / spec).resolve()
+    else:
+        return []
+
+    if module_path.suffix:
+        targets.append(module_path)
+    else:
+        for ext in SOURCE_EXTENSIONS:
+            targets.append(module_path.with_suffix(ext))
+        for ext in SOURCE_EXTENSIONS:
+            targets.append(module_path / f"index{ext}")
+
+    return targets
+
+
+def resolve_python_import(source_file: Path, statement: str) -> list[Path]:
+    statement = statement.strip()
+    if not statement or (not statement.startswith(".")):
+        return []
+
+    dots = len(statement) - len(statement.lstrip("."))
+    module_suffix = statement[dots:]
+
+    parent = source_file.parent
+    for _ in range(max(1, dots) - 1):
+        parent = parent.parent
+
+    if module_suffix:
+        module_path = parent / module_suffix.replace(".", os.sep)
+    else:
+        module_path = parent
+
+    candidates: list[Path] = []
+    for ext in SOURCE_EXTENSIONS:
+        candidates.append(module_path.with_suffix(ext))
+    for ext in SOURCE_EXTENSIONS:
+        candidates.append(module_path / f"__init__{ext}")
+    for ext in SOURCE_EXTENSIONS:
+        candidates.append(module_path / f"index{ext}")
+
+    return candidates
+
+
+def build_dependency_graph(files: list[Path]) -> dict[Path, set[Path]]:
+    file_set = {path.resolve() for path in files}
+    graph: dict[Path, set[Path]] = {path.resolve(): set() for path in files}
+
+    for source_file in files:
+        resolved_source = source_file.resolve()
+        content = source_file.read_text(encoding="utf-8", errors="ignore")
+
+        for py_from, py_import in PY_IMPORT_RE.findall(content):
+            statement = py_from or py_import
+            for target in resolve_python_import(source_file, statement):
+                resolved_target = target.resolve()
+                if resolved_target in file_set:
+                    graph[resolved_source].add(resolved_target)
+
+        for js_spec in JS_IMPORT_RE.findall(content):
+            for target in candidate_local_module_targets(source_file, js_spec):
+                resolved_target = target.resolve()
+                if resolved_target in file_set:
+                    graph[resolved_source].add(resolved_target)
+
+    return graph
+
+
+def normalize_path_list(paths: Iterable[str], existing_files: set[Path]) -> set[Path]:
+    normalized: set[Path] = set()
+    for rel in paths:
+        candidate = (REPO_ROOT / rel).resolve()
+        if candidate in existing_files:
+            normalized.add(candidate)
+    return normalized
+
+
+def traverse_reachable(graph: dict[Path, set[Path]], starts: set[Path]) -> set[Path]:
+    visited: set[Path] = set()
+    stack = list(starts)
+
+    while stack:
+        current = stack.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        stack.extend(graph.get(current, []))
+
+    return visited
+
+
+def analyze(config: dict) -> GraphResult:
+    files = list_source_files(config["include_roots"])
+    graph = build_dependency_graph(files)
+    all_files = set(graph.keys())
+
+    entrypoints = normalize_path_list(config["entrypoints"], all_files)
+    protected = normalize_path_list(config["protected_files"], all_files)
+
+    if not entrypoints:
+        raise ConfigError("No valid entrypoints found in config.")
+
+    reachable = traverse_reachable(graph, entrypoints | protected) | protected | entrypoints
+    unreachable = all_files - reachable
+
+    return GraphResult(
+        sources=graph,
+        reachable=reachable,
+        unreachable=unreachable,
+        entrypoints=entrypoints,
+    )
+
+
+def write_report(result: GraphResult, output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "cleanup_audit_report.json"
+
+    payload = {
+        "entrypoints": sorted(str(p.relative_to(REPO_ROOT)) for p in result.entrypoints),
+        "reachable_count": len(result.reachable),
+        "unreachable_count": len(result.unreachable),
+        "unreachable_files": sorted(str(p.relative_to(REPO_ROOT)) for p in result.unreachable),
+    }
+
+    with report_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    return report_path
+
+
+def quarantine_files(unreachable_files: set[Path], quarantine_dir: Path) -> Path:
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    moved_manifest = []
+
+    for abs_path in sorted(unreachable_files):
+        rel = abs_path.relative_to(REPO_ROOT)
+        destination = quarantine_dir / rel
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(abs_path), str(destination))
+        moved_manifest.append(str(rel))
+
+    manifest_path = quarantine_dir / "moved_manifest.json"
+    with manifest_path.open("w", encoding="utf-8") as f:
+        json.dump({"moved_files": moved_manifest}, f, indent=2)
+
+    return manifest_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Repository cleanup analyzer for zTTato Platform")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG, help="Path to JSON config file")
+    parser.add_argument("--report-dir", type=Path, default=DEFAULT_REPORT_DIR, help="Report output directory")
+    parser.add_argument(
+        "--quarantine-dir",
+        type=Path,
+        default=DEFAULT_QUARANTINE_DIR,
+        help="Quarantine destination for unreachable files",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Move unreachable files to quarantine directory",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    result = analyze(config)
+    report_path = write_report(result, args.report_dir)
+
+    print(f"Cleanup report written to: {report_path}")
+    print(f"Reachable files: {len(result.reachable)}")
+    print(f"Unreachable files: {len(result.unreachable)}")
+
+    if args.apply and result.unreachable:
+        manifest_path = quarantine_files(result.unreachable, args.quarantine_dir)
+        print(f"Quarantine manifest written to: {manifest_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_repo_cleanup_audit.py
+++ b/tests/test_repo_cleanup_audit.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from scripts.repo_cleanup_audit import (
+    candidate_local_module_targets,
+    normalize_path_list,
+    traverse_reachable,
+)
+
+
+def test_candidate_local_module_targets_resolves_index_and_suffix(tmp_path: Path) -> None:
+    src = tmp_path / "app" / "main.ts"
+    src.parent.mkdir(parents=True)
+    src.write_text("import './lib'", encoding="utf-8")
+
+    targets = candidate_local_module_targets(src, "./lib")
+
+    assert any(path.name == "lib.ts" for path in targets)
+    assert any(path.name == "index.ts" for path in targets)
+
+
+def test_traverse_reachable_returns_transitive_nodes(tmp_path: Path) -> None:
+    file_a = (tmp_path / "a.py").resolve()
+    file_b = (tmp_path / "b.py").resolve()
+    file_c = (tmp_path / "c.py").resolve()
+
+    graph = {
+        file_a: {file_b},
+        file_b: {file_c},
+        file_c: set(),
+    }
+
+    visited = traverse_reachable(graph, {file_a})
+
+    assert visited == {file_a, file_b, file_c}
+
+
+def test_normalize_path_list_ignores_non_existing_entries(tmp_path: Path) -> None:
+    repo_root = Path.cwd()
+    existing = {(repo_root / "scripts" / "repo_cleanup_audit.py").resolve()}
+
+    normalized = normalize_path_list(
+        [
+            "scripts/repo_cleanup_audit.py",
+            "scripts/does-not-exist.py",
+        ],
+        existing,
+    )
+
+    assert normalized == existing


### PR DESCRIPTION
### Motivation

- Provide a production-ready blueprint for an Affiliate Video Automation platform (TikTok/Shopee/Lazada) including ingestion, content intelligence, video generation, publishing limits (30 videos/day), role-based dashboards and SaaS billing to guide implementation. 
- Add a deterministic, config-driven repository cleanup auditor to identify and quarantine unused source files so the codebase can be organized and unnecessary code separated safely. 
- Ensure changes are secure and reproducible: no secrets were added and quarantine is opt-in to avoid accidental removal.

### Description

- Add architecture manual `docs/manuals/affiliate-video-platform-th.md` describing system layers, DB schema, daily workflow (30 videos/day), dashboards, security baseline, and next implementation steps. 
- Add deterministic analyzer `scripts/repo_cleanup_audit.py` that scans `include_roots`, parses Python and JS/TS local imports, builds a dependency graph, computes reachable vs unreachable files from configured `entrypoints` and `protected_files`, writes a JSON report, and optionally moves unreachable files to `feature_repo/unused_candidates` with `--apply`. 
- Add configuration `configs/repo_cleanup_entrypoints.json`, `scripts/__init__.py` and unit tests `tests/test_repo_cleanup_audit.py` covering module-target resolution, traversal, and path normalization.

### Testing

- Ran unit tests with `python3 -m pytest tests/test_repo_cleanup_audit.py` which passed (3 tests). 
- Executed the analyzer with `python3 scripts/repo_cleanup_audit.py` which produced a JSON report at `feature_repo/cleanup_reports/cleanup_audit_report.json` and printed reachable/unreachable file counts (report run showed 17 reachable and 221 unreachable in this workspace). 
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c132c16b50832cb37baad78ad6c24c)