### PR TITLE
Add Gemini.md artifact extractor, tests, and generated artifacts

### DIFF
--- a/generated/gemini-source/heredoc_file/0001_b1fbde7f0f6e86c2_zttato-enterprise-fix.patch
+++ b/generated/gemini-source/heredoc_file/0001_b1fbde7f0f6e86c2_zttato-enterprise-fix.patch
@@ -1,0 +1,117 @@
+diff --git a/services/arbitrage-engine/src/engine/arbitrage.py b/services/arbitrage-engine/src/engine/arbitrage.py
+--- a/services/arbitrage-engine/src/engine/arbitrage.py
++++ b/services/arbitrage-engine/src/engine/arbitrage.py
+@@ -1,37 +1,38 @@
+ from collections import defaultdict
++import logging
+
+ def detect(products, payout_lookup):
+-
+     grouped = defaultdict(list)
+-
+     for p in products:
+-        grouped[p["name"]].append(p)
++        # Normalize names to improve matching precision
++        name_key = p["name"].strip().lower()
++        grouped[name_key].append(p)
+
+     opportunities = []
+-
+     for name, items in grouped.items():
+-
+         if len(items) < 2:
+             continue
+
++        # Optimization: Sort by price to allow early exit or two-pointer approach if scaled
+         for buy in items:
+-
+             for sell in items:
+-
++                # Skip same source or same unique product ID
+                 if buy["source"] == sell["source"]:
+                     continue
++                if buy.get("id") == sell.get("id") and buy.get("id") is not None:
++                    continue
+
+                 buy_price = buy["price"]
+                 sell_price = sell["price"]
+
+                 product_id = str(sell.get("id", ""))
+                 commission = payout_lookup(sell["source"], product_id)
+-                if commission is None:
++                
++                if commission is None or not isinstance(commission, (int, float)):
+                     continue
+
+                 revenue = sell_price * commission
+-
+                 profit = revenue - buy_price
+
+-                if profit > 1:
+-
++                # Thresholding for business viability
++                if profit > 1.0:
+                     opportunities.append(
+                         {
+diff --git a/services/gpu-renderer/src/core/render.py b/services/gpu-renderer/src/core/render.py
+--- a/services/gpu-renderer/src/core/render.py
++++ b/services/gpu-renderer/src/core/render.py
+@@ -8,11 +8,13 @@
+     hwaccel_mode = os.environ.get("FFMPEG_HWACCEL", "auto").strip().lower()
+ 
+     if hwaccel_mode in {"none", "cpu", "off", "false", "0"}:
+         return False
+ 
+-    if hwaccel_mode in {"cuda", "nvidia", "gpu", "on", "true", "1"}:
+-        return True
++    # Strict check: Even if requested, verify binary presence to prevent crash
++    has_nvidia = shutil.which("nvidia-smi") is not None
++    
++    if hwaccel_mode in {"cuda", "nvidia", "gpu", "on", "true", "1"} and has_nvidia:
++        return True
+ 
+-    # auto mode
+-    return shutil.which("nvidia-smi") is not None
++    return has_nvidia if hwaccel_mode == "auto" else False
+diff --git a/services/jwt-auth/src/main.py b/services/jwt-auth/src/main.py
+--- a/services/jwt-auth/src/main.py
++++ b/services/jwt-auth/src/main.py
+@@ -9,7 +9,11 @@
+ 
+ JWT_ISSUER = os.getenv("JWT_ISSUER", "https://jwt-auth.platform.svc.cluster.local")
+ JWT_AUDIENCE = os.getenv("JWT_AUDIENCE", "zttato-platform")
+-JWT_SECRET = os.getenv("JWT_SECRET", "change-me-in-production")
++
++JWT_SECRET = os.getenv("JWT_SECRET")
++if not JWT_SECRET or JWT_SECRET == "change-me-in-production":
++    raise RuntimeError("CRITICAL: JWT_SECRET is not set or uses insecure default.")
++
+ JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+diff --git a/services/master-orchestrator/src/main.py b/services/master-orchestrator/src/main.py
+--- a/services/master-orchestrator/src/main.py
++++ b/services/master-orchestrator/src/main.py
+@@ -5,6 +5,7 @@
+ import requests
+ import uvicorn
+ from fastapi import FastAPI, HTTPException
++from urllib3.util.retry import Retry
++from requests.adapters import HTTPAdapter
+ 
+@@ -37,13 +38,21 @@
+ 
+-def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
++def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
+     kwargs.setdefault("timeout", TIMEOUT)
++    
++    # Resilient Session with Backoff
++    session = requests.Session()
++    retries = Retry(total=3, backoff_factor=1, status_forcelist=[502, 503, 504])
++    session.mount("http://", HTTPAdapter(max_retries=retries))
++    
+     try:
+-        response = method(url, **kwargs)
++        # Extract method name from function for session call
++        verb = method_func.__name__.lower()
++        response = getattr(session, verb)(url, **kwargs)
+         response.raise_for_status()
+         return response.json()

--- a/generated/gemini-source/manifest.json
+++ b/generated/gemini-source/manifest.json
@@ -1,0 +1,22 @@
+{
+  "artifacts": [
+    {
+      "digest": "d9bae99148808a78",
+      "kind": "patch",
+      "source_index": 1,
+      "suggested_path": "patches/patch_0001.diff"
+    },
+    {
+      "digest": "b1fbde7f0f6e86c2",
+      "kind": "heredoc_file",
+      "source_index": 1,
+      "suggested_path": "files/zttato-enterprise-fix.patch"
+    }
+  ],
+  "counts": {
+    "heredoc_file": 1,
+    "hinted_file": 0,
+    "patch": 1
+  },
+  "total": 2
+}

--- a/generated/gemini-source/patches/patch_0001.diff
+++ b/generated/gemini-source/patches/patch_0001.diff
@@ -1,0 +1,149 @@
+# ZTTATO PLATFORM v3 ENTERPRISE: META DEEP SCAN & REPAIR PATCH
+# Scan Date: 2026-03-29
+# Focus: Distributed Logic, Race Conditions, Security (OWASP), and Compute Efficiency.
+
+# --- ANALYSIS REPORT ---
+# 1. Race Condition in Arbitrage Engine:
+#    - File: services/arbitrage-engine/src/engine/arbitrage.py
+#    - Bug: O(N^2) complexity on nested loops without prior filtering. 
+#    - Risk: Denial of Service (DoS) on large product sets. Missing deep comparison for product IDs.
+#
+# 2. Insecure JWT Implementation:
+#    - File: services/jwt-auth/src/main.py
+#    - Bug: Hardcoded fallback secret "change-me-in-production". 
+#    - Risk: Critical security vulnerability if env var is missing.
+#
+# 3. Fragile Upstream Handling in Master Orchestrator:
+#    - File: services/master-orchestrator/src/main.py
+#    - Bug: `safe_call` lacks a retry mechanism for transient 502/504 errors common in k8s/Traefik mesh.
+#
+# 4. GPU-Renderer Logic Flaw:
+#    - File: services/gpu-renderer/src/core/render.py
+#    - Bug: Incorrect fallback logic in `_should_use_cuda`. It returns True if env is set, 
+#      even if binary `nvidia-smi` is missing, causing process crash.
+
+cat << 'EOF' > zttato-enterprise-fix.patch
+diff --git a/services/arbitrage-engine/src/engine/arbitrage.py b/services/arbitrage-engine/src/engine/arbitrage.py
+--- a/services/arbitrage-engine/src/engine/arbitrage.py
++++ b/services/arbitrage-engine/src/engine/arbitrage.py
+@@ -1,37 +1,38 @@
+ from collections import defaultdict
++import logging
+
+ def detect(products, payout_lookup):
+-
+     grouped = defaultdict(list)
+-
+     for p in products:
+-        grouped[p["name"]].append(p)
++        # Normalize names to improve matching precision
++        name_key = p["name"].strip().lower()
++        grouped[name_key].append(p)
+
+     opportunities = []
+-
+     for name, items in grouped.items():
+-
+         if len(items) < 2:
+             continue
+
++        # Optimization: Sort by price to allow early exit or two-pointer approach if scaled
+         for buy in items:
+-
+             for sell in items:
+-
++                # Skip same source or same unique product ID
+                 if buy["source"] == sell["source"]:
+                     continue
++                if buy.get("id") == sell.get("id") and buy.get("id") is not None:
++                    continue
+
+                 buy_price = buy["price"]
+                 sell_price = sell["price"]
+
+                 product_id = str(sell.get("id", ""))
+                 commission = payout_lookup(sell["source"], product_id)
+-                if commission is None:
++                
++                if commission is None or not isinstance(commission, (int, float)):
+                     continue
+
+                 revenue = sell_price * commission
+-
+                 profit = revenue - buy_price
+
+-                if profit > 1:
+-
++                # Thresholding for business viability
++                if profit > 1.0:
+                     opportunities.append(
+                         {
+diff --git a/services/gpu-renderer/src/core/render.py b/services/gpu-renderer/src/core/render.py
+--- a/services/gpu-renderer/src/core/render.py
++++ b/services/gpu-renderer/src/core/render.py
+@@ -8,11 +8,13 @@
+     hwaccel_mode = os.environ.get("FFMPEG_HWACCEL", "auto").strip().lower()
+ 
+     if hwaccel_mode in {"none", "cpu", "off", "false", "0"}:
+         return False
+ 
+-    if hwaccel_mode in {"cuda", "nvidia", "gpu", "on", "true", "1"}:
+-        return True
++    # Strict check: Even if requested, verify binary presence to prevent crash
++    has_nvidia = shutil.which("nvidia-smi") is not None
++    
++    if hwaccel_mode in {"cuda", "nvidia", "gpu", "on", "true", "1"} and has_nvidia:
++        return True
+ 
+-    # auto mode
+-    return shutil.which("nvidia-smi") is not None
++    return has_nvidia if hwaccel_mode == "auto" else False
+diff --git a/services/jwt-auth/src/main.py b/services/jwt-auth/src/main.py
+--- a/services/jwt-auth/src/main.py
++++ b/services/jwt-auth/src/main.py
+@@ -9,7 +9,11 @@
+ 
+ JWT_ISSUER = os.getenv("JWT_ISSUER", "https://jwt-auth.platform.svc.cluster.local")
+ JWT_AUDIENCE = os.getenv("JWT_AUDIENCE", "zttato-platform")
+-JWT_SECRET = os.getenv("JWT_SECRET", "change-me-in-production")
++
++JWT_SECRET = os.getenv("JWT_SECRET")
++if not JWT_SECRET or JWT_SECRET == "change-me-in-production":
++    raise RuntimeError("CRITICAL: JWT_SECRET is not set or uses insecure default.")
++
+ JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+diff --git a/services/master-orchestrator/src/main.py b/services/master-orchestrator/src/main.py
+--- a/services/master-orchestrator/src/main.py
++++ b/services/master-orchestrator/src/main.py
+@@ -5,6 +5,7 @@
+ import requests
+ import uvicorn
+ from fastapi import FastAPI, HTTPException
++from urllib3.util.retry import Retry
++from requests.adapters import HTTPAdapter
+ 
+@@ -37,13 +38,21 @@
+ 
+-def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
++def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
+     kwargs.setdefault("timeout", TIMEOUT)
++    
++    # Resilient Session with Backoff
++    session = requests.Session()
++    retries = Retry(total=3, backoff_factor=1, status_forcelist=[502, 503, 504])
++    session.mount("http://", HTTPAdapter(max_retries=retries))
++    
+     try:
+-        response = method(url, **kwargs)
++        # Extract method name from function for session call
++        verb = method_func.__name__.lower()
++        response = getattr(session, verb)(url, **kwargs)
+         response.raise_for_status()
+         return response.json()
+EOF
+
+# Apply the patch
+patch -p1 < zttato-enterprise-fix.patch
+
+# Verify integrity
+./infrastructure/scripts/full-source-scan.sh

--- a/scripts/extract_gemini_source.py
+++ b/scripts/extract_gemini_source.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Extract recoverable source artifacts from Gemini chat-export markdown.
+
+This utility scans a markdown transcript for:
+1) unified diffs (`diff --git ...`)
+2) shell heredoc file writes (`cat << 'EOF' > path`)
+3) fenced code blocks with a `File:` or `Path:` hint directly above them
+
+Output is deterministic and idempotent: running it repeatedly produces the same
+set of files for unchanged input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+CODE_FENCE_PATTERN = re.compile(r"```(?P<lang>[^\n]*)\n(?P<body>.*?)\n```", re.DOTALL)
+HEREDOC_PATTERN = re.compile(
+    r"cat\s+<<\s*['\"]?(?P<tag>[A-Za-z0-9_\-]+)['\"]?\s*>\s*(?P<path>[^\n]+)\n(?P<body>.*?)\n(?P=tag)",
+    re.DOTALL,
+)
+PATH_HINT_PATTERN = re.compile(r"(?:^|\n)(?:File|Path)\s*:\s*(?P<path>[^\n]+)\s*$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Artifact:
+    kind: str
+    suggested_path: str
+    content: str
+    source_index: int
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(self.content.encode("utf-8")).hexdigest()[:16]
+
+
+def _iter_code_fences(markdown: str) -> Iterator[tuple[int, int, str, str]]:
+    for idx, match in enumerate(CODE_FENCE_PATTERN.finditer(markdown), start=1):
+        yield idx, match.start(), (match.group("lang") or "").strip().lower(), match.group("body")
+
+
+def extract_artifacts(markdown: str) -> list[Artifact]:
+    artifacts: list[Artifact] = []
+
+    for idx, fence_start, lang, body in _iter_code_fences(markdown):
+        stripped = body.strip()
+        if not stripped:
+            continue
+
+        if "diff --git " in stripped or stripped.startswith("--- ") and "+++ " in stripped:
+            artifacts.append(
+                Artifact(
+                    kind="patch",
+                    suggested_path=f"patches/patch_{idx:04d}.diff",
+                    content=stripped + "\n",
+                    source_index=idx,
+                )
+            )
+
+        for heredoc in HEREDOC_PATTERN.finditer(body):
+            target = heredoc.group("path").strip()
+            content = heredoc.group("body")
+            if target:
+                artifacts.append(
+                    Artifact(
+                        kind="heredoc_file",
+                        suggested_path=f"files/{target}",
+                        content=content + "\n",
+                        source_index=idx,
+                    )
+                )
+
+        # Heuristic: nearby path hint in raw markdown before the current fence.
+        prefix = markdown[max(0, fence_start - 500) : fence_start]
+        hint_match = PATH_HINT_PATTERN.search(prefix)
+        if hint_match:
+            hint_path = hint_match.group("path").strip()
+            if hint_path:
+                artifacts.append(
+                    Artifact(
+                        kind="hinted_file",
+                        suggested_path=f"files/{hint_path}",
+                        content=body.rstrip("\n") + "\n",
+                        source_index=idx,
+                    )
+                )
+
+    # Deduplicate by (kind, path, digest) while keeping stable order
+    seen: set[tuple[str, str, str]] = set()
+    deduped: list[Artifact] = []
+    for artifact in artifacts:
+        key = (artifact.kind, artifact.suggested_path, artifact.digest)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(artifact)
+    return deduped
+
+
+def _safe_join(root: Path, relative: str) -> Path:
+    cleaned = relative.strip().lstrip("/")
+    path = (root / cleaned).resolve()
+    if root.resolve() not in path.parents and path != root.resolve():
+        raise ValueError(f"Unsafe output path outside output directory: {relative}")
+    return path
+
+
+def write_artifacts(artifacts: Iterable[Artifact], output_dir: Path) -> dict[str, int]:
+    counts = {"patch": 0, "heredoc_file": 0, "hinted_file": 0}
+    for artifact in artifacts:
+        rel = artifact.suggested_path
+        if artifact.kind in {"heredoc_file", "hinted_file"}:
+            rel = f"{artifact.kind}/{artifact.source_index:04d}_{artifact.digest}_{Path(rel).name}"
+        out_path = _safe_join(output_dir, rel)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(artifact.content, encoding="utf-8")
+        counts[artifact.kind] = counts.get(artifact.kind, 0) + 1
+
+    manifest = {
+        "total": sum(counts.values()),
+        "counts": counts,
+        "artifacts": [
+            {
+                "kind": a.kind,
+                "source_index": a.source_index,
+                "digest": a.digest,
+                "suggested_path": a.suggested_path,
+            }
+            for a in artifacts
+        ],
+    }
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return counts
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Path to Gemini markdown export")
+    parser.add_argument("-o", "--output", type=Path, default=Path("generated/gemini-source"), help="Output directory")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    markdown = args.input.read_text(encoding="utf-8")
+    artifacts = extract_artifacts(markdown)
+    counts = write_artifacts(artifacts, args.output)
+    print(json.dumps({"output": str(args.output), "counts": counts, "total": len(artifacts)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_extract_gemini_source.py
+++ b/tests/test_extract_gemini_source.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from scripts.extract_gemini_source import extract_artifacts, write_artifacts
+
+
+def test_extracts_patch_and_heredoc(tmp_path: Path) -> None:
+    markdown = """
+## Response
+```\ndiff --git a/a.py b/a.py
+--- a/a.py
++++ b/a.py
+@@ -1 +1 @@
+-print('a')
++print('b')
+
+cat << 'EOF' > src/main.py
+print('ok')
+EOF
+```
+"""
+    artifacts = extract_artifacts(markdown)
+    kinds = [a.kind for a in artifacts]
+    assert "patch" in kinds
+    assert "heredoc_file" in kinds
+
+    counts = write_artifacts(artifacts, tmp_path)
+    assert counts["patch"] == 1
+    assert counts["heredoc_file"] == 1
+
+
+def test_extracts_hinted_file() -> None:
+    markdown = """
+File: services/api/src/main.py
+```python
+print('hello')
+```
+"""
+    artifacts = extract_artifacts(markdown)
+    assert any(a.kind == "hinted_file" for a in artifacts)


### PR DESCRIPTION
### Motivation
- Enable deterministic recovery of source artifacts embedded in long Gemini chat-export markdown to aid audits and repo restoration. 
- Provide an idempotent, safe utility for extracting diffs, heredoc file writes, and path-hinted code blocks from `Gemini.md` for traceability and reproducibility.

### Description
- Add `scripts/extract_gemini_source.py`, a deterministic extractor that finds unified diffs, `cat << 'EOF' > path` heredocs, and fenced code blocks with nearby `File:`/`Path:` hints, and emits stable artifacts and a manifest.  
- Implement safety and hygiene features including path traversal protection via `_safe_join`, stable deduplication by `(kind, path, digest)`, and consistent naming for generated files.  
- Adjust fence scanning to preserve fence byte offsets for reliable proximity hinting (fence index + start position).  
- Add unit tests in `tests/test_extract_gemini_source.py` that validate patch/heredoc extraction and hinted-file detection, and include deterministic generated output under `generated/gemini-source/` (extracted patch, heredoc file, and `manifest.json`).

### Testing
- Checked syntax with `python3 -m py_compile scripts/extract_gemini_source.py` which succeeded.  
- Ran unit tests with `pytest -q tests/test_extract_gemini_source.py` which passed (`2 passed`).  
- Executed the extractor against `Gemini.md` with `python3 scripts/extract_gemini_source.py Gemini.md -o generated/gemini-source` and verified `generated/gemini-source/manifest.json` and extracted artifacts were produced as reported (counts match expected), all commands succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c848f670708321b1f10f6f8a99a058)