### PR TITLE
Harden v3 service configs, gateway routing, and bootstrap script

### DIFF
--- a/apps/api-gateway/src/index.ts
+++ b/apps/api-gateway/src/index.ts
@@ -1,24 +1,27 @@
 import cors from "cors";
-import express from "express";
+import express, { type Request, type Response } from "express";
 import rateLimit from "express-rate-limit";
 import helmet from "helmet";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import pino from "pino";
 import crypto from "node:crypto";
+import { type IncomingMessage, type ServerResponse } from "node:http";
 import { auth } from "./middleware.js";
 
 const logger = pino({ level: process.env.LOG_LEVEL ?? "info" });
 const port = Number(process.env.API_GATEWAY_PORT ?? "3000");
 
-const coreTarget = process.env.PLATFORM_CORE_URL ?? "http://platform-core:4000";
-const workerAiTarget = process.env.WORKER_AI_URL ?? "http://worker-ai:5000";
 const allowedOrigins = (process.env.CORS_ALLOWED_ORIGINS ?? "")
   .split(",")
   .map((origin) => origin.trim())
   .filter(Boolean);
-const authTarget = process.env.AUTH_SERVICE_URL ?? "http://auth-service:3001";
-const billingTarget = process.env.BILLING_SERVICE_URL ?? "http://billing-service:3002";
-const logTarget = process.env.LOG_SERVICE_URL ?? "http://log-service:6000";
+const routeTargets = {
+  "/core": process.env.PLATFORM_CORE_URL ?? "http://platform-core:4000",
+  "/ai": process.env.WORKER_AI_URL ?? "http://worker-ai:5000",
+  "/auth": process.env.AUTH_SERVICE_URL ?? "http://auth-service:3001",
+  "/billing": process.env.BILLING_SERVICE_URL ?? "http://billing-service:3002",
+  "/logs": process.env.LOG_SERVICE_URL ?? "http://log-service:6000",
+};
 
 const app = express();
 
@@ -61,52 +64,38 @@ app.get("/healthz", (_req, res) => {
 
 app.use(auth);
 
-app.use(
-  "/core",
-  createProxyMiddleware({
-    target: coreTarget,
-    changeOrigin: true,
-    pathRewrite: { "^/core": "" },
-  }),
-);
-
-app.use(
-  "/ai",
-  createProxyMiddleware({
-    target: workerAiTarget,
-    changeOrigin: true,
-    pathRewrite: { "^/ai": "" },
-  }),
-);
-
-app.use(
-  "/auth",
-  createProxyMiddleware({
-    target: authTarget,
-    changeOrigin: true,
-    pathRewrite: { "^/auth": "" },
-  }),
-);
-
-app.use(
-  "/billing",
-  createProxyMiddleware({
-    target: billingTarget,
-    changeOrigin: true,
-    pathRewrite: { "^/billing": "" },
-  }),
-);
-
-app.use(
-  "/logs",
-  createProxyMiddleware({
-    target: logTarget,
-    changeOrigin: true,
-    pathRewrite: { "^/logs": "" },
-  }),
-);
+for (const [route, target] of Object.entries(routeTargets)) {
+  app.use(
+    route,
+    createProxyMiddleware({
+      target,
+      changeOrigin: true,
+      pathRewrite: { [`^${route}`]: "" },
+      proxyTimeout: Number(process.env.PROXY_TIMEOUT_MS ?? "10000"),
+      on: {
+        proxyReq: (proxyReq, req: IncomingMessage) => {
+          const requestId = req.headers["x-request-id"]?.toString();
+          if (requestId) {
+            proxyReq.setHeader("x-request-id", requestId);
+          }
+        },
+        error: (err: Error, req: IncomingMessage, res: ServerResponse<IncomingMessage> | NodeJS.WritableStream) => {
+          const expressRequest = req as Request;
+          const requestId = expressRequest.headers["x-request-id"];
+          logger.error(
+            { err, requestId, path: expressRequest.url, target },
+            "proxy.error",
+          );
+          const expressResponse = res as Response;
+          if (typeof expressResponse.status === "function" && !expressResponse.headersSent) {
+            expressResponse.status(502).json({ error: "Bad Gateway", requestId });
+          }
+        },
+      },
+    }),
+  );
+}
 
 app.listen(port, () => {
-  logger.info({ port, coreTarget, workerAiTarget, allowedOrigins }, "api-gateway.started");
-  logger.info({ port, coreTarget, workerAiTarget, authTarget, billingTarget }, "api-gateway started");
+  logger.info({ port, allowedOrigins, routeTargets }, "api-gateway.started");
 });

--- a/infrastructure/scripts/bootstrap-platform.sh
+++ b/infrastructure/scripts/bootstrap-platform.sh
@@ -1,41 +1,43 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+IFS=$'\n\t'
+trap 'echo "Bootstrap failed at line ${LINENO}" >&2' ERR
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 echo "Bootstrapping platform..."
 
 echo "Fixing shell permissions..."
-find "$ROOT" -type f -name "*.sh" -exec chmod +x {} \;
+find "$ROOT/infrastructure/scripts" -type f -name "*.sh" -exec chmod 755 {} +
 
 echo ""
 echo "Installing Node dependencies..."
 
-NODE_PKGS=$(find "$ROOT/services" -maxdepth 2 -name package.json)
+NODE_PKGS=$(find "$ROOT/services" -maxdepth 2 -type f -name package.json)
 
 for pkg in $NODE_PKGS
 do
   dir=$(dirname "$pkg")
-  echo "npm install -> $dir"
-  (cd "$dir" && npm install)
+  echo "npm ci -> $dir"
+  (cd "$dir" && npm ci)
 done
 
 echo ""
 echo "Installing Python dependencies..."
 
-PY_PKGS=$(find "$ROOT/services" -maxdepth 2 -name requirements.txt)
+PY_PKGS=$(find "$ROOT/services" -maxdepth 2 -type f -name requirements.txt)
 
 for req in $PY_PKGS
 do
   dir=$(dirname "$req")
-  echo "pip install -> $dir"
-  (cd "$dir" && pip install -r requirements.txt)
+  echo "python -m pip install -> $dir"
+  (cd "$dir" && python -m pip install --no-cache-dir -r requirements.txt)
 done
 
 echo ""
 echo "Starting Docker compose..."
 
 cd "$ROOT"
-docker compose up -d
+docker compose -f "$ROOT/docker-compose.yml" up -d --wait
 
 echo "Bootstrap completed."

--- a/services/arbitrage-engine/src/main.py
+++ b/services/arbitrage-engine/src/main.py
@@ -1,3 +1,5 @@
+import os
+
 import uvicorn
 
 
@@ -5,5 +7,5 @@ if __name__ == "__main__":
     uvicorn.run(
         "api.server:app",
         host="0.0.0.0",
-        port=9500,
+        port=int(os.getenv("ARBITRAGE_ENGINE_PORT", "9500")),
     )

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Any, Literal
 from urllib.parse import quote
 
@@ -20,12 +21,18 @@ from federated_loop import run_global_task
 from kafka_producer import emit_decision
 
 app = FastAPI(title="Master Orchestrator")
-TIMEOUT = 10
+TIMEOUT = float(os.getenv("HTTP_TIMEOUT_SECONDS", "10"))
+HTTP_RETRY_TOTAL = int(os.getenv("HTTP_RETRY_TOTAL", "3"))
+HTTP_RETRY_BACKOFF = float(os.getenv("HTTP_RETRY_BACKOFF", "0.5"))
 logging.basicConfig(level=logging.INFO)
 
 
-CLICK_TRACKER_URL = "http://click-tracker:8080"
-PAYMENT_GATEWAY_URL = "http://payment-gateway:8000"
+CLICK_TRACKER_URL = os.getenv("CLICK_TRACKER_URL", "http://click-tracker:8080")
+PAYMENT_GATEWAY_URL = os.getenv("PAYMENT_GATEWAY_URL", "http://payment-gateway:8000")
+FEATURE_STORE_URL = os.getenv("FEATURE_STORE_URL", "http://feature-store:8000")
+MODEL_SERVICE_URL = os.getenv("MODEL_SERVICE_URL", "http://model-service:8000")
+EXECUTION_ENGINE_URL = os.getenv("EXECUTION_ENGINE_URL", "http://execution-engine:9600")
+APP_PORT = int(os.getenv("MASTER_ORCHESTRATOR_PORT", "8000"))
 deployment_store = DeploymentStore()
 
 
@@ -70,13 +77,13 @@ def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
     kwargs.setdefault("timeout", TIMEOUT)
     session = requests.Session()
     retries = Retry(
-        total=3,
-        connect=3,
-        read=3,
-        status=3,
-        backoff_factor=0.5,
+        total=HTTP_RETRY_TOTAL,
+        connect=HTTP_RETRY_TOTAL,
+        read=HTTP_RETRY_TOTAL,
+        status=HTTP_RETRY_TOTAL,
+        backoff_factor=HTTP_RETRY_BACKOFF,
         status_forcelist=[502, 503, 504],
-        allowed_methods={"DELETE", "GET", "HEAD", "OPTIONS", "POST", "PUT", "TRACE"},
+        allowed_methods={"DELETE", "GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH"},
     )
     adapter = HTTPAdapter(max_retries=retries)
     session.mount("http://", adapter)
@@ -227,10 +234,10 @@ def create_checkout(request: ProfitModeRequest, tracked_destination_url: str) ->
 @app.post("/campaign/run", response_model=CampaignDecision)
 def run_campaign(offer: Offer) -> CampaignDecision:
     cycle = run_cycle(offer.id)
-    model = safe_call(requests.post, "http://model-service:8000/predict", json=cycle["features"])
+    model = safe_call(requests.post, f"{MODEL_SERVICE_URL}/predict", json=cycle["features"])
     execution = safe_call(
         requests.post,
-        "http://execution-engine:9600/publish",
+        f"{EXECUTION_ENGINE_URL}/publish",
         json={
             "campaign_id": offer.id,
             "video_url": offer.video_url,
@@ -269,7 +276,7 @@ def run_campaign(offer: Offer) -> CampaignDecision:
 def activate_profit_mode(request: ProfitModeRequest) -> ProfitModeResponse:
     safe_call(
         requests.post,
-        f"http://feature-store:8000/features/{request.campaign_id}",
+        f"{FEATURE_STORE_URL}/features/{request.campaign_id}",
         json={
             "max_budget": request.max_budget,
             "daily_cap": request.daily_cap,
@@ -278,7 +285,7 @@ def activate_profit_mode(request: ProfitModeRequest) -> ProfitModeResponse:
         },
     )
     cycle = run_cycle(request.campaign_id)
-    model = safe_call(requests.post, "http://model-service:8000/predict", json=cycle["features"])
+    model = safe_call(requests.post, f"{MODEL_SERVICE_URL}/predict", json=cycle["features"])
     tracked_destination_url = build_tracked_destination(
         request.campaign_id,
         str(request.landing_url),
@@ -286,7 +293,7 @@ def activate_profit_mode(request: ProfitModeRequest) -> ProfitModeResponse:
     )
     execution = safe_call(
         requests.post,
-        "http://execution-engine:9600/publish",
+        f"{EXECUTION_ENGINE_URL}/publish",
         json={
             "campaign_id": request.campaign_id,
             "video_url": str(request.video_url),
@@ -331,4 +338,4 @@ def activate_profit_mode(request: ProfitModeRequest) -> ProfitModeResponse:
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=APP_PORT)

--- a/services/viral-predictor/src/main.py
+++ b/services/viral-predictor/src/main.py
@@ -1,3 +1,5 @@
+import os
+
 import uvicorn
 
 
@@ -5,5 +7,5 @@ if __name__ == "__main__":
     uvicorn.run(
         "api.server:app",
         host="0.0.0.0",
-        port=9100,
+        port=int(os.getenv("VIRAL_PREDICTOR_PORT", "9100")),
     )


### PR DESCRIPTION
### Motivation
- Bring core services and automation scripts into alignment with the v3 Enterprise target by removing hardcoded endpoints and ports, making runtime behavior environment-driven, and improving safety and reliability.
- Reduce blast radius from unsafe shell operations and non-deterministic installs by enforcing stricter shell options and deterministic package installation.
- Improve API gateway routing and observability propagation so edge requests can be correlated and routed dynamically in a v3 deployment model. 

### Description
- Replaced hardcoded service endpoints, timeouts, retry settings and server port in `services/master-orchestrator/src/main.py` with environment-driven configuration (`*_URL`, `HTTP_TIMEOUT_SECONDS`, `HTTP_RETRY_*`, `MASTER_ORCHESTRATOR_PORT`) and used those values for all upstream calls. 
- Consolidated proxy target mapping in `apps/api-gateway/src/index.ts`, added request-id propagation to upstreams, added structured proxy error handling and configurable proxy timeout, and switched to an environment-driven `routeTargets` map. 
- Hardened `infrastructure/scripts/bootstrap-platform.sh` by adding `IFS`, a `trap` on `ERR`, limiting permission changes to the infra scripts directory, using `npm ci` for deterministic Node installs, using `python -m pip --no-cache-dir` for Python installs, and starting compose with `--wait`. 
- Made service entrypoint ports configurable via environment variables in `services/arbitrage-engine/src/main.py` and `services/viral-predictor/src/main.py`. 

### Testing
- Ran `python -m compileall` for modified Python entry points and it completed successfully. 
- Ran shell lint check `bash -n infrastructure/scripts/bootstrap-platform.sh` and it passed. 
- Attempted `npm --prefix apps/api-gateway run build` but the TypeScript build fails due to pre-existing type issues in `apps/api-gateway/src/middleware.ts` that are unrelated to these changes (build failure noted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84aec0acc8321bebe6c2a33947d13)