### PR TITLE
ci: install fastapi dependency in Python test workflows

### DIFF
--- a/.github/workflows/enterprise-platform-delivery.yml
+++ b/.github/workflows/enterprise-platform-delivery.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install checks
         run: |
           python -m pip install --upgrade pip
-          pip install pytest yamllint
+          pip install pytest yamllint fastapi
 
       - name: Unit tests
         run: pytest -q

--- a/.github/workflows/zttato-ci.yml
+++ b/.github/workflows/zttato-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Python test tooling
         run: |
           python -m pip install --upgrade pip
-          pip install pytest bandit
+          pip install pytest bandit fastapi
 
       - name: Repository validation
         run: bash infrastructure/scripts/validate-repo.sh


### PR DESCRIPTION
### Motivation
- The test suite imports `fastapi.testclient` during collection causing `ModuleNotFoundError`; the CI workflow should install FastAPI before running `pytest` to allow test collection to succeed.

### Description
- Added `fastapi` to the Python tooling install steps in ` .github/workflows/zttato-ci.yml` and ` .github/workflows/enterprise-platform-delivery.yml` so the runner executes `pip install pytest bandit fastapi` / `pip install pytest yamllint fastapi` prior to `pytest`.

### Testing
- Ran `pytest -q` locally; test collection now proceeds but the suite reports `4 failed, 66 passed, 5 skipped`, so the original FastAPI import error is resolved while four unrelated tests still fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c84d21ee808321a9dad9f4058069f4)