### PR TITLE
ci: harden Docker build workflow with authenticated main-branch pushes

### DIFF
--- a/.github/workflows/zttato-ci.yml
+++ b/.github/workflows/zttato-ci.yml
@@ -90,8 +90,27 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build image
-        run: docker build -t $REGISTRY/$IMAGE_PREFIX/${{ matrix.service }}:${{ github.sha }} services/${{ matrix.service }}
+        uses: docker/build-push-action@v6
+        with:
+          context: services/${{ matrix.service }}
+          push: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
+
+      - name: Build and push image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: services/${{ matrix.service }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
 
   dast-scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

- Prevent accidental or unauthorized image pushes from PRs and ensure Docker credentials are only used for trusted `push` events to `main`.
- Replace ad-hoc `docker build` calls with the official build/push action for consistent, cacheable and repeatable builds.
- Align secret handling with secure practices by using `vars.DOCKER_USERNAME` and `secrets.DOCKER_PASSWORD` rather than embedding tokens in workflows.

### Description

- Updated `.github/workflows/zttato-ci.yml` `build-images` job to add a gated `docker/login-action@v3` step that runs only on `push` to `refs/heads/main` and uses `username: ${{ vars.DOCKER_USERNAME }}` and `password: ${{ secrets.DOCKER_PASSWORD }}`.
- Replaced the raw `docker build` command with `docker/build-push-action@v6` and split it into a non-pushing validation build (`push: false`) and a gated push step (`push: true`) for `main`.
- Standardized image tagging to use `${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}` for both validation and publish steps.
- Change is limited to the `zttato-ci.yml` workflow and does not modify runtime application code.

### Testing

- Parsed all workflow YAML files using a small Python script with `yaml.safe_load()` which reported `OK` for each workflow file.
- Ran an `actionlint` availability check which printed a warning that `actionlint` is not installed in the environment so no `actionlint` validation was executed.
- Verified the change was committed and contains only the intended workflow edits by inspecting the commit (`git show`/`git log`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85573b6248321bf0b9a829d3e562e)