### PR TITLE
Add full feature replacement APIs and stronger validation in feature-store

### DIFF
--- a/services/feature-store/src/main.py
+++ b/services/feature-store/src/main.py
@@ -4,7 +4,7 @@ from typing import Any
 import redis
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 app = FastAPI(title="Feature Store")
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
@@ -12,25 +12,33 @@ REDIS = redis.Redis.from_url(REDIS_URL, decode_responses=True)
 
 
 class CampaignFeatures(BaseModel):
-    views: int = 0
-    clicks: int = 0
-    conversions: int = 0
-    revenue: float = 0.0
-    spend: float = 0.0
-    max_budget: float = 100.0
-    daily_cap: float = 100.0
-    base_bid: float = 0.1
+    views: int = Field(default=0, ge=0)
+    clicks: int = Field(default=0, ge=0)
+    conversions: int = Field(default=0, ge=0)
+    revenue: float = Field(default=0.0, ge=0.0)
+    spend: float = Field(default=0.0, ge=0.0)
+    max_budget: float = Field(default=100.0, ge=0.0)
+    daily_cap: float = Field(default=100.0, ge=0.0)
+    base_bid: float = Field(default=0.1, ge=0.0)
+
+    @field_validator("daily_cap")
+    @classmethod
+    def validate_daily_cap(cls, daily_cap: float, info):
+        max_budget = info.data.get("max_budget")
+        if max_budget is not None and daily_cap > max_budget:
+            raise ValueError("daily_cap must be less than or equal to max_budget")
+        return daily_cap
 
 
 class FeatureUpdate(BaseModel):
-    views: int = Field(default=0)
-    clicks: int = Field(default=0)
-    conversions: int = Field(default=0)
-    revenue: float = Field(default=0.0)
-    spend: float | None = None
-    max_budget: float | None = None
-    daily_cap: float | None = None
-    base_bid: float | None = None
+    views: int = Field(default=0, ge=0)
+    clicks: int = Field(default=0, ge=0)
+    conversions: int = Field(default=0, ge=0)
+    revenue: float = Field(default=0.0, ge=0.0)
+    spend: float | None = Field(default=None, ge=0.0)
+    max_budget: float | None = Field(default=None, ge=0.0)
+    daily_cap: float | None = Field(default=None, ge=0.0)
+    base_bid: float | None = Field(default=None, ge=0.0)
     mode: str = Field(default="increment")
 
 
@@ -50,6 +58,25 @@ def _load_features(campaign_id: str) -> CampaignFeatures:
         daily_cap=float(data.get("daily_cap", data.get("max_budget", 100.0))),
         base_bid=float(data.get("base_bid", 0.1)),
     )
+
+
+def _save_features(campaign_id: str, features: CampaignFeatures) -> None:
+    try:
+        REDIS.hset(
+            f"campaign:{campaign_id}:features",
+            mapping={
+                "views": features.views,
+                "clicks": features.clicks,
+                "conv": features.conversions,
+                "revenue": features.revenue,
+                "spend": features.spend,
+                "max_budget": features.max_budget,
+                "daily_cap": features.daily_cap,
+                "base_bid": features.base_bid,
+            },
+        )
+    except redis.RedisError as exc:
+        raise HTTPException(status_code=503, detail=f"redis unavailable: {exc}") from exc
 
 
 @app.get("/healthz")
@@ -101,24 +128,30 @@ def update_features(campaign_id: str, request: FeatureUpdate) -> CampaignFeature
             base_bid=request.base_bid if request.base_bid is not None else current.base_bid,
         )
 
-    try:
-        REDIS.hset(
-            f"campaign:{campaign_id}:features",
-            mapping={
-                "views": updated.views,
-                "clicks": updated.clicks,
-                "conv": updated.conversions,
-                "revenue": updated.revenue,
-                "spend": updated.spend,
-                "max_budget": updated.max_budget,
-                "daily_cap": updated.daily_cap,
-                "base_bid": updated.base_bid,
-            },
-        )
-    except redis.RedisError as exc:
-        raise HTTPException(status_code=503, detail=f"redis unavailable: {exc}") from exc
-
+    _save_features(campaign_id, updated)
     return updated
+
+
+@app.put("/features/{campaign_id}", response_model=CampaignFeatures)
+def replace_all_features(campaign_id: str, request: CampaignFeatures) -> CampaignFeatures:
+    if not campaign_id:
+        raise HTTPException(status_code=400, detail="campaign_id is required")
+
+    _save_features(campaign_id, request)
+    return request
+
+
+@app.put("/features", response_model=dict[str, CampaignFeatures])
+def replace_all_campaign_features(request: dict[str, CampaignFeatures]) -> dict[str, CampaignFeatures]:
+    if not request:
+        raise HTTPException(status_code=400, detail="at least one campaign payload is required")
+
+    for campaign_id, payload in request.items():
+        if not campaign_id:
+            raise HTTPException(status_code=400, detail="campaign_id is required")
+        _save_features(campaign_id, payload)
+
+    return request
 
 
 if __name__ == "__main__":

--- a/tests/test_profit_mode_pipeline.py
+++ b/tests/test_profit_mode_pipeline.py
@@ -74,6 +74,69 @@ def test_feature_store_supports_budget_and_revenue_updates(monkeypatch):
     assert latest.json()['max_budget'] == 150.0
 
 
+def test_feature_store_can_replace_all_campaign_features(monkeypatch):
+    redis_stub = FakeRedis()
+    import redis
+
+    monkeypatch.setattr(redis.Redis, 'from_url', staticmethod(lambda *args, **kwargs: redis_stub))
+    module = load_module('test_feature_store_replace_all', 'services/feature-store/src/main.py')
+    client = TestClient(module.app)
+
+    payload = {
+        'cmp-a': {
+            'views': 11,
+            'clicks': 3,
+            'conversions': 1,
+            'revenue': 4.2,
+            'spend': 1.4,
+            'max_budget': 25.0,
+            'daily_cap': 10.0,
+            'base_bid': 0.15,
+        },
+        'cmp-b': {
+            'views': 23,
+            'clicks': 5,
+            'conversions': 2,
+            'revenue': 6.3,
+            'spend': 2.1,
+            'max_budget': 45.0,
+            'daily_cap': 20.0,
+            'base_bid': 0.2,
+        },
+    }
+    response = client.put('/features', json=payload)
+    assert response.status_code == 200
+    assert response.json() == payload
+
+    cmp_a = client.get('/features/cmp-a')
+    assert cmp_a.status_code == 200
+    assert cmp_a.json()['views'] == 11
+    cmp_b = client.get('/features/cmp-b')
+    assert cmp_b.status_code == 200
+    assert cmp_b.json()['clicks'] == 5
+
+
+def test_feature_store_rejects_daily_cap_above_budget(monkeypatch):
+    redis_stub = FakeRedis()
+    import redis
+
+    monkeypatch.setattr(redis.Redis, 'from_url', staticmethod(lambda *args, **kwargs: redis_stub))
+    module = load_module('test_feature_store_budget_validation', 'services/feature-store/src/main.py')
+    client = TestClient(module.app)
+
+    response = client.put('/features/cmp-risky', json={
+        'views': 5,
+        'clicks': 1,
+        'conversions': 0,
+        'revenue': 1.0,
+        'spend': 0.5,
+        'max_budget': 10.0,
+        'daily_cap': 20.0,
+        'base_bid': 0.1,
+    })
+    assert response.status_code == 422
+
+
 def test_affiliate_webhook_updates_feature_store_and_reward_collector(monkeypatch):
     monkeypatch.setenv('AFFILIATE_WEBHOOK_SECRET', 'topsecret')
     calls: list[tuple[str, dict[str, object]]] = []


### PR DESCRIPTION
### Motivation
- Enable deterministic and safe batch and single-campaign feature replacements and centralize Redis persistence to reduce duplication and unify error handling.
- Enforce stricter input validation for campaign metrics and budgets to prevent invalid/unsafe values (e.g. negative metrics or daily cap > max budget).

### Description
- Hardened Pydantic models by switching fields to `Field(..., ge=0)` for numeric metrics and budgets and added a `@field_validator` to ensure `daily_cap <= max_budget` in `services/feature-store/src/main.py`.
- Introduced a shared `_save_features(campaign_id, features)` helper to centralize Redis `hset` writes and consistent `RedisError` -> `HTTPException` handling in `services/feature-store/src/main.py`.
- Updated the existing `POST /features/{campaign_id}` flow to use the new `_save_features` helper for persistence in `services/feature-store/src/main.py`.
- Added `PUT /features/{campaign_id}` for full replacement of a single campaign and `PUT /features` for batch replacement across multiple campaigns, both validating inputs and using `_save_features`, implemented in `services/feature-store/src/main.py`.
- Added tests to `tests/test_profit_mode_pipeline.py` covering the batch replacement API and the new budget validation (two new tests: `test_feature_store_can_replace_all_campaign_features` and `test_feature_store_rejects_daily_cap_above_budget`).

### Testing
- Ran `pytest -q tests/test_profit_mode_pipeline.py` which executed the expanded suite and all tests passed (`5 passed`).
- The new tests exercise `PUT /features` batch replacement and validation failure paths and succeeded as part of the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d34b239e28832cb6e72a74405a45ee)