### PR TITLE
fix(rl-trainer): align pydantic pin with ray[rllib] dependency constraints

### DIFF
--- a/services/rl-trainer/requirements.txt
+++ b/services/rl-trainer/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn==1.7.1
 
 cryptography==46.0.6
 fastapi==0.116.1
-pydantic==2.11.7
+pydantic==2.12.0


### PR DESCRIPTION
### Motivation
- Resolve a dependency resolution failure caused by `pydantic==2.11.7` being excluded by `ray[rllib]==2.54.0` by choosing a compatible `pydantic` minor release.

### Description
- Update `services/rl-trainer/requirements.txt` to change `pydantic==2.11.7` to `pydantic==2.12.0` and commit the change.

### Testing
- Attempted an automated dependency availability check with `python3 -m pip index versions pydantic`, which failed due to network/proxy restrictions (`ProxyError 403`), and no other automated tests were executed; the requirements file change was successfully committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d35b84ea60832ca1fcf849399d2334)