### PR TITLE
Update CI Codex call, add httpx to test tooling, and bump PyJWT/Pydantic versions

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -26,6 +26,6 @@ jobs:
         run: npm install -g @openai/codex
 
       - name: Run Codex review
-        run: codex --task "review code and propose improvements"
+        run: codex "review code and propose improvements"
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/zttato-ci.yml
+++ b/.github/workflows/zttato-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Python test tooling
         run: |
           python -m pip install --upgrade pip
-          pip install pytest bandit fastapi
+          pip install pytest bandit fastapi httpx
 
       - name: Repository validation
         run: bash infrastructure/scripts/validate-repo.sh

--- a/services/jwt-auth/requirements.txt
+++ b/services/jwt-auth/requirements.txt
@@ -1,3 +1,3 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
-PyJWT==2.10.1
+PyJWT==2.12.0

--- a/services/rl-trainer/requirements.txt
+++ b/services/rl-trainer/requirements.txt
@@ -6,4 +6,4 @@ scikit-learn==1.7.1
 
 cryptography==46.0.6
 fastapi==0.116.1
-pydantic==2.11.7
+pydantic==2.12.0


### PR DESCRIPTION
### Motivation
- Align the GitHub Actions workflow with the updated `codex` CLI invocation syntax to avoid runtime errors.  
- Ensure HTTP client dependency is available in the Python test environment for integration tests and test clients.  
- Upgrade `PyJWT` and `pydantic` to newer patch releases for compatibility and potential security/bug fixes.

### Description
- Changed the Codex workflow step to call `codex "review code and propose improvements"` instead of using the `--task` flag.  
- Added `httpx` to the CI `pip install` line so the Python test environment installs the HTTP client.  
- Bumped `PyJWT` in `services/jwt-auth/requirements.txt` from `2.10.1` to `2.12.0`.  
- Bumped `pydantic` in `services/rl-trainer/requirements.txt` from `2.11.7` to `2.12.0`.

### Testing
- CI CI job installs tooling with `pip install pytest bandit fastapi httpx` and runs `pytest -q`, and the unit tests completed successfully.  
- Static analysis and security scans were run via `bandit -r enterprise_maturity services -x services/admin-panel` and returned without failures.  
- Repository validation and infrastructure checks were executed using `infrastructure/scripts/validate-repo.sh`, `check-api-contracts.sh`, and `check-iac-policy.sh` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d35b84ea60832ca1fcf849399d2334)