### PR TITLE
docs: add validation report for non-applicable Minecraft patch

### DIFF
--- a/docs/reviews/2026-04-06-minecraft-plugin-patch-validation.md
+++ b/docs/reviews/2026-04-06-minecraft-plugin-patch-validation.md
@@ -1,0 +1,28 @@
+# Minecraft plugin patch validation (2026-04-06)
+
+## Scope
+Validated the proposed patch targeting:
+
+- `src/main/java/dev/zeaze/zttatoplatform/...`
+- `src/main/resources/plugin.yml`
+
+## Result
+The proposed patch cannot be applied to this repository as-is because the targeted Minecraft/Bukkit plugin source tree does not exist in the current codebase.
+
+## Evidence
+- No `src/main/java` tree is present for `dev.zeaze.zttatoplatform` classes.
+- No plugin descriptor exists at `src/main/resources/plugin.yml`.
+- The repository currently contains a multi-service platform layout (for example `services/`, `infrastructure/`, `workers/`, `apps/`) rather than a Bukkit plugin module.
+
+## Impact
+Applying the patch directly would fail and could introduce confusion by adding an unrelated module in an arbitrary location.
+
+## Recommended next steps
+1. Confirm the intended repository or branch for the Minecraft plugin code.
+2. If this repository should include a Bukkit module, provide the correct module path and build system.
+3. Re-run patch generation against the correct tree and include compile/test commands (for example, Maven/Gradle targets).
+
+## Commands used
+- `rg --files | rg 'src/main/java|plugin.yml|zttato|minecraft|bukkit'`
+- `rg "class ZttatoPlatform|PlayerJoinListener|ScoreboardTask|plugin.yml|CommandExecutor"`
+- `find . -name AGENTS.md -print`


### PR DESCRIPTION
### Motivation
- Document that the provided Bukkit/Minecraft patch targets paths (`src/main/java/...` and `src/main/resources/plugin.yml`) which are not present in this repository to prevent invalid patch application.

### Description
- Add `docs/reviews/2026-04-06-minecraft-plugin-patch-validation.md` containing evidence that the plugin source tree and `plugin.yml` are missing, the impact of applying the patch, and recommended next steps to proceed in the correct repository/module.

### Testing
- Verified repository contents with `rg --files | rg 'src/main/java|plugin.yml|zttato|minecraft|bukkit'`, which returned no matching plugin tree and succeeded.
- Searched for class identifiers with `rg "class ZttatoPlatform|PlayerJoinListener|ScoreboardTask|plugin.yml|CommandExecutor"`, which returned no matches and succeeded.
- Confirmed presence of repository metadata with `find . -name AGENTS.md -print`, which located the project `AGENTS.md` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d365afb930832c8e137617184a6b2b)