### PR TITLE
Fix TypeScript build breaks in API gateway auth and frontend App component

### DIFF
--- a/apps/api-gateway/src/middleware.ts
+++ b/apps/api-gateway/src/middleware.ts
@@ -1,17 +1,26 @@
 import type { NextFunction, Request, Response } from "express";
-import jwt from "jsonwebtoken";
+import jwt, { type JwtPayload } from "jsonwebtoken";
 
 type JwtClaims = {
   userId: string;
   tenantId: string;
 };
 
-const jwtSecret = process.env.JWT_SECRET;
-if (!jwtSecret || jwtSecret.length < 32) {
+const jwtSecretEnv = process.env.JWT_SECRET;
+if (!jwtSecretEnv || jwtSecretEnv.length < 32) {
   throw new Error("JWT_SECRET is required and must be at least 32 characters long");
 }
 
+const jwtSecret: string = jwtSecretEnv;
 const publicRoutes = new Set(["/healthz", "/auth/login", "/auth/register"]);
+
+function isJwtClaims(value: string | JwtPayload): value is JwtClaims {
+  if (typeof value === "string") {
+    return false;
+  }
+
+  return typeof value.userId === "string" && typeof value.tenantId === "string";
+}
 
 export function auth(req: Request, res: Response, next: NextFunction) {
   if (publicRoutes.has(req.path)) {
@@ -29,7 +38,11 @@ export function auth(req: Request, res: Response, next: NextFunction) {
     const decoded = jwt.verify(token, jwtSecret, {
       issuer: "zttato-auth-service",
       audience: "zttato-platform",
-    }) as JwtClaims;
+    });
+
+    if (!isJwtClaims(decoded)) {
+      return res.status(403).json({ ok: false, error: "Forbidden" });
+    }
 
     req.headers["x-user-id"] = decoded.userId;
     req.headers["x-tenant-id"] = decoded.tenantId;

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
-import Landing from "./Landing";
 import { useEffect, useState } from "react";
+import Landing from "./Landing";
 import Logs from "./Logs";
 
 type LoginResponse = { ok: boolean; token?: string; error?: string; userId?: string };
@@ -18,7 +17,7 @@ export default function App() {
   const [token, setToken] = useState(localStorage.getItem("token") ?? "");
   const [gallery, setGallery] = useState<Array<{ projectId: string; url: string }>>([]);
 
-  const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
+  const authHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
 
   const register = async () => {
     const res = await fetch("/auth/register", {
@@ -48,13 +47,18 @@ export default function App() {
   };
 
   const deploy = async () => {
-    const res = await fetch("/core/deploy", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...authHeaders },
-      body: JSON.stringify({ projectId: project.trim() }),
-    });
-    const data = (await res.json()) as DeployResponse;
-    setStatus(data.ok ? `Deploy queued: ${data.deploy?.url ?? data.status}` : (data.error ?? "Deploy failed"));
+    setIsDeploying(true);
+    try {
+      const res = await fetch("/core/deploy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...authHeaders },
+        body: JSON.stringify({ projectId: project.trim() }),
+      });
+      const data = (await res.json()) as DeployResponse;
+      setStatus(data.ok ? `Deploy queued: ${data.deploy?.url ?? data.status}` : (data.error ?? "Deploy failed"));
+    } finally {
+      setIsDeploying(false);
+    }
   };
 
   const deployRepo = async () => {
@@ -80,7 +84,7 @@ export default function App() {
   }, [token]);
 
   return (
-    <div style={{ padding: "2rem", fontFamily: "Arial, sans-serif", maxWidth: 760, margin: "0 auto" }}>
+    <div style={{ padding: "2rem", fontFamily: "Arial, sans-serif", maxWidth: 840, margin: "0 auto" }}>
       <Landing onStartFree={() => setShowSignup(true)} />
 
       <section
@@ -97,58 +101,43 @@ export default function App() {
       </section>
 
       <section style={{ marginTop: "1.5rem" }}>
-        <h2 style={{ fontSize: "1.3rem" }}>Deploy Console</h2>
-        {showSignup ? (
-          <p style={{ color: "#111827" }}>
-            Signup step simulated. Connect GitHub, then deploy your first app.
-          </p>
-        ) : null}
+        <h2 style={{ fontSize: "1.3rem" }}>Authentication</h2>
+        {showSignup ? <p style={{ color: "#111827" }}>Signup step simulated. Connect GitHub, then deploy your first app.</p> : null}
 
+        <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
         <input
-          style={{ width: "100%", padding: "0.6rem", marginTop: "1rem" }}
-          placeholder="Project ID"
-          onChange={(e) => setProject(e.target.value)}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          type="password"
         />
+        <button onClick={register}>Register</button>
+        <button onClick={login}>Login</button>
 
-        <button
-          style={{ marginTop: "1rem", padding: "0.6rem 1rem" }}
-          onClick={deploy}
-          disabled={isDeploying}
-        >
+        <h2>Deploy Project</h2>
+        <input value={project} onChange={(e) => setProject(e.target.value)} placeholder="Project ID" />
+        <button onClick={deploy} disabled={isDeploying}>
           {isDeploying ? "Deploying..." : "Deploy"}
         </button>
-    <div style={{ padding: "2rem", fontFamily: "Arial, sans-serif", maxWidth: 840 }}>
-      <h1>ZTTATO SaaS Console</h1>
-      <p>Auth, deploy, GitHub 1-click pipeline, and real-time logs.</p>
 
-      <h2>Authentication</h2>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
-      <input value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" type="password" />
-      <button onClick={register}>Register</button>
-      <button onClick={login}>Login</button>
+        <h2>1-Click GitHub Deploy</h2>
+        <input value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="https://github.com/org/repo" />
+        <button onClick={deployRepo}>Deploy Repo</button>
 
-      <h2>Deploy Project</h2>
-      <input value={project} onChange={(e) => setProject(e.target.value)} placeholder="Project ID" />
-      <button onClick={deploy}>Deploy</button>
+        <h2>Public Gallery</h2>
+        <button onClick={loadGallery}>Refresh Gallery</button>
+        <ul>
+          {gallery.map((projectItem) => (
+            <li key={projectItem.projectId}>
+              <a href={projectItem.url} target="_blank" rel="noreferrer">
+                {projectItem.projectId}
+              </a>
+            </li>
+          ))}
+        </ul>
 
-      <h2>1-Click GitHub Deploy</h2>
-      <input value={repo} onChange={(e) => setRepo(e.target.value)} placeholder="https://github.com/org/repo" />
-      <button onClick={deployRepo}>Deploy Repo</button>
-
-      <h2>Public Gallery</h2>
-      <button onClick={loadGallery}>Refresh Gallery</button>
-      <ul>
-        {gallery.map((projectItem) => (
-          <li key={projectItem.projectId}>
-            <a href={projectItem.url} target="_blank" rel="noreferrer">
-              {projectItem.projectId}
-            </a>
-          </li>
-        ))}
-      </ul>
-
-      <h2>Live Logs</h2>
-      <Logs />
+        <h2>Live Logs</h2>
+        <Logs />
 
         <div style={{ marginTop: "1rem" }}>
           <strong>Status:</strong> {status}


### PR DESCRIPTION
### Motivation
- The monorepo TypeScript build was failing due to unsafe JWT decoding assumptions and malformed/duplicate JSX and header typing in the frontend, blocking CI and local builds.
- Harden auth middleware to avoid runtime token errors and make types deterministic for downstream handlers.

### Description
- Validate `JWT_SECRET` into a non-optional typed constant (`jwtSecret`) and add a `JwtClaims` type guard to `apps/api-gateway/src/middleware.ts` so decoded tokens are explicitly checked for `userId` and `tenantId` before use.
- Replace unsafe cast of `jwt.verify` result with runtime validation and return `403` for tokens missing required claims in the gateway middleware.
- Clean up `apps/frontend/src/App.tsx` by removing duplicated imports/JSX blocks, restoring a single valid component tree with proper closing tags, and harmonizing layout sizes.
- Fix `fetch` header typing by typing `authHeaders` as `Record<string, string>` and ensure the deploy button loading state is always reset using a `finally` block.

### Testing
- Ran `npm run build` for the repository and confirmed TypeScript compilation and frontend build succeed across workspaces, including `@zttato/api-gateway` and `@zttato/frontend` (build passed).
- Verified the gateway auth middleware now rejects malformed/insufficient JWTs by code inspection and type-checked compilation (TypeScript errors resolved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36d38e828832cb5fcb7316e7140b8)