### PR TITLE
Fix payment service import/runtime bugs, circuit-breaker threshold, and harden retry logic

### DIFF
--- a/services/payment/adapter.py
+++ b/services/payment/adapter.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import requests
 
-from audit import log
-from circuit import allow, fail, success
+from .audit import log
+from .circuit import allow, fail, success
 
 TIMEOUT = float(os.getenv("PAYMENT_TIMEOUT", "3"))
 DEFAULT_HEADERS = {"Content-Type": "application/json"}
@@ -15,10 +15,14 @@ DEFAULT_HEADERS = {"Content-Type": "application/json"}
 
 
 def send(endpoint: str, payload: dict[str, Any], retries: int = 3) -> dict[str, Any]:
+    if retries < 1:
+        raise ValueError("retries must be at least 1")
+
     if not allow():
         log("payment_circuit_open", payload)
         return {"status": "circuit_open"}
 
+    last_error: Exception | None = None
     for attempt in range(retries):
         try:
             response = requests.post(endpoint, json=payload, headers=DEFAULT_HEADERS, timeout=TIMEOUT)
@@ -26,11 +30,14 @@ def send(endpoint: str, payload: dict[str, Any], retries: int = 3) -> dict[str, 
                 success()
                 log("payment_success", payload)
                 return response.json()
-        except requests.RequestException:
-            pass
-
-        fail()
-        log("payment_fail", payload)
+            fail()
+            log("payment_fail", {**payload, "http_status": response.status_code})
+        except requests.RequestException as exc:
+            last_error = exc
+            fail()
+            log("payment_fail", {**payload, "error": str(exc)})
         time.sleep(2**attempt)
 
+    if last_error is not None:
+        log("payment_request_error", payload)
     return {"status": "failed"}

--- a/services/payment/circuit.py
+++ b/services/payment/circuit.py
@@ -32,5 +32,5 @@ def fail(now: float | None = None) -> None:
     global FAILS, OPEN, LAST_FAIL
     FAILS += 1
     LAST_FAIL = time.time() if now is None else now
-    if FAILS > MAX_FAILURES:
+    if FAILS >= MAX_FAILURES:
         OPEN = True

--- a/services/payment/main.py
+++ b/services/payment/main.py
@@ -8,8 +8,8 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, HttpUrl
 
-from adapter import send
-from audit import log
+from .adapter import send
+from .audit import log
 
 app = FastAPI(title="Payment Gateway")
 STRIPE_ENDPOINT = os.getenv("PAYMENT_STRIPE_ENDPOINT", "https://payments.example/stripe")

--- a/tests/test_payment_adapter_resilience.py
+++ b/tests/test_payment_adapter_resilience.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from services.payment import adapter, circuit
+
+
+def test_payment_modules_importable() -> None:
+    importlib.import_module("services.payment.adapter")
+    importlib.import_module("services.payment.main")
+
+
+def test_circuit_opens_at_failure_threshold() -> None:
+    circuit.FAILS = 0
+    circuit.OPEN = False
+    circuit.LAST_FAIL = 0.0
+
+    for _ in range(circuit.MAX_FAILURES):
+        circuit.fail(now=100.0)
+
+    assert circuit.OPEN is True
+    assert circuit.allow(now=100.0 + circuit.RESET_AFTER_SECONDS - 1) is False
+
+
+def test_send_rejects_invalid_retry_count() -> None:
+    with pytest.raises(ValueError, match="retries must be at least 1"):
+        adapter.send("https://payments.example/stripe", {"campaign_id": "cmp-1"}, retries=0)
+
+
+def test_send_returns_failed_after_http_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    class StubResponse:
+        status_code = 503
+
+    monkeypatch.setattr(adapter, "allow", lambda: True)
+    monkeypatch.setattr(adapter, "fail", lambda: None)
+    monkeypatch.setattr(adapter, "success", lambda: None)
+    monkeypatch.setattr(adapter, "log", lambda *args, **kwargs: None)
+    monkeypatch.setattr(adapter.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(adapter.requests, "post", lambda *args, **kwargs: StubResponse())
+
+    response = adapter.send("https://payments.example/stripe", {"campaign_id": "cmp-1"}, retries=1)
+
+    assert response == {"status": "failed"}


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when importing the payment service as a package and harden its runtime behavior to be production-safe and deterministic. 
- Ensure the circuit-breaker opens at the intended threshold to avoid delayed fail-fast behavior. 
- Make the HTTP adapter more robust with input validation and clearer failure logging so retries behave deterministically.

### Description
- Use package-relative imports in `services/payment/adapter.py` and `services/payment/main.py` to fix `ModuleNotFoundError` when importing `services.payment.*`.
- Change the circuit-breaker condition in `services/payment/circuit.py` to open when `FAILS >= MAX_FAILURES` instead of only after exceeding the threshold. 
- Harden `services/payment/adapter.py::send()` by adding retry count validation (`retries >= 1`), tracking the last exception, improving logging for HTTP 5xx and request exceptions, and making failure behavior deterministic after exhausting retries. 
- Add focused regression tests in `tests/test_payment_adapter_resilience.py` that cover module importability, circuit threshold behavior, retry validation, and HTTP 5xx exhaustion behavior.

### Testing
- Ran the new focused tests with `pytest -q tests/test_payment_adapter_resilience.py tests/test_tracking_and_payment_webhook.py` and they passed (`6 passed`).
- Ran the full test suite with `pytest -q` and all tests succeeded (`78 passed, 5 skipped`).
- Verified module importability with `python - <<'PY' ... import services.payment.main, services.payment.adapter ... PY` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36e65ae6c832ca487ec672a7791a9)