### PR TITLE
Harden frontend auth defaults and enforce pre-submit credential checks

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -7,8 +7,8 @@ type DeployResponse = { ok: boolean; status?: string; error?: string; deploy?: {
 type GalleryResponse = { ok: boolean; projects?: Array<{ projectId: string; url: string }> };
 
 export default function App() {
-  const [email, setEmail] = useState("founder@zttato.dev");
-  const [password, setPassword] = useState("ChangeMe123456");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [project, setProject] = useState("");
   const [repo, setRepo] = useState("");
   const [status, setStatus] = useState("Idle");
@@ -20,19 +20,29 @@ export default function App() {
   const authHeaders: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
 
   const register = async () => {
+    if (!email.trim() || !password) {
+      setStatus("Registration requires both email and password.");
+      return;
+    }
+
     const res = await fetch("/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email: email.trim(), password }),
     });
     setStatus(res.ok ? "Registered. Now login." : "Registration failed.");
   };
 
   const login = async () => {
+    if (!email.trim() || !password) {
+      setStatus("Login requires both email and password.");
+      return;
+    }
+
     const res = await fetch("/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email: email.trim(), password }),
     });
     const data = (await res.json()) as LoginResponse;
 

--- a/tests/test_frontend_auth_security_defaults.py
+++ b/tests/test_frontend_auth_security_defaults.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_frontend_does_not_ship_seeded_credentials():
+    app_source = Path("apps/frontend/src/App.tsx").read_text(encoding="utf-8")
+    assert 'useState("founder@zttato.dev")' not in app_source
+    assert 'useState("ChangeMe123456")' not in app_source
+
+
+def test_frontend_requires_credentials_before_auth_calls():
+    app_source = Path("apps/frontend/src/App.tsx").read_text(encoding="utf-8")
+    assert "Registration requires both email and password." in app_source
+    assert "Login requires both email and password." in app_source


### PR DESCRIPTION
### Motivation
- The frontend shipped with hardcoded seeded credentials which risk accidental reuse and weaken auth hygiene in shared/demo environments. 
- Empty or whitespace-only auth submissions caused unnecessary backend traffic and noisy failures. 
- Normalizing outbound auth payloads reduces malformed input and accidental account creation issues.

### Description
- Removed seeded default values for email and password in `apps/frontend/src/App.tsx` so fields are empty by default. 
- Added client-side pre-submit guards that block `register` and `login` when email is empty/whitespace or password is empty and surface clear status messages. 
- Trim `email` before sending auth payloads to backend to normalize input. 
- Added regression tests in `tests/test_frontend_auth_security_defaults.py` to prevent reintroduction of seeded credentials and to assert the presence of the credential-required guards.

### Testing
- Ran the new frontend tests with `pytest -q tests/test_frontend_auth_security_defaults.py` which passed (`2 passed`). 
- Ran the full test suite with `pytest -q` which succeeded (`80 passed, 5 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d36fa5d450832c925553495382e6c7)