### PR TITLE
Harden auto-ml loop command execution and failure handling

### DIFF
--- a/services/auto-ml/loop.py
+++ b/services/auto-ml/loop.py
@@ -1,23 +1,65 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import subprocess
+import sys
 from pathlib import Path
+from typing import Any
 
 MODEL_DIR = Path(os.getenv("MODEL_DIR", "/models"))
 THRESHOLD = float(os.getenv("PROMOTE_DELTA", "0.02"))
+COMMAND_TIMEOUT_SECONDS = int(os.getenv("AUTO_ML_COMMAND_TIMEOUT_SECONDS", "900"))
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+logger = logging.getLogger("auto_ml.loop")
+
+
+def _log(event: str, **fields: Any) -> None:
+    payload: dict[str, Any] = {"event": event, **fields}
+    logger.info(json.dumps(payload, sort_keys=True))
+
+
+def _run_command(*args: str) -> subprocess.CompletedProcess[str] | None:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=SCRIPT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=COMMAND_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _log("command_spawn_failed", command=list(args))
+        return None
+
+    _log(
+        "command_executed",
+        command=list(args),
+        returncode=completed.returncode,
+        stderr=completed.stderr.strip(),
+    )
+    return completed
 
 
 
 def train() -> bool:
-    return subprocess.call("python train.py", shell=True) == 0
+    completed = _run_command(sys.executable, "train.py")
+    return bool(completed) and completed.returncode == 0
 
 
 
 def evaluate() -> float:
-    output = subprocess.check_output("python eval.py", shell=True).decode().strip()
-    return float(output)
+    completed = _run_command(sys.executable, "eval.py")
+    if not completed or completed.returncode != 0:
+        raise RuntimeError("evaluate command failed")
+
+    try:
+        return float(completed.stdout.strip())
+    except ValueError as exc:
+        raise RuntimeError("evaluate command returned non-numeric score") from exc
 
 
 
@@ -36,7 +78,8 @@ def save_metric(path: Path, value: float) -> None:
 
 
 def deploy() -> bool:
-    return subprocess.call("bash deploy_model.sh", shell=True) == 0
+    completed = _run_command("bash", "deploy_model.sh")
+    return bool(completed) and completed.returncode == 0
 
 
 
@@ -44,15 +87,24 @@ def loop() -> dict[str, float | str]:
     previous_metric_path = MODEL_DIR / "metric.txt"
     previous = load_metric(previous_metric_path)
     if not train():
+        _log("loop_exit", status="train_failed")
         return {"status": "train_failed"}
 
-    score = evaluate()
+    try:
+        score = evaluate()
+    except RuntimeError:
+        _log("loop_exit", status="evaluate_failed")
+        return {"status": "evaluate_failed"}
+
     if score >= previous + THRESHOLD:
         if deploy():
             save_metric(previous_metric_path, score)
+            _log("loop_exit", status="promoted", score=score, prev=previous)
             return {"status": "promoted", "score": score}
+        _log("loop_exit", status="deploy_failed", score=score, prev=previous)
         return {"status": "deploy_failed"}
 
+    _log("loop_exit", status="rejected", score=score, prev=previous)
     return {"status": "rejected", "score": score, "prev": previous}
 
 

--- a/tests/test_auto_ml_loop_security.py
+++ b/tests/test_auto_ml_loop_security.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+MODULE_PATH = Path("services/auto-ml/loop.py")
+SPEC = importlib.util.spec_from_file_location("auto_ml_loop", MODULE_PATH)
+assert SPEC and SPEC.loader
+auto_ml_loop = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(auto_ml_loop)
+
+
+def test_run_command_uses_argument_list_without_shell(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs):
+        called["args"] = args
+        called["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args=["ok"], returncode=0, stdout="0.9", stderr="")
+
+    monkeypatch.setattr(auto_ml_loop.subprocess, "run", fake_run)
+
+    result = auto_ml_loop._run_command("echo", "ok")
+
+    assert result is not None
+    assert called["args"] == (("echo", "ok"),)
+    assert "shell" not in called["kwargs"]
+
+
+def test_evaluate_rejects_non_numeric_output(monkeypatch) -> None:
+    monkeypatch.setattr(
+        auto_ml_loop,
+        "_run_command",
+        lambda *_: subprocess.CompletedProcess(args=["eval"], returncode=0, stdout="not-a-number", stderr=""),
+    )
+
+    try:
+        auto_ml_loop.evaluate()
+    except RuntimeError as exc:
+        assert "non-numeric" in str(exc)
+    else:
+        raise AssertionError("evaluate() should fail when eval.py is non-numeric")
+
+
+def test_loop_returns_evaluate_failed_when_eval_command_fails(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(auto_ml_loop, "MODEL_DIR", tmp_path)
+    monkeypatch.setattr(auto_ml_loop, "train", lambda: True)
+    monkeypatch.setattr(auto_ml_loop, "evaluate", lambda: (_ for _ in ()).throw(RuntimeError("failed")))
+
+    result = auto_ml_loop.loop()
+
+    assert result["status"] == "evaluate_failed"


### PR DESCRIPTION
### Motivation
- Prevent command injection and improve reliability in the Auto-ML promotion pipeline by removing shell-based subprocess calls. 
- Ensure deterministic failure modes and better observability for production troubleshooting. 
- Make script execution use the same Python interpreter that runs the service to avoid interpreter ambiguity.

### Description
- Replaced shell-invocations (`shell=True`) with an argument-list executor `_run_command()` that calls `subprocess.run` with `capture_output`, `text`, a fixed `cwd`, and a bounded timeout configured via `AUTO_ML_COMMAND_TIMEOUT_SECONDS` in `services/auto-ml/loop.py`.
- Added structured JSON logging via `_log()` to record command spawn/execution outcomes and loop exit events. 
- Switched Python invocations to use `sys.executable` for `train()` and `evaluate()` and hardened `evaluate()` to raise on non-zero exit or non-numeric stdout. 
- Added `tests/test_auto_ml_loop_security.py` with tests verifying argument-list execution (no `shell`), non-numeric eval handling, and `loop()` behavior when evaluation fails.

### Testing
- Ran focused tests with `pytest -q tests/test_auto_ml_loop_security.py tests/test_profit_mode_pipeline.py` which passed (`8 passed`).
- Ran the full test suite with `pytest -q` which succeeded (`83 passed, 5 skipped`).
- New security-focused tests exercise the hardened command execution paths and assertion behaviors and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d370980d58832c84e86281b71acaa3)