### PR TITLE
Add deterministic feature impact dive report generator

### DIFF
--- a/docs/development/feature-impact-dive-2026-04-06.md
+++ b/docs/development/feature-impact-dive-2026-04-06.md
@@ -1,0 +1,82 @@
+# zTTato Feature Impact Dive
+
+- Generated from repository sources on 2026-04-06 (UTC).
+- Compose services discovered: **43**
+- Node app features discovered: **6**
+- Service documentation feature specs: **11**
+- Aggregate discovered feature surfaces: **60**
+
+## Compose Service Surface
+
+- affiliate-webhook
+- arbitrage-engine
+- arbitrage-worker
+- billing-service
+- budget-allocator
+- capital-allocator
+- crawler-worker
+- drift-detector
+- execution-engine
+- feature-store
+- federation
+- gpu-renderer
+- landing-service
+- market-crawler
+- market-orchestrator
+- master-orchestrator
+- model-registry
+- model-service
+- model-sync
+- nginx
+- p2p-node
+- payment-gateway
+- postgres
+- product-generator
+- ray-head
+- ray-worker
+- redis
+- redpanda
+- renderer-worker
+- retraining-loop
+- reward-collector
+- rl-agent-1
+- rl-agent-2
+- rl-coordinator
+- rl-engine
+- rl-policy
+- rl-trainer
+- rtb-engine
+- scaling-engine
+- scheduler
+- stream-consumer
+- tenant-service
+- viral-predictor
+
+## Application API Surface
+
+- api-gateway (1 endpoints): /healthz
+- auth-service (3 endpoints): /healthz, /login, /register
+- billing-service (4 endpoints): /checkout, /healthz, /plan/:userId, /webhook
+- log-service (2 endpoints): /healthz, /log
+- platform-core (7 endpoints): /deploy, /deploy/github, /github/repos, /healthz, /orgs, /orgs/:orgId/members, /projects/public
+- worker-ai (2 endpoints): /fix, /healthz
+
+## Documented Product Feature Surface
+
+- account-farm: Account Farm Service
+- admin-panel: Admin Panel
+- ai-video-generator: AI Video Generator Service
+- analytics: Analytics Service
+- arbitrage-engine: Arbitrage Engine Service
+- click-tracker: Click Tracker Service
+- gpu-renderer: GPU Renderer Service
+- market-crawler: Market Crawler Service
+- master-orchestrator: Master Orchestrator Service
+- tiktok-uploader: TikTok Uploader Service
+- viral-predictor: Viral Predictor Service
+
+## Recommended Fixes
+
+1. Consolidate duplicated feature naming between compose services and docs/services into a single source-of-truth manifest.
+2. Add this script to CI to detect undocumented apps or routes drift.
+3. Review app routes that expose write endpoints and enforce tenant/auth middleware at service level.

--- a/scripts/feature_impact_dive.py
+++ b/scripts/feature_impact_dive.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Generate a deterministic feature inventory and impact report for the repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "development" / "feature-impact-dive-2026-04-06.md"
+
+SERVICE_DOCS_DIR = REPO_ROOT / "docs" / "services"
+APPS_DIR = REPO_ROOT / "apps"
+COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
+
+ENDPOINT_RE = re.compile(r'app\.(?:get|post|put|patch|delete)\(\s*[\'"]([^\'"]+)[\'"]')
+DOC_HEADING_RE = re.compile(r"^#\s+(.+?)\s*$")
+SERVICE_NAME_RE = re.compile(r"^\s{2}([a-zA-Z0-9_.-]+):\s*$")
+
+
+@dataclass(frozen=True)
+class AppFeature:
+    name: str
+    endpoints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ServiceDocFeature:
+    slug: str
+    title: str
+
+
+@dataclass(frozen=True)
+class ImpactReport:
+    compose_services: tuple[str, ...]
+    app_features: tuple[AppFeature, ...]
+    documented_features: tuple[ServiceDocFeature, ...]
+
+    @property
+    def total_features(self) -> int:
+        return len(self.compose_services) + len(self.app_features) + len(self.documented_features)
+
+
+def _read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def extract_compose_services(compose_file: Path) -> tuple[str, ...]:
+    if not compose_file.exists():
+        return tuple()
+
+    lines = _read_lines(compose_file)
+    in_services_block = False
+    services: list[str] = []
+
+    for line in lines:
+        if not in_services_block:
+            if line.strip() == "services:":
+                in_services_block = True
+            continue
+
+        if line and not line.startswith(" "):
+            break
+
+        match = SERVICE_NAME_RE.match(line)
+        if match:
+            services.append(match.group(1))
+
+    return tuple(sorted(set(services)))
+
+
+def extract_app_features(apps_dir: Path) -> tuple[AppFeature, ...]:
+    if not apps_dir.exists():
+        return tuple()
+
+    features: list[AppFeature] = []
+    for app_dir in sorted(path for path in apps_dir.iterdir() if path.is_dir()):
+        index_file = app_dir / "src" / "index.ts"
+        if not index_file.exists():
+            continue
+
+        content = index_file.read_text(encoding="utf-8")
+        endpoints = tuple(sorted(set(ENDPOINT_RE.findall(content))))
+        features.append(AppFeature(name=app_dir.name, endpoints=endpoints))
+
+    return tuple(features)
+
+
+def extract_documented_features(service_docs_dir: Path) -> tuple[ServiceDocFeature, ...]:
+    if not service_docs_dir.exists():
+        return tuple()
+
+    docs: list[ServiceDocFeature] = []
+    for doc_file in sorted(service_docs_dir.glob("*.md")):
+        heading = doc_file.stem.replace("-", " ").title()
+        for line in _read_lines(doc_file):
+            match = DOC_HEADING_RE.match(line)
+            if match:
+                heading = match.group(1).strip()
+                break
+        docs.append(ServiceDocFeature(slug=doc_file.stem, title=heading))
+
+    return tuple(docs)
+
+
+def build_impact_report(repo_root: Path = REPO_ROOT) -> ImpactReport:
+    return ImpactReport(
+        compose_services=extract_compose_services(repo_root / "docker-compose.yml"),
+        app_features=extract_app_features(repo_root / "apps"),
+        documented_features=extract_documented_features(repo_root / "docs" / "services"),
+    )
+
+
+def _render_section(title: str, rows: Iterable[str]) -> str:
+    formatted_rows = "\n".join(f"- {row}" for row in rows)
+    return f"## {title}\n\n{formatted_rows if formatted_rows else '- (none)'}\n"
+
+
+def format_markdown(report: ImpactReport) -> str:
+    summary = (
+        f"# zTTato Feature Impact Dive\n\n"
+        f"- Generated from repository sources on 2026-04-06 (UTC).\n"
+        f"- Compose services discovered: **{len(report.compose_services)}**\n"
+        f"- Node app features discovered: **{len(report.app_features)}**\n"
+        f"- Service documentation feature specs: **{len(report.documented_features)}**\n"
+        f"- Aggregate discovered feature surfaces: **{report.total_features}**\n"
+    )
+
+    compose_rows = tuple(report.compose_services)
+    app_rows = tuple(
+        f"{feature.name} ({len(feature.endpoints)} endpoints): "
+        + (", ".join(feature.endpoints) if feature.endpoints else "no HTTP routes found")
+        for feature in report.app_features
+    )
+    doc_rows = tuple(f"{doc.slug}: {doc.title}" for doc in report.documented_features)
+
+    return "\n".join(
+        [
+            summary,
+            _render_section("Compose Service Surface", compose_rows),
+            _render_section("Application API Surface", app_rows),
+            _render_section("Documented Product Feature Surface", doc_rows),
+            "## Recommended Fixes\n\n"
+            "1. Consolidate duplicated feature naming between compose services and docs/services into a single source-of-truth manifest.\n"
+            "2. Add this script to CI to detect undocumented apps or routes drift.\n"
+            "3. Review app routes that expose write endpoints and enforce tenant/auth middleware at service level.\n",
+        ]
+    )
+
+
+def write_report(report: ImpactReport, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(format_markdown(report), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate repository feature impact dive report")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Markdown output file path",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON to stdout",
+    )
+    args = parser.parse_args()
+
+    report = build_impact_report(REPO_ROOT)
+    write_report(report, args.output)
+
+    if args.json:
+        payload = {
+            "compose_services": report.compose_services,
+            "app_features": [
+                {
+                    "name": feature.name,
+                    "endpoint_count": len(feature.endpoints),
+                    "endpoints": feature.endpoints,
+                }
+                for feature in report.app_features
+            ],
+            "documented_features": [
+                {"slug": doc.slug, "title": doc.title} for doc in report.documented_features
+            ],
+            "total_features": report.total_features,
+        }
+        print(json.dumps(payload, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_feature_impact_dive.py
+++ b/tests/test_feature_impact_dive.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from scripts.feature_impact_dive import (
+    extract_app_features,
+    extract_compose_services,
+    extract_documented_features,
+    format_markdown,
+    ImpactReport,
+    AppFeature,
+    ServiceDocFeature,
+)
+
+
+def test_extract_compose_services_reads_services_block(tmp_path: Path) -> None:
+    compose_file = tmp_path / "docker-compose.yml"
+    compose_file.write_text(
+        """
+services:
+  api:
+    image: api:latest
+  worker:
+    image: worker:latest
+networks:
+  default:
+    driver: bridge
+""".strip(),
+        encoding="utf-8",
+    )
+
+    assert extract_compose_services(compose_file) == ("api", "worker")
+
+
+def test_extract_app_features_discovers_endpoints(tmp_path: Path) -> None:
+    app_dir = tmp_path / "apps" / "demo" / "src"
+    app_dir.mkdir(parents=True)
+    (app_dir / "index.ts").write_text(
+        """
+app.get('/healthz', handler)
+app.post('/deploy', handler)
+""".strip(),
+        encoding="utf-8",
+    )
+
+    features = extract_app_features(tmp_path / "apps")
+    assert len(features) == 1
+    assert features[0].name == "demo"
+    assert features[0].endpoints == ("/deploy", "/healthz")
+
+
+def test_extract_documented_features_reads_titles(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs" / "services"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "analytics.md").write_text("# Analytics Service\n\nDetails", encoding="utf-8")
+
+    docs = extract_documented_features(docs_dir)
+    assert docs[0].slug == "analytics"
+    assert docs[0].title == "Analytics Service"
+
+
+def test_format_markdown_contains_counts() -> None:
+    report = ImpactReport(
+        compose_services=("api",),
+        app_features=(AppFeature(name="platform", endpoints=("/healthz",)),),
+        documented_features=(ServiceDocFeature(slug="analytics", title="Analytics Service"),),
+    )
+
+    markdown = format_markdown(report)
+    assert "Compose services discovered: **1**" in markdown
+    assert "Application API Surface" in markdown
+    assert "platform (1 endpoints): /healthz" in markdown


### PR DESCRIPTION
### Motivation

- Provide a deterministic, repeatable inventory of implemented feature surfaces so repo drift between implemented services, Node app routes, and documented features can be detected automatically. 
- Produce a machine-readable baseline and human-friendly report to include in CI and operational reviews. 

### Description

- Add `scripts/feature_impact_dive.py`, a deterministic scanner that extracts compose services from `docker-compose.yml`, HTTP route surfaces from `apps/*/src/index.ts` via a regex, and documented features from `docs/services/*.md`, and emits Markdown and optional JSON outputs. 
- Add generated baseline report at `docs/development/feature-impact-dive-2026-04-06.md` containing discovered surfaces and recommended remediation actions. 
- Add unit tests in `tests/test_feature_impact_dive.py` that cover `extract_compose_services`, `extract_app_features`, `extract_documented_features`, and `format_markdown` to lock deterministic behavior. 

### Testing

- Executed `python3 scripts/feature_impact_dive.py --output docs/development/feature-impact-dive-2026-04-06.md --json` successfully and produced the Markdown + JSON output. 
- Ran targeted unit tests with `pytest -q tests/test_feature_impact_dive.py` which returned `4 passed`. 
- Ran full test suite with `pytest -q` which returned `87 passed, 5 skipped` after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3741b71a0832c99a385e2c6b7e5bf)