### PR TITLE
Expand feature impact deep-dive coverage and update generated report

### DIFF
--- a/docs/development/feature-impact-dive-2026-04-06.md
+++ b/docs/development/feature-impact-dive-2026-04-06.md
@@ -2,9 +2,10 @@
 
 - Generated from repository sources on 2026-04-06 (UTC).
 - Compose services discovered: **43**
-- Node app features discovered: **6**
+- Node app features discovered: **7**
+- Runtime service modules discovered: **46**
 - Service documentation feature specs: **11**
-- Aggregate discovered feature surfaces: **60**
+- Aggregate discovered feature surfaces: **107**
 
 ## Compose Service Surface
 
@@ -54,12 +55,62 @@
 
 ## Application API Surface
 
-- api-gateway (1 endpoints): /healthz
-- auth-service (3 endpoints): /healthz, /login, /register
-- billing-service (4 endpoints): /checkout, /healthz, /plan/:userId, /webhook
-- log-service (2 endpoints): /healthz, /log
-- platform-core (7 endpoints): /deploy, /deploy/github, /github/repos, /healthz, /orgs, /orgs/:orgId/members, /projects/public
-- worker-ai (2 endpoints): /fix, /healthz
+- api-gateway (1 endpoints): GET /healthz
+- auth-service (3 endpoints): GET /healthz, POST /login, POST /register
+- billing-service (4 endpoints): GET /healthz, GET /plan/:userId, POST /checkout, POST /webhook
+- frontend (0 endpoints): no HTTP routes found
+- log-service (2 endpoints): GET /healthz, POST /log
+- platform-core (7 endpoints): GET /github/repos, GET /healthz, GET /projects/public, POST /deploy, POST /deploy/github, POST /orgs, POST /orgs/:orgId/members
+- worker-ai (2 endpoints): GET /healthz, POST /fix
+
+## Runtime Service API Surface
+
+- account-farm [node] (2 endpoints): GET /farm/health, POST /farm/run
+- affiliate-webhook [python] (2 endpoints): GET /healthz, POST /conversion
+- ai-orchestrator [python] (2 endpoints): GET /health, POST /run-growth-cycle
+- ai-video-generator [node] (0 endpoints): no HTTP routes found
+- analytics [node] (6 endpoints): GET /analytics/campaigns, GET /analytics/conversion, GET /analytics/products, GET /analytics/revenue, GET /analytics/summary, GET /healthz
+- arbitrage-engine [python] (11 endpoints): GET /arbitrage, GET /healthz, GET /metrics, GET /publishing/counters/{tenant_id}, GET /reporting/posted-products/{tenant_id}, POST /affiliate/payouts/ingest, POST /affiliate/sync, POST /performance, POST /publishing/jobs, POST /publishing/run-daily, POST /videos
+- billing-service [python] (2 endpoints): GET /healthz, POST /charge
+- budget-allocator [python] (2 endpoints): GET /healthz, POST /allocate
+- campaign-optimizer [python] (1 endpoints): POST /optimize
+- capital-allocator [python] (2 endpoints): GET /healthz, POST /allocate
+- click-tracker [node] (0 endpoints): no HTTP routes found
+- creative-generator [python] (0 endpoints): no HTTP routes found
+- drift-detector [python] (0 endpoints): no HTTP routes found
+- exchange [python] (1 endpoints): POST /order
+- execution-engine [python] (3 endpoints): GET /healthz, GET /status/{external_id}, POST /publish
+- feature-store [python] (5 endpoints): GET /features/{campaign_id}, GET /healthz, POST /features/{campaign_id}, PUT /features, PUT /features/{campaign_id}
+- federation [python] (3 endpoints): GET /healthz, GET /nodes, POST /register
+- gpu-renderer [python] (3 endpoints): GET /healthz, GET /metrics, POST /render
+- jwt-auth [python] (4 endpoints): GET /.well-known/jwks.json, GET /healthz, GET /introspect, POST /token
+- landing-service [python] (2 endpoints): GET /healthz, GET /landing/{product_id}
+- market-crawler [python] (3 endpoints): GET /healthz, GET /metrics, POST /crawl
+- market-orchestrator [python] (2 endpoints): GET /healthz, POST /launch
+- master-orchestrator [python] (9 endpoints): GET /deployments/{deployment_id}, GET /healthz, POST /campaign/run, POST /deployments, POST /deployments/events, POST /economy/run, POST /federation/run, POST /profit-mode/activate, POST /run-cycle
+- model-registry [python] (3 endpoints): GET /healthz, GET /latest/{name}, POST /register
+- model-service [python] (6 endpoints): GET /healthz, GET /metrics, GET /result/{job_id}, GET /result/{job_id}/wait, POST /predict, POST /predict_async
+- model-sync [python] (0 endpoints): no HTTP routes found
+- network-egress [python] (0 endpoints): no HTTP routes found
+- p2p-node [node] (0 endpoints): no HTTP routes found
+- product-discovery [python] (2 endpoints): GET /discover, GET /healthz
+- product-generator [python] (2 endpoints): GET /healthz, POST /generate
+- retraining-loop [python] (0 endpoints): no HTTP routes found
+- reward-collector [python] (2 endpoints): GET /healthz, POST /reward
+- rl-coordinator [python] (3 endpoints): GET /healthz, POST /decide, POST /update
+- rl-engine [python] (3 endpoints): GET /healthz, POST /select, POST /update
+- rl-policy [python] (2 endpoints): GET /healthz, POST /train
+- rl-trainer [python] (0 endpoints): no HTTP routes found
+- rtb-engine [python] (3 endpoints): GET /healthz, POST /bid, POST /openrtb/bid
+- scaling-engine [python] (2 endpoints): GET /healthz, POST /scale
+- scheduler [python] (2 endpoints): GET /healthz, POST /assign
+- shopee-crawler [node] (0 endpoints): no HTTP routes found
+- stream-consumer [python] (0 endpoints): no HTTP routes found
+- tenant-service [python] (2 endpoints): GET /healthz, POST /tenant
+- tiktok-farm [node] (2 endpoints): GET /farm/status, POST /farm/job
+- tiktok-shop-miner [node] (0 endpoints): no HTTP routes found
+- tiktok-uploader [node] (0 endpoints): no HTTP routes found
+- viral-predictor [python] (3 endpoints): GET /healthz, GET /metrics, POST /predict
 
 ## Documented Product Feature Surface
 
@@ -77,6 +128,6 @@
 
 ## Recommended Fixes
 
-1. Consolidate duplicated feature naming between compose services and docs/services into a single source-of-truth manifest.
-2. Add this script to CI to detect undocumented apps or routes drift.
-3. Review app routes that expose write endpoints and enforce tenant/auth middleware at service level.
+1. Consolidate duplicated feature naming between compose services, runtime services, and docs/services into a single source-of-truth manifest.
+2. Add this script to CI to detect undocumented apps, runtime modules, or routes drift.
+3. Review all write endpoints and enforce tenant/auth middleware and schema validation at service level.

--- a/scripts/feature_impact_dive.py
+++ b/scripts/feature_impact_dive.py
@@ -13,11 +13,14 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT = REPO_ROOT / "docs" / "development" / "feature-impact-dive-2026-04-06.md"
 
-SERVICE_DOCS_DIR = REPO_ROOT / "docs" / "services"
-APPS_DIR = REPO_ROOT / "apps"
-COMPOSE_FILE = REPO_ROOT / "docker-compose.yml"
-
-ENDPOINT_RE = re.compile(r'app\.(?:get|post|put|patch|delete)\(\s*[\'"]([^\'"]+)[\'"]')
+JS_ENDPOINT_RE = re.compile(
+    r'\b(?:app|router)\.(get|post|put|patch|delete|options|head)\(\s*[\'"]([^\'"]+)[\'"]',
+    flags=re.IGNORECASE,
+)
+PY_DECORATOR_ENDPOINT_RE = re.compile(
+    r'@\w+\.(get|post|put|patch|delete|options|head)\(\s*[\'"]([^\'"]+)[\'"]',
+    flags=re.IGNORECASE,
+)
 DOC_HEADING_RE = re.compile(r"^#\s+(.+?)\s*$")
 SERVICE_NAME_RE = re.compile(r"^\s{2}([a-zA-Z0-9_.-]+):\s*$")
 
@@ -35,18 +38,42 @@ class ServiceDocFeature:
 
 
 @dataclass(frozen=True)
+class RuntimeServiceFeature:
+    name: str
+    language: str
+    api_endpoints: tuple[str, ...]
+
+
+@dataclass(frozen=True)
 class ImpactReport:
     compose_services: tuple[str, ...]
     app_features: tuple[AppFeature, ...]
+    runtime_services: tuple[RuntimeServiceFeature, ...]
     documented_features: tuple[ServiceDocFeature, ...]
 
     @property
     def total_features(self) -> int:
-        return len(self.compose_services) + len(self.app_features) + len(self.documented_features)
+        return (
+            len(self.compose_services)
+            + len(self.app_features)
+            + len(self.runtime_services)
+            + len(self.documented_features)
+        )
 
 
 def _read_lines(path: Path) -> list[str]:
     return path.read_text(encoding="utf-8").splitlines()
+
+
+def _extract_endpoint_signatures(content: str, suffix: str) -> tuple[str, ...]:
+    found: set[str] = set()
+    if suffix in {".js", ".ts"}:
+        for method, route in JS_ENDPOINT_RE.findall(content):
+            found.add(f"{method.upper()} {route}")
+    elif suffix == ".py":
+        for method, route in PY_DECORATOR_ENDPOINT_RE.findall(content):
+            found.add(f"{method.upper()} {route}")
+    return tuple(sorted(found))
 
 
 def extract_compose_services(compose_file: Path) -> tuple[str, ...]:
@@ -79,13 +106,52 @@ def extract_app_features(apps_dir: Path) -> tuple[AppFeature, ...]:
 
     features: list[AppFeature] = []
     for app_dir in sorted(path for path in apps_dir.iterdir() if path.is_dir()):
-        index_file = app_dir / "src" / "index.ts"
-        if not index_file.exists():
+        src_dir = app_dir / "src"
+        if not src_dir.exists():
             continue
 
-        content = index_file.read_text(encoding="utf-8")
-        endpoints = tuple(sorted(set(ENDPOINT_RE.findall(content))))
-        features.append(AppFeature(name=app_dir.name, endpoints=endpoints))
+        endpoint_signatures: set[str] = set()
+        for source_file in sorted(src_dir.rglob("*")):
+            if source_file.suffix not in {".ts", ".js", ".py"}:
+                continue
+            content = source_file.read_text(encoding="utf-8")
+            endpoint_signatures.update(_extract_endpoint_signatures(content, source_file.suffix))
+
+        features.append(AppFeature(name=app_dir.name, endpoints=tuple(sorted(endpoint_signatures))))
+
+    return tuple(features)
+
+
+def extract_runtime_service_features(services_dir: Path) -> tuple[RuntimeServiceFeature, ...]:
+    if not services_dir.exists():
+        return tuple()
+
+    features: list[RuntimeServiceFeature] = []
+    for service_dir in sorted(path for path in services_dir.iterdir() if path.is_dir()):
+        src_dir = service_dir / "src"
+        if not src_dir.exists():
+            continue
+
+        endpoint_signatures: set[str] = set()
+        language = "unknown"
+        source_files = [path for path in src_dir.rglob("*") if path.suffix in {".py", ".js", ".ts"}]
+
+        for source_file in sorted(source_files):
+            if source_file.suffix == ".py":
+                language = "python"
+            elif source_file.suffix in {".js", ".ts"} and language == "unknown":
+                language = "node"
+
+            content = source_file.read_text(encoding="utf-8")
+            endpoint_signatures.update(_extract_endpoint_signatures(content, source_file.suffix))
+
+        features.append(
+            RuntimeServiceFeature(
+                name=service_dir.name,
+                language=language,
+                api_endpoints=tuple(sorted(endpoint_signatures)),
+            )
+        )
 
     return tuple(features)
 
@@ -111,6 +177,7 @@ def build_impact_report(repo_root: Path = REPO_ROOT) -> ImpactReport:
     return ImpactReport(
         compose_services=extract_compose_services(repo_root / "docker-compose.yml"),
         app_features=extract_app_features(repo_root / "apps"),
+        runtime_services=extract_runtime_service_features(repo_root / "services"),
         documented_features=extract_documented_features(repo_root / "docs" / "services"),
     )
 
@@ -126,6 +193,7 @@ def format_markdown(report: ImpactReport) -> str:
         f"- Generated from repository sources on 2026-04-06 (UTC).\n"
         f"- Compose services discovered: **{len(report.compose_services)}**\n"
         f"- Node app features discovered: **{len(report.app_features)}**\n"
+        f"- Runtime service modules discovered: **{len(report.runtime_services)}**\n"
         f"- Service documentation feature specs: **{len(report.documented_features)}**\n"
         f"- Aggregate discovered feature surfaces: **{report.total_features}**\n"
     )
@@ -136,6 +204,11 @@ def format_markdown(report: ImpactReport) -> str:
         + (", ".join(feature.endpoints) if feature.endpoints else "no HTTP routes found")
         for feature in report.app_features
     )
+    runtime_rows = tuple(
+        f"{feature.name} [{feature.language}] ({len(feature.api_endpoints)} endpoints): "
+        + (", ".join(feature.api_endpoints) if feature.api_endpoints else "no HTTP routes found")
+        for feature in report.runtime_services
+    )
     doc_rows = tuple(f"{doc.slug}: {doc.title}" for doc in report.documented_features)
 
     return "\n".join(
@@ -143,11 +216,12 @@ def format_markdown(report: ImpactReport) -> str:
             summary,
             _render_section("Compose Service Surface", compose_rows),
             _render_section("Application API Surface", app_rows),
+            _render_section("Runtime Service API Surface", runtime_rows),
             _render_section("Documented Product Feature Surface", doc_rows),
             "## Recommended Fixes\n\n"
-            "1. Consolidate duplicated feature naming between compose services and docs/services into a single source-of-truth manifest.\n"
-            "2. Add this script to CI to detect undocumented apps or routes drift.\n"
-            "3. Review app routes that expose write endpoints and enforce tenant/auth middleware at service level.\n",
+            "1. Consolidate duplicated feature naming between compose services, runtime services, and docs/services into a single source-of-truth manifest.\n"
+            "2. Add this script to CI to detect undocumented apps, runtime modules, or routes drift.\n"
+            "3. Review all write endpoints and enforce tenant/auth middleware and schema validation at service level.\n",
         ]
     )
 
@@ -185,6 +259,15 @@ def main() -> int:
                     "endpoints": feature.endpoints,
                 }
                 for feature in report.app_features
+            ],
+            "runtime_services": [
+                {
+                    "name": feature.name,
+                    "language": feature.language,
+                    "endpoint_count": len(feature.api_endpoints),
+                    "endpoints": feature.api_endpoints,
+                }
+                for feature in report.runtime_services
             ],
             "documented_features": [
                 {"slug": doc.slug, "title": doc.title} for doc in report.documented_features

--- a/tests/test_feature_impact_dive.py
+++ b/tests/test_feature_impact_dive.py
@@ -1,13 +1,15 @@
 from pathlib import Path
 
 from scripts.feature_impact_dive import (
+    AppFeature,
+    ImpactReport,
+    RuntimeServiceFeature,
+    ServiceDocFeature,
     extract_app_features,
     extract_compose_services,
     extract_documented_features,
+    extract_runtime_service_features,
     format_markdown,
-    ImpactReport,
-    AppFeature,
-    ServiceDocFeature,
 )
 
 
@@ -30,13 +32,18 @@ networks:
     assert extract_compose_services(compose_file) == ("api", "worker")
 
 
-def test_extract_app_features_discovers_endpoints(tmp_path: Path) -> None:
+def test_extract_app_features_discovers_endpoints_from_multiple_files(tmp_path: Path) -> None:
     app_dir = tmp_path / "apps" / "demo" / "src"
     app_dir.mkdir(parents=True)
     (app_dir / "index.ts").write_text(
         """
 app.get('/healthz', handler)
-app.post('/deploy', handler)
+""".strip(),
+        encoding="utf-8",
+    )
+    (app_dir / "routes.ts").write_text(
+        """
+router.post('/deploy', handler)
 """.strip(),
         encoding="utf-8",
     )
@@ -44,7 +51,26 @@ app.post('/deploy', handler)
     features = extract_app_features(tmp_path / "apps")
     assert len(features) == 1
     assert features[0].name == "demo"
-    assert features[0].endpoints == ("/deploy", "/healthz")
+    assert features[0].endpoints == ("GET /healthz", "POST /deploy")
+
+
+def test_extract_runtime_service_features_supports_python_decorators(tmp_path: Path) -> None:
+    src_dir = tmp_path / "services" / "predictor" / "src"
+    src_dir.mkdir(parents=True)
+    (src_dir / "main.py").write_text(
+        """
+@app.get('/healthz')
+def healthz():
+    return {'ok': True}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    features = extract_runtime_service_features(tmp_path / "services")
+    assert len(features) == 1
+    assert features[0].name == "predictor"
+    assert features[0].language == "python"
+    assert features[0].api_endpoints == ("GET /healthz",)
 
 
 def test_extract_documented_features_reads_titles(tmp_path: Path) -> None:
@@ -60,11 +86,19 @@ def test_extract_documented_features_reads_titles(tmp_path: Path) -> None:
 def test_format_markdown_contains_counts() -> None:
     report = ImpactReport(
         compose_services=("api",),
-        app_features=(AppFeature(name="platform", endpoints=("/healthz",)),),
+        app_features=(AppFeature(name="platform", endpoints=("GET /healthz",)),),
+        runtime_services=(
+            RuntimeServiceFeature(
+                name="model-service",
+                language="python",
+                api_endpoints=("POST /predict",),
+            ),
+        ),
         documented_features=(ServiceDocFeature(slug="analytics", title="Analytics Service"),),
     )
 
     markdown = format_markdown(report)
     assert "Compose services discovered: **1**" in markdown
     assert "Application API Surface" in markdown
-    assert "platform (1 endpoints): /healthz" in markdown
+    assert "Runtime Service API Surface" in markdown
+    assert "platform (1 endpoints): GET /healthz" in markdown


### PR DESCRIPTION
### Motivation

- Improve the repository feature-inventory so the deep-dive detects real API surfaces across multi-file apps and runtime services instead of only scanning a single index file. 
- Provide deterministic, machine-readable outputs (markdown + JSON) that include HTTP method + route signatures and runtime language to aid drift detection and CI gating.

### Description

- Reworked `scripts/feature_impact_dive.py` to scan `.ts`, `.js`, and `.py` source files under `apps/*/src` and `services/*/src`, extracting HTTP method + route signatures for Node/Express style calls and Python decorator routes. 
- Added `RuntimeServiceFeature` and a `runtime_services` section to `ImpactReport`, and extended both Markdown and JSON outputs to include runtime service language and endpoint lists. 
- Implemented `_extract_endpoint_signatures` and new extraction helpers `extract_runtime_service_features` and enhanced `extract_app_features` to aggregate endpoints across multiple files. 
- Expanded `tests/test_feature_impact_dive.py` to cover multi-file app discovery, Python decorator discovery, and the new runtime API surface, and regenerated `docs/development/feature-impact-dive-2026-04-06.md` with the updated scanner output.

### Testing

- Ran unit tests with `pytest -q tests/test_feature_impact_dive.py`, all tests passed (`5 passed`).
- Executed the scanner end-to-end with `python3 scripts/feature_impact_dive.py --json > /tmp/feature-impact.json` and `python3 scripts/feature_impact_dive.py` to regenerate the markdown report, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37805ec98832c90e7a3fb3a6d142d)