### PR TITLE
Harden network egress client and add full repository deep-dive

### DIFF
--- a/docs/architecture/full-feature-deep-dive-2026-04-06.md
+++ b/docs/architecture/full-feature-deep-dive-2026-04-06.md
@@ -1,0 +1,99 @@
+# zTTato Platform Full Feature Deep Dive
+
+**Date (UTC):** 2026-04-06  
+**Scope:** Whole repository feature topology and runtime capability mapping
+
+## 1) Platform shape at a glance
+
+- **Monorepo with multiple execution planes:**
+  - `apps/` for core product-facing gateway/auth/platform services and frontend.
+  - `services/` for specialized domain microservices (AI, data, orchestration, commerce, tracking, rendering, RL, model lifecycle).
+  - `enterprise_maturity/` for blueprint-grade platform modules (governance, resilience, security, autoscaling, discovery).
+  - `infra/`, `infrastructure/`, `installer/`, and `scripts/` for deployment, operations, and bootstrapping.
+- **Current Compose runtime defines 43 services**, including stateful infra (`postgres`, `redis`, `redpanda`), orchestration (`ray-head`, `ray-worker`), and feature services (affiliate, model, RL, billing, scaling, rendering).
+
+## 2) Feature inventory by domain
+
+## A. Identity, tenancy, and access
+
+- `apps/auth-service`: authentication and account registration with secure password hashing workflows.
+- `services/jwt-auth`: token validation/signing helper service pattern.
+- `services/tenant-service`: tenant-centric operational domain.
+- `services/identity` and `services/org`: identity/org boundaries for multi-tenant expansion.
+
+## B. API edge and platform control plane
+
+- `apps/api-gateway`: edge ingress, policy enforcement, and request routing.
+- `apps/platform-core`: core control-plane endpoints and deployment workflow integration.
+- `apps/log-service`: centralized operational logging API.
+- `services/master-orchestrator`: higher-order orchestration and service coordination.
+
+## C. Commerce, payments, and affiliate workflows
+
+- `apps/billing-service` and `services/billing-service`: billing and subscription operation surfaces.
+- `services/payment` + `payment-gateway` compose role: payment rails and webhook/event settlement pattern.
+- `services/affiliate-webhook`: partner conversion/event intake.
+- `services/arbitrage-engine`, `services/capital-allocator`, `services/budget-allocator`: decisioning around spend/profit loops.
+
+## D. AI/ML lifecycle and inference mesh
+
+- `services/model-service`, `services/model-sync`, `services/model-registry`: model lifecycle and synchronization responsibilities.
+- `services/feature-store`: feature persistence and retrieval.
+- `services/auto-ml`, `services/retraining-loop`, `services/drift-detector`, `services/self-modifier`: continuous learning and adaptation path.
+- `services/ai-orchestrator`, `services/execution-engine`: AI task execution and routing.
+
+## E. Reinforcement-learning stack
+
+- `services/rl-engine`, `services/rl-policy`, `services/rl-trainer`, `services/rl-coordinator`.
+- Compose includes dedicated RL replicas (`rl-agent-1`, `rl-agent-2`) for distributed experimentation/execution.
+
+## F. Acquisition, growth, and market intelligence
+
+- `services/product-discovery`, `services/product-generator`, `services/market-crawler`, `services/market-orchestrator`.
+- `services/viral-predictor`, `services/campaign-optimizer`, `services/tracking`, `services/click-tracker`.
+- Social channel automation surfaces: `services/tiktok-farm`, `services/tiktok-uploader`, `services/tiktok-shop-miner`, `services/shopee-crawler`.
+
+## G. Rendering and compute substrate
+
+- `services/gpu-renderer`, `services/ai-video-generator`, `services/gpu`.
+- Distributed execution primitives in Compose via Ray (`ray-head`, `ray-worker`) and worker services (`crawler-worker`, `renderer-worker`, `arbitrage-worker`).
+
+## H. Reliability, operations, and enterprise controls
+
+- `enterprise_maturity/` modules include:
+  - Resilience controls (retry, idempotency, circuit breaker).
+  - Security controls (RBAC, audit pipeline, secret rotation policy).
+  - Operations/SLO modules and governance/versioning helpers.
+  - v3 runtime references (autoscaling, queue systems, service discovery).
+- `tests/` validates these patterns with broad integration-style and component tests.
+
+## 3) Fix generated from this deep dive
+
+### Target
+
+- `services/network-egress/src/client.py`
+
+### Problem observed
+
+- Request exception path used silent `pass`, reducing diagnosability and violating security/operational audit expectations.
+- No URL guardrails against unsafe target classes (e.g., private/loopback IPs), creating SSRF exposure risk if misused upstream.
+- Missing deterministic input validation on timeout/retry/backoff.
+
+### Implemented hardening
+
+- Added strict constructor validation (`timeout`, `retries`, `backoff`).
+- Added URL validation:
+  - `http/https` only.
+  - hostname required.
+  - optional host allowlist support.
+  - private/loopback/link-local IP target blocking.
+- Replaced silent exception handling with structured warning logs and retained last failure context.
+- Added deterministic retry loop with exponential backoff and explicit error reporting.
+
+### Regression coverage
+
+- Added `tests/test_network_egress_client.py` to verify:
+  - retry-then-success behavior,
+  - retry exhaustion failure path,
+  - allowlist enforcement,
+  - private address rejection.

--- a/services/network-egress/src/client.py
+++ b/services/network-egress/src/client.py
@@ -1,22 +1,86 @@
+import ipaddress
+import logging
 import time
+from collections.abc import Mapping
+from urllib.parse import urlparse
 
 import requests
 
+logger = logging.getLogger(__name__)
+
 
 class SafeHttpClient:
-    def __init__(self, timeout: int = 10, retries: int = 3, backoff: float = 0.5):
+    """HTTP client with deterministic retry behavior and SSRF guardrails."""
+
+    def __init__(
+        self,
+        timeout: int = 10,
+        retries: int = 3,
+        backoff: float = 0.5,
+        allowed_hosts: set[str] | None = None,
+    ):
+        if timeout <= 0:
+            raise ValueError("timeout must be > 0")
+        if retries <= 0:
+            raise ValueError("retries must be > 0")
+        if backoff < 0:
+            raise ValueError("backoff must be >= 0")
         self.timeout = timeout
         self.retries = retries
         self.backoff = backoff
+        self.allowed_hosts = {host.lower() for host in allowed_hosts} if allowed_hosts else None
 
-    def post(self, url, json=None, headers=None):
-        for attempt in range(self.retries):
+    def _validate_url(self, url: str) -> None:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("url must use http or https")
+        if not parsed.hostname:
+            raise ValueError("url hostname is required")
+
+        hostname = parsed.hostname.lower()
+        if self.allowed_hosts is not None and hostname not in self.allowed_hosts:
+            raise ValueError(f"url host '{hostname}' is not allowed")
+
+        try:
+            host_ip = ipaddress.ip_address(hostname)
+        except ValueError:
+            # Non-IP hostnames are allowed and resolved by network policy.
+            return
+
+        if host_ip.is_loopback or host_ip.is_private or host_ip.is_link_local:
+            raise ValueError("private or loopback host targets are not allowed")
+
+    def post(
+        self,
+        url: str,
+        json: dict | list | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> requests.Response:
+        self._validate_url(url)
+        last_error: Exception | None = None
+        last_response: requests.Response | None = None
+
+        for attempt in range(1, self.retries + 1):
             try:
                 response = requests.post(url, json=json, headers=headers, timeout=self.timeout)
                 if response.status_code < 500:
                     return response
-            except requests.RequestException:
-                pass
-            time.sleep(self.backoff * (2 ** attempt))
+                last_response = response
+                logger.warning(
+                    "Transient upstream response",
+                    extra={"url": url, "attempt": attempt, "status_code": response.status_code},
+                )
+            except requests.RequestException as exc:
+                last_error = exc
+                logger.warning(
+                    "Network request failed",
+                    extra={"url": url, "attempt": attempt, "error": str(exc)},
+                )
+            if attempt < self.retries:
+                time.sleep(self.backoff * (2 ** (attempt - 1)))
 
-        raise RuntimeError("request failed after retries")
+        if last_response is not None:
+            raise RuntimeError(
+                f"request failed after retries with status {last_response.status_code}: {url}"
+            )
+        raise RuntimeError(f"request failed after retries: {url}") from last_error

--- a/tests/test_network_egress_client.py
+++ b/tests/test_network_egress_client.py
@@ -1,0 +1,60 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import requests
+
+MODULE_PATH = Path("services/network-egress/src/client.py")
+SPEC = importlib.util.spec_from_file_location("network_egress_client", MODULE_PATH)
+client_module = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(client_module)
+
+SafeHttpClient = client_module.SafeHttpClient
+
+
+class _Response:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def test_retries_on_server_error_and_succeeds(monkeypatch):
+    calls = {"count": 0}
+
+    def fake_post(url, json=None, headers=None, timeout=0):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return _Response(503)
+        return _Response(200)
+
+    monkeypatch.setattr(client_module.requests, "post", fake_post)
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+
+    client = SafeHttpClient(retries=3, backoff=0, allowed_hosts={"api.example.com"})
+    response = client.post("https://api.example.com/webhook", json={"ok": True})
+    assert response.status_code == 200
+    assert calls["count"] == 3
+
+
+def test_raises_after_retry_exhaustion(monkeypatch):
+    def failing_post(url, json=None, headers=None, timeout=0):
+        raise requests.RequestException("network down")
+
+    monkeypatch.setattr(client_module.requests, "post", failing_post)
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+
+    client = SafeHttpClient(retries=2, backoff=0)
+    with pytest.raises(RuntimeError, match="request failed after retries"):
+        client.post("https://api.partner.example/publish")
+
+
+def test_blocks_disallowed_host():
+    client = SafeHttpClient(allowed_hosts={"api.example.com"})
+    with pytest.raises(ValueError, match="not allowed"):
+        client.post("https://evil.example.net/collect")
+
+
+def test_blocks_private_address():
+    client = SafeHttpClient()
+    with pytest.raises(ValueError, match="private or loopback"):
+        client.post("http://127.0.0.1:8080/admin")


### PR DESCRIPTION
### Motivation
- The network egress client silently swallowed request exceptions and lacked deterministic input validation, reducing diagnosability and violating security hardening expectations.
- There was no SSRF guardrail for unsafe targets (private/loopback IPs or non-http schemes), creating a risk if callers supplied untrusted URLs.
- A repo-wide feature deep-dive surfaced these risks and provided context for remediation across platform services.

### Description
- Harden `SafeHttpClient` in `services/network-egress/src/client.py` by validating constructor inputs (`timeout`, `retries`, `backoff`) and adding an optional `allowed_hosts` allowlist.
- Add URL validation to enforce `http`/`https`, require a hostname, and block private/loopback/link-local IP targets to mitigate SSRF.
- Replace silent `except` behavior with structured warning logs, deterministic exponential backoff retry loop, and explicit `RuntimeError` propagation including last-response context.
- Add regression tests `tests/test_network_egress_client.py` covering retry-success, retry exhaustion, allowlist blocking, and private-address rejection, and add `docs/architecture/full-feature-deep-dive-2026-04-06.md` describing the repo feature inventory and the remediation rationale.

### Testing
- Ran `pytest -q tests/test_network_egress_client.py` which passed (`4 passed`).
- Ran full test suite with `pytest -q` which completed successfully (`92 passed, 5 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37a10e25c832cb1f41c104cd39492)