### PR TITLE
Guard platform-core protected routes against missing user context

### DIFF
--- a/apps/platform-core/src/index.ts
+++ b/apps/platform-core/src/index.ts
@@ -105,13 +105,28 @@ app.use((req, res, next) => {
 const kafka = new Kafka({ brokers: kafkaBrokers });
 const producer = kafka.producer();
 
-function requireUserContext(req: express.Request): { userId: string; tenantId: string } {
+function getUserContext(req: express.Request): { userId: string; tenantId: string } | null {
   const userId = req.header("x-user-id");
   const tenantId = req.header("x-tenant-id");
   if (!userId || !tenantId) {
-    throw new Error("Missing user context");
+    return null;
   }
   return { userId, tenantId };
+}
+
+function requireUserContextOrRespond(
+  req: express.Request,
+  res: express.Response,
+): { userId: string; tenantId: string } | null {
+  const context = getUserContext(req);
+  if (!context) {
+    const requestId = req.header("x-request-id");
+    logger.warn({ requestId, path: req.path }, "missing user context");
+    res.status(401).json({ ok: false, error: "Unauthorized" });
+    return null;
+  }
+
+  return context;
 }
 
 app.get("/healthz", (_req, res) => {
@@ -141,7 +156,11 @@ app.post("/deploy", async (req, res) => {
     });
   }
 
-  const { userId, tenantId } = requireUserContext(req);
+  const userContext = requireUserContextOrRespond(req, res);
+  if (!userContext) {
+    return;
+  }
+  const { userId, tenantId } = userContext;
   const limits = await checkLimits(userId);
   const tenantDeployments = deployments.filter((entry) => entry.tenantId === tenantId).length;
   if (tenantDeployments >= limits.maxDeploys) {
@@ -194,7 +213,11 @@ app.post("/deploy/github", async (req, res) => {
     return res.status(400).json({ ok: false, error: "Invalid GitHub deploy payload" });
   }
 
-  const { userId, tenantId } = requireUserContext(req);
+  const userContext = requireUserContextOrRespond(req, res);
+  if (!userContext) {
+    return;
+  }
+  const { userId, tenantId } = userContext;
   await producer.send({
     topic: process.env.DEPLOY_TOPIC ?? "deploy.started",
     messages: [{ value: JSON.stringify({ repo: parsed.data.repo, tenantId, userId }) }],
@@ -215,7 +238,11 @@ app.post("/orgs", (req, res) => {
     return res.status(400).json({ ok: false, error: "Invalid organization payload" });
   }
 
-  const { userId } = requireUserContext(req);
+  const userContext = requireUserContextOrRespond(req, res);
+  if (!userContext) {
+    return;
+  }
+  const { userId } = userContext;
   const org = createOrg(parsed.data.name, userId);
   return res.status(201).json({ ok: true, org });
 });
@@ -226,7 +253,11 @@ app.post("/orgs/:orgId/members", (req, res) => {
     return res.status(400).json({ ok: false, error: "Invalid membership payload" });
   }
 
-  const { userId } = requireUserContext(req);
+  const userContext = requireUserContextOrRespond(req, res);
+  if (!userContext) {
+    return;
+  }
+  const { userId } = userContext;
   const org = getOrg(req.params.orgId);
   if (!org) {
     return res.status(404).json({ ok: false, error: "Organization not found" });

--- a/tests/test_platform_core_auth_context_guard.py
+++ b/tests/test_platform_core_auth_context_guard.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_platform_core_missing_user_context_returns_unauthorized() -> None:
+    source = Path('apps/platform-core/src/index.ts').read_text(encoding='utf-8')
+
+    assert 'function requireUserContextOrRespond' in source
+    assert 'res.status(401).json({ ok: false, error: "Unauthorized" });' in source
+    assert 'logger.warn({ requestId, path: req.path }, "missing user context");' in source
+    assert 'throw new Error("Missing user context")' not in source


### PR DESCRIPTION
### Motivation
- Prevent protected endpoints from throwing when `x-user-id`/`x-tenant-id` are absent and avoid turning missing auth into a 500 error.
- Ensure deterministic, secure behavior by returning an explicit HTTP `401` and logging the event instead of throwing.

### Description
- Replaced the old throw-based `requireUserContext` with a nullable `getUserContext` and added `requireUserContextOrRespond` which logs and responds `401` when context is missing.
- Applied the new guard (`requireUserContextOrRespond`) to the `/deploy`, `/deploy/github`, `/orgs`, and `/orgs/:orgId/members` handlers to short-circuit unauthenticated requests.
- Added structured warning logs that include `x-request-id` and request `path` when user context is missing.
- Added a regression test `tests/test_platform_core_auth_context_guard.py` to assert the new guard is present and the old throw path is not reintroduced.

### Testing
- Ran `pytest tests/test_platform_core_auth_context_guard.py` and it passed.
- Ran the full test suite with `pytest` which completed successfully (`93 passed, 5 skipped`).
- Ran `npm run build` to validate TypeScript/frontend build and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37e12e2f4832c99cc09d92e5cecf1)