### PR TITLE
Fix arbitrage-engine in-memory listing and add scan endpoint

### DIFF
--- a/services/arbitrage-engine/src/api/server.py
+++ b/services/arbitrage-engine/src/api/server.py
@@ -15,12 +15,17 @@ from core.database import (
     MEMORY_STORE,
     ProductPayoutRecord,
     PublishingJob,
+    fetch_products,
     get_daily_counter,
+    get_product_payout,
     get_posted_product_reporting,
+    insert_event,
+    list_events,
     record_performance,
     record_video,
     upsert_product_payout,
 )
+from engine.arbitrage import detect
 from metrics import request_counter, request_latency
 from publishing.controller import DailyPublishingController
 
@@ -74,6 +79,12 @@ class PublishSimulationResult(BaseModel):
     network: AffiliateNetwork = AffiliateNetwork.TIKTOK
 
 
+class ArbitrageScanRequest(BaseModel):
+    persist: bool = True
+    min_profit: float = Field(default=1.0, ge=0)
+    max_results: int = Field(default=100, ge=1, le=2000)
+
+
 def get_db():
     return psycopg2.connect(os.environ["DB_URL"])
 
@@ -106,34 +117,38 @@ def metrics():
 
 
 @app.get('/arbitrage')
-def list_events():
+def list_arbitrage_events():
     start = time.perf_counter()
-    with get_db() as db:
-        with db.cursor() as cur:
-            cur.execute(
-                '''
-                select product_name,buy_source,sell_source,profit
-                from arbitrage_events
-                order by profit desc
-                limit 50
-                '''
-            )
-            rows = cur.fetchall()
-
-    result = []
-    for r in rows:
-        result.append(
-            {
-                'product': r[0],
-                'buy': r[1],
-                'sell': r[2],
-                'profit': float(r[3]),
-            }
-        )
-
+    result = list_events(limit=50)
     request_counter.inc()
     request_latency.observe(time.perf_counter() - start)
     return result
+
+
+@app.post('/arbitrage/scan')
+def scan_arbitrage(payload: ArbitrageScanRequest):
+    start = time.perf_counter()
+    products = fetch_products()
+    opportunities = detect(products, get_product_payout, min_profit=payload.min_profit)
+    opportunities.sort(key=lambda item: float(item["profit"]), reverse=True)
+    selected = opportunities[: payload.max_results]
+    inserted = 0
+
+    if payload.persist:
+        for event in selected:
+            insert_event(event)
+            inserted += 1
+
+    request_counter.inc()
+    request_latency.observe(time.perf_counter() - start)
+    return {
+        "ok": True,
+        "products_scanned": len(products),
+        "opportunities_found": len(opportunities),
+        "returned": len(selected),
+        "persisted": inserted,
+        "results": selected,
+    }
 
 
 @app.post('/affiliate/payouts/ingest')

--- a/services/arbitrage-engine/src/core/database.py
+++ b/services/arbitrage-engine/src/core/database.py
@@ -103,6 +103,37 @@ def insert_event(event: dict[str, Any]) -> None:
             )
 
 
+def list_events(limit: int = 50) -> list[dict[str, Any]]:
+    if USE_INMEMORY_DB:
+        sorted_events = sorted(MEMORY_STORE.arbitrage_events, key=lambda event: float(event.get("profit", 0)), reverse=True)
+        return [dict(event) for event in sorted_events[:limit]]
+
+    with get_db() as db:
+        with db.cursor() as cur:
+            cur.execute(
+                """
+                select product_name,buy_source,sell_source,buy_price,sell_price,profit
+                from arbitrage_events
+                order by profit desc
+                limit %s
+                """,
+                (limit,),
+            )
+            rows = cur.fetchall()
+
+    return [
+        {
+            "product": row[0],
+            "buy": row[1],
+            "sell": row[2],
+            "buy_price": float(row[3]),
+            "sell_price": float(row[4]),
+            "profit": float(row[5]),
+        }
+        for row in rows
+    ]
+
+
 def upsert_product_payout(record: ProductPayoutRecord) -> None:
     if USE_INMEMORY_DB:
         MEMORY_STORE.product_payouts[(record.network, record.product_id)] = record

--- a/services/arbitrage-engine/src/engine/arbitrage.py
+++ b/services/arbitrage-engine/src/engine/arbitrage.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-def detect(products, payout_lookup):
+def detect(products, payout_lookup, min_profit: float = 1.0):
     grouped = defaultdict(list)
     for p in products:
         # Normalize names to improve matching precision
@@ -33,7 +33,7 @@ def detect(products, payout_lookup):
                 profit = revenue - buy_price
 
                 # Thresholding for business viability
-                if profit > 1.0:
+                if profit > min_profit:
                     opportunities.append(
                         {
                             "product": name,

--- a/tests/test_affiliate_publishing_flow.py
+++ b/tests/test_affiliate_publishing_flow.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -149,3 +150,43 @@ def test_dead_letter_after_retry_budget(monkeypatch):
     report = client.get("/reporting/posted-products/tenant-b")
     assert report.status_code == 200
     assert len(report.json()["dead_letters"]) == 1
+
+
+def test_arbitrage_scan_and_listing_work_inmemory(monkeypatch):
+    monkeypatch.setenv("USE_INMEMORY_DB", "1")
+    sys.path.insert(0, str(ROOT / "services/arbitrage-engine/src"))
+    server = load_module("test_arb_scan", "services/arbitrage-engine/src/api/server.py")
+    server.MEMORY_STORE.arbitrage_events.clear()
+    server.MEMORY_STORE.product_payouts.clear()
+    server.MEMORY_STORE.seed_products(
+        [
+            {"id": "sku-10", "name": "Keyboard", "price": 8.0, "source": "shopee"},
+            {"id": "sku-11", "name": "Keyboard", "price": 18.0, "source": "lazada"},
+        ]
+    )
+    server.upsert_product_payout(
+        server.ProductPayoutRecord(
+            network="lazada",
+            product_id="sku-11",
+            payout_rate=0.6,
+            currency="USD",
+            freshness_ts=datetime.now(timezone.utc),
+        )
+    )
+
+    client = TestClient(server.app)
+    scan = client.post("/arbitrage/scan", json={"persist": True, "min_profit": 1.0, "max_results": 10})
+    assert scan.status_code == 200
+    payload = scan.json()
+    assert payload["ok"] is True
+    assert payload["opportunities_found"] == 1
+    assert payload["persisted"] == 1
+    assert payload["results"][0]["profit"] == pytest.approx(2.8)
+
+    listed = client.get("/arbitrage")
+    assert listed.status_code == 200
+    listed_payload = listed.json()
+    assert len(listed_payload) == 1
+    assert listed_payload[0]["product"] == "keyboard"
+    assert listed_payload[0]["buy"] == "shopee"
+    assert listed_payload[0]["sell"] == "lazada"


### PR DESCRIPTION
### Motivation
- Ensure the arbitrage engine works in both in-memory simulation mode and PostgreSQL mode by unifying event reads behind a shared data-access path.
- Provide an API-driven full scan workflow with configurable profit threshold and optional persistence to support testing and controlled runs.

### Description
- Add `list_events()` in `services/arbitrage-engine/src/core/database.py` to return top events from either the in-memory store or Postgres and updated `GET /arbitrage` to use it.
- Implement `POST /arbitrage/scan` in `services/arbitrage-engine/src/api/server.py` which runs detection, ranks opportunities, optionally persists results, and returns scan metrics and results.
- Make detection threshold configurable by adding `min_profit` to `detect()` in `services/arbitrage-engine/src/engine/arbitrage.py` and wire it into the scan flow.
- Add an integration/regression test `test_arbitrage_scan_and_listing_work_inmemory` in `tests/test_affiliate_publishing_flow.py` and adjust assertions to use `pytest.approx` for floating comparisons.

### Testing
- Ran `pytest -q tests/test_affiliate_publishing_flow.py` and the suite completed successfully with `3 passed`.
- The new test verifies scanning, persistence to the in-memory store, and that `GET /arbitrage` returns the persisted event as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d385d697c8832c8f027794e6880ae6)