### PR TITLE
Add POST /arbitrage/scan to service surface manifest

### DIFF
--- a/config/service-surface-manifest.json
+++ b/config/service-surface-manifest.json
@@ -177,6 +177,7 @@
         "GET /reporting/posted-products/{tenant_id}",
         "POST /affiliate/payouts/ingest",
         "POST /affiliate/sync",
+        "POST /arbitrage/scan",
         "POST /performance",
         "POST /publishing/jobs",
         "POST /publishing/run-daily",
@@ -195,6 +196,12 @@
         {
           "auth": "required",
           "endpoint": "POST /affiliate/sync",
+          "schema": "required",
+          "tenant": "required"
+        },
+        {
+          "auth": "required",
+          "endpoint": "POST /arbitrage/scan",
           "schema": "required",
           "tenant": "required"
         },

--- a/docs/development/feature-impact-dive-2026-04-06.md
+++ b/docs/development/feature-impact-dive-2026-04-06.md
@@ -71,7 +71,7 @@
 - ai-orchestrator [python] (2 endpoints): GET /health, POST /run-growth-cycle
 - ai-video-generator [node] (0 endpoints): no HTTP routes found
 - analytics [node] (6 endpoints): GET /analytics/campaigns, GET /analytics/conversion, GET /analytics/products, GET /analytics/revenue, GET /analytics/summary, GET /healthz
-- arbitrage-engine [python] (11 endpoints): GET /arbitrage, GET /healthz, GET /metrics, GET /publishing/counters/{tenant_id}, GET /reporting/posted-products/{tenant_id}, POST /affiliate/payouts/ingest, POST /affiliate/sync, POST /performance, POST /publishing/jobs, POST /publishing/run-daily, POST /videos
+- arbitrage-engine [python] (12 endpoints): GET /arbitrage, GET /healthz, GET /metrics, GET /publishing/counters/{tenant_id}, GET /reporting/posted-products/{tenant_id}, POST /affiliate/payouts/ingest, POST /affiliate/sync, POST /arbitrage/scan, POST /performance, POST /publishing/jobs, POST /publishing/run-daily, POST /videos
 - billing-service [python] (2 endpoints): GET /healthz, POST /charge
 - budget-allocator [python] (2 endpoints): GET /healthz, POST /allocate
 - campaign-optimizer [python] (1 endpoints): POST /optimize
@@ -132,7 +132,7 @@
 - account-farm: 1 write endpoint policies
 - affiliate-webhook: 1 write endpoint policies
 - ai-orchestrator: 1 write endpoint policies
-- arbitrage-engine: 6 write endpoint policies
+- arbitrage-engine: 7 write endpoint policies
 - auth-service: 2 write endpoint policies
 - billing-service: 3 write endpoint policies
 - budget-allocator: 1 write endpoint policies


### PR DESCRIPTION
### Motivation
- The generated service-surface artifacts included the `POST /arbitrage/scan` endpoint for `arbitrage-engine` while the tracked manifest was stale, causing manifest validation drift and failing automated checks.

### Description
- Updated `config/service-surface-manifest.json` to include `POST /arbitrage/scan` in the `arbitrage-engine` `endpoints` list and added the matching `write_policies` entry requiring `auth`, `schema`, and `tenant`.
- Updated `docs/development/feature-impact-dive-2026-04-06.md` to reflect the additional endpoint (arbitrage-engine: 11→12 endpoints) and the updated write-policy count (6→7).
- Regenerated the manifest using `scripts/feature_impact_dive.py --write-manifest` to ensure the tracked artifacts match generator output.

### Testing
- Ran `python scripts/feature_impact_dive.py --write-manifest` which initially surfaced a diff against `config/service-surface-manifest.json` (manifest drift detected; failed exit code before fix).
- After updating the manifest and docs, ran `python scripts/feature_impact_dive.py --validate-manifest` which completed successfully and reported no validation errors.
- Re-ran `python scripts/feature_impact_dive.py --write-manifest` and confirmed the generated output matches the updated `config/service-surface-manifest.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38a1db384832ca82372b8c404e540)