### PR TITLE
Fix CI Codex TTY invocation and add httpx to workflow tests

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -26,6 +26,6 @@ jobs:
         run: npm install -g @openai/codex
 
       - name: Run Codex review
-        run: codex "review code and propose improvements"
+        run: script -q -e -c 'codex "review code and propose improvements"' /dev/null
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/enterprise-platform-delivery.yml
+++ b/.github/workflows/enterprise-platform-delivery.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install checks
         run: |
           python -m pip install --upgrade pip
-          pip install pytest yamllint fastapi
+          pip install pytest yamllint fastapi httpx
 
       - name: Unit tests
         run: pytest -q


### PR DESCRIPTION
### Motivation
- Prevent CI failures where the Codex CLI errors with `stdin is not a terminal` and where pytest collection fails because `starlette.testclient` requires `httpx`.

### Description
- Run the Codex CLI under a pseudo-TTY in ` .github/workflows/codex.yml` using `script -q -e -c 'codex "review code and propose improvements"' /dev/null` to avoid terminal errors.
- Add `httpx` to the test dependency installation in ` .github/workflows/enterprise-platform-delivery.yml` by including it in the `pip install pytest yamllint fastapi httpx` line so FastAPI/Starlette `TestClient` imports succeed.

### Testing
- Parsed both modified workflow files with `PyYAML` using `python -m pip install -q pyyaml` and a small parsing script, and both files parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38f9f6940832cb00dea3d3d95b9a3)