### PR TITLE
CI: wrap Codex invocation for non-interactive shells and add httpx/requests to validate installs

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -26,6 +26,6 @@ jobs:
         run: npm install -g @openai/codex
 
       - name: Run Codex review
-        run: codex "review code and propose improvements"
+        run: script -q -e -c 'codex "review code and propose improvements"' /dev/null
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/enterprise-platform-delivery.yml
+++ b/.github/workflows/enterprise-platform-delivery.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install checks
         run: |
           python -m pip install --upgrade pip
-          pip install pytest yamllint fastapi
+          pip install pytest yamllint fastapi httpx requests
 
       - name: Unit tests
         run: pytest -q


### PR DESCRIPTION
### Motivation

- Ensure the `codex` CLI runs reliably inside GitHub Actions non-interactive shells by wrapping the invocation with `script`. 
- Provide additional HTTP client libraries required by tests or services by installing `httpx` and `requests` in the CI `validate` job.

### Description

- Replace the direct call `codex "review code and propose improvements"` with `script -q -e -c 'codex "review code and propose improvements"' /dev/null` in `.github/workflows/codex.yml` to force a pseudo-terminal and non-interactive execution.
- Add `httpx` and `requests` to the `pip install` line in `.github/workflows/enterprise-platform-delivery.yml` so the CI environment installs those dependencies.
- Preserve existing CI steps including `pytest -q` unit tests and `yamllint` manifest linting.

### Testing

- The CI `validate` job runs `pytest -q` to execute unit tests; this is configured but not executed as part of this PR description. 
- The CI also runs `yamllint infrastructure/k8s`; this is configured but not executed as part of this PR description. 
- No automated tests were run locally as part of preparing this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38f9f6940832cb00dea3d3d95b9a3)