### PR TITLE
Harden CI Python deps and model-registry path fallback

### DIFF
--- a/.github/workflows/enterprise-platform-delivery.yml
+++ b/.github/workflows/enterprise-platform-delivery.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install checks
         run: |
           python -m pip install --upgrade pip
-          pip install pytest yamllint fastapi httpx requests
+          pip install pytest yamllint fastapi httpx requests redis psycopg2-binary
 
       - name: Unit tests
         run: pytest -q

--- a/.github/workflows/zttato-ci.yml
+++ b/.github/workflows/zttato-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Python test tooling
         run: |
           python -m pip install --upgrade pip
-          pip install pytest bandit fastapi httpx requests
+          pip install pytest bandit fastapi httpx requests redis psycopg2-binary
 
       - name: Repository validation
         run: bash infrastructure/scripts/validate-repo.sh

--- a/services/model-registry/src/main.py
+++ b/services/model-registry/src/main.py
@@ -11,8 +11,21 @@ from pydantic import BaseModel, Field
 app = FastAPI(title="Model Registry")
 BASE = Path(os.getenv("MODEL_REGISTRY_PATH", "/models"))
 SHARED = Path(os.getenv("MODEL_REGISTRY_SHARED_PATH", "/shared-models"))
-BASE.mkdir(parents=True, exist_ok=True)
-SHARED.mkdir(parents=True, exist_ok=True)
+
+
+def _ensure_writable_directory(path: Path, env_override_name: str) -> Path:
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    except PermissionError:
+        fallback = Path("/tmp/zttato-model-registry") / path.name
+        fallback.mkdir(parents=True, exist_ok=True)
+        os.environ.setdefault(env_override_name, str(fallback))
+        return fallback
+
+
+BASE = _ensure_writable_directory(BASE, "MODEL_REGISTRY_PATH")
+SHARED = _ensure_writable_directory(SHARED, "MODEL_REGISTRY_SHARED_PATH")
 
 
 class Register(BaseModel):


### PR DESCRIPTION
### Motivation
- CI runs were failing due to missing Python packages (`redis`, `psycopg2`) required by tests, causing `ModuleNotFoundError` during test import. 
- The model registry service attempted to create `/models` and `/shared-models` at import time and raised `PermissionError` in restricted environments, breaking service import during tests.

### Description
- Add a helper `_ensure_writable_directory(path: Path, env_override_name: str)` in `services/model-registry/src/main.py` that attempts to create the configured directory and falls back to `/tmp/zttato-model-registry/<dirname>` on `PermissionError` while setting an environment fallback. 
- Replace eager `Path.mkdir(...)` calls with calls to `_ensure_writable_directory` for both `BASE` and `SHARED` directories so startup no longer fails when `/models` is not writable. 
- Update CI workflows (`.github/workflows/zttato-ci.yml` and `.github/workflows/enterprise-platform-delivery.yml`) to install `redis` and `psycopg2-binary` alongside existing test tooling so imports used by tests are available in runners.

### Testing
- Ran targeted tests with `pytest -q tests/test_autonomous_rl_services.py::test_model_registry_registers_and_returns_latest tests/test_profit_mode_pipeline.py::test_feature_store_supports_budget_and_revenue_updates tests/test_affiliate_publishing_flow.py::test_affiliate_connector_payout_ingestion_daily_controller_and_reporting` and they all passed. 
- Ran the full test suite with `pytest -q` and observed `100 passed, 5 skipped`, confirming the fixes resolve the prior failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d393872d00832c85a9dcf9b502c41c)