### PR TITLE
Fix CI test failures: add prometheus-client to workflows and make model-service test path portable

### DIFF
--- a/.github/workflows/enterprise-platform-delivery.yml
+++ b/.github/workflows/enterprise-platform-delivery.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install checks
         run: |
           python -m pip install --upgrade pip
-          pip install pytest yamllint fastapi httpx requests redis psycopg2-binary
+          pip install pytest yamllint fastapi httpx requests redis psycopg2-binary prometheus-client
 
       - name: Unit tests
         run: pytest -q

--- a/.github/workflows/zttato-ci.yml
+++ b/.github/workflows/zttato-ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Python test tooling
         run: |
           python -m pip install --upgrade pip
-          pip install pytest bandit fastapi httpx requests redis psycopg2-binary
+          pip install pytest bandit fastapi httpx requests redis psycopg2-binary prometheus-client
 
       - name: Repository validation
         run: bash infrastructure/scripts/validate-repo.sh

--- a/tests/test_model_service_async.py
+++ b/tests/test_model_service_async.py
@@ -81,7 +81,7 @@ class NoopMetric:
 
 
 def load_main_module():
-    base = Path("/workspace/zttato-platform/services/model-service/src")
+    base = Path(__file__).resolve().parents[1] / "services" / "model-service" / "src"
     sys.path.insert(0, str(base))
     sys.modules["torch"] = FakeTorch()
     sys.modules["confluent_kafka"] = types.SimpleNamespace(Producer=FakeProducer, Consumer=FakeConsumer)


### PR DESCRIPTION
### Motivation
- CI jobs were failing with `ModuleNotFoundError: No module named 'prometheus_client'` because some workflows installed a minimal Python dependency set that omitted the Prometheus client. 
- Tests also experienced `FileNotFoundError` due to a hardcoded absolute path in `tests/test_model_service_async.py` which does not exist on CI runners.

### Description
- Add `prometheus-client` to the Python install step in `.github/workflows/zttato-ci.yml` to ensure the test environment includes the Prometheus client. 
- Add `prometheus-client` to the Python install step in `.github/workflows/enterprise-platform-delivery.yml` for consistent CI dependency installation. 
- Make `tests/test_model_service_async.py` portable by replacing the hardcoded absolute source path with a repository-relative path derived from `__file__` (`Path(__file__).resolve().parents[1] / "services" / "model-service" / "src"`).

### Testing
- Ran `pytest -q tests/test_model_service_async.py tests/test_affiliate_publishing_flow.py` and the targeted tests passed (`5 passed`).
- Ran the full test suite with `pytest -q` and all tests passed (`100 passed, 5 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a4b4337c832c92a6c4dca4fd4479)