### PR TITLE
fix(security): remove hardcoded 0.0.0.0 uvicorn binds in Python services

### DIFF
--- a/services/scaling-engine/src/main.py
+++ b/services/scaling-engine/src/main.py
@@ -1,9 +1,12 @@
+import os
 from typing import Any
 
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 app = FastAPI(title="Scaling Engine")
+SERVICE_HOST = os.getenv("SERVICE_HOST", "127.0.0.1")
+SERVICE_PORT = int(os.getenv("SERVICE_PORT", "8000"))
 
 
 class ScaleRequest(BaseModel):
@@ -39,4 +42,4 @@ def scale(request: ScaleRequest) -> ScaleResponse:
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=SERVICE_HOST, port=SERVICE_PORT)

--- a/services/scheduler/src/main.py
+++ b/services/scheduler/src/main.py
@@ -14,6 +14,8 @@ app = FastAPI(title="Global Scheduler")
 FEDERATION_URL = os.getenv("FEDERATION_URL", "http://federation:8000")
 FEDERATION_SECRET = os.getenv("FEDERATION_SECRET", "change-me")
 TIMEOUT = float(os.getenv("SCHEDULER_TIMEOUT", "3.0"))
+SERVICE_HOST = os.getenv("SERVICE_HOST", "127.0.0.1")
+SERVICE_PORT = int(os.getenv("SERVICE_PORT", "8000"))
 
 
 class Task(BaseModel):
@@ -129,4 +131,4 @@ def assign(task: Task) -> Assignment:
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=SERVICE_HOST, port=SERVICE_PORT)

--- a/services/tenant-service/src/main.py
+++ b/services/tenant-service/src/main.py
@@ -10,6 +10,8 @@ from pydantic import BaseModel, Field
 app = FastAPI(title="Tenant Service")
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://zttato:zttato@postgres:5432/zttato")
 DEFAULT_DAILY_SPEND_LIMIT = float(os.getenv("DEFAULT_DAILY_SPEND_LIMIT", "100.0"))
+SERVICE_HOST = os.getenv("SERVICE_HOST", "127.0.0.1")
+SERVICE_PORT = int(os.getenv("SERVICE_PORT", "8000"))
 
 
 def db_connection():
@@ -78,4 +80,4 @@ def create_tenant(payload: TenantCreateRequest) -> TenantCreateResponse:
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=SERVICE_HOST, port=SERVICE_PORT)

--- a/services/viral-predictor/src/main.py
+++ b/services/viral-predictor/src/main.py
@@ -1,11 +1,13 @@
 import os
 
+SERVICE_HOST = os.getenv("SERVICE_HOST", "127.0.0.1")
+SERVICE_PORT = int(os.getenv("VIRAL_PREDICTOR_PORT", "9100"))
 
 
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(
         "api.server:app",
-        host="0.0.0.0",
-        port=int(os.getenv("VIRAL_PREDICTOR_PORT", "9100")),
+        host=SERVICE_HOST,
+        port=SERVICE_PORT,
     )


### PR DESCRIPTION
### Motivation
- Address Bandit B104 findings where several services bound the ASGI server to all interfaces (`0.0.0.0`), which increases unintended network exposure.
- Align startup behavior with the repository security policy by requiring explicit environment configuration for host/port and defaulting to localhost for safer development defaults.

### Description
- Replaced hardcoded `host="0.0.0.0"` uvicorn bindings with environment-driven `SERVICE_HOST` and `SERVICE_PORT` variables in `services/scaling-engine/src/main.py`, `services/scheduler/src/main.py`, and `services/tenant-service/src/main.py` so `uvicorn.run(...)` uses `host=SERVICE_HOST` and `port=SERVICE_PORT`.
- Updated `services/viral-predictor/src/main.py` to use `SERVICE_HOST` and its existing `VIRAL_PREDICTOR_PORT` (exposed as `SERVICE_PORT` in the file) instead of a hardcoded `0.0.0.0` bind.
- Defaulted `SERVICE_HOST` to `127.0.0.1` to reduce accidental exposure while preserving existing default service ports (`8000` for scaling-engine, scheduler, tenant-service; `9100` for viral-predictor) and keeping runtime override via environment variables.

### Testing
- Ran `python -m compileall services/scaling-engine/src/main.py services/scheduler/src/main.py services/tenant-service/src/main.py services/viral-predictor/src/main.py` and compilation succeeded for all modified files.
- Attempted to run `bandit -q -r ...` but `bandit` is not installed in this environment so the security scan could not be executed here (`/bin/bash: bandit: command not found`).
- Verified via a search that no occurrences of `host = "0.0.0.0"` remain in the modified service entrypoints after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a5b0d4cc832c91925f687c7f1546)