### PR TITLE
Handle BuildKit snapshot cache corruption during compose startup

### DIFF
--- a/scripts/start-zttato-platform.sh
+++ b/scripts/start-zttato-platform.sh
@@ -30,6 +30,38 @@ compose_cmd(){
   fi
 }
 
+is_snapshot_cache_error(){
+  local log_file="$1"
+  grep -Eq 'failed to prepare extraction snapshot|parent snapshot .* does not exist' "$log_file"
+}
+
+compose_up_with_recovery(){
+  local -a compose_args=("$@")
+  local tmp_log
+  tmp_log="$(mktemp)"
+
+  set +e
+  compose_cmd up -d --build --remove-orphans "${compose_args[@]}" 2>&1 | tee "$tmp_log"
+  local up_status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ $up_status -eq 0 ]]; then
+    rm -f "$tmp_log"
+    return 0
+  fi
+
+  if is_snapshot_cache_error "$tmp_log"; then
+    log "Detected corrupted Docker BuildKit snapshot cache; pruning builder cache and retrying once"
+    docker builder prune -af >/dev/null
+    compose_cmd up -d --build --remove-orphans "${compose_args[@]}"
+    rm -f "$tmp_log"
+    return 0
+  fi
+
+  rm -f "$tmp_log"
+  return "$up_status"
+}
+
 ensure_env(){
   [[ -f .env ]] || bash "$ROOT_DIR/scripts/install-zttato-platform.sh"
 }
@@ -89,10 +121,10 @@ log "Validating compose configuration"
 compose_cmd config >/dev/null
 if [[ "$STACK_MODE" == "core" ]]; then
   log "Building and starting CORE compose stack (reduced footprint)"
-  compose_cmd up -d --build --remove-orphans "${CORE_SERVICES[@]}"
+  compose_up_with_recovery "${CORE_SERVICES[@]}"
 else
   log "Building and starting FULL compose stack"
-  compose_cmd up -d --build --remove-orphans
+  compose_up_with_recovery
 fi
 log "Current compose status"
 compose_cmd ps


### PR DESCRIPTION
### Motivation
- Docker Compose startups intermittently fail with BuildKit extraction snapshot errors like `failed to prepare extraction snapshot` due to corrupted builder cache, which requires manual intervention to recover. 
- The goal is to make the platform startup scripts resilient by auto-detecting this failure mode and performing a safe one-time recovery step to reduce manual fixes.

### Description
- Added `is_snapshot_cache_error` to `scripts/start-zttato-platform.sh` to detect the known BuildKit cache-corruption error signatures in `docker compose up` output.  
- Implemented `compose_up_with_recovery` which captures `docker compose up` logs, preserves the original exit code, and retries once after running `docker builder prune -af` when a snapshot-cache error is detected.  
- Replaced direct `compose_cmd up -d --build --remove-orphans` calls for both core and full startup paths with `compose_up_with_recovery` to apply the recovery behavior consistently.  
- The wrapper uses a temporary log file and cleans up artifacts, and it only retries for the targeted cache-corruption case while leaving other failures unchanged.

### Testing
- Verified shell syntax with `bash -n scripts/start-zttato-platform.sh` which succeeded.  
- Verified shell syntax for the installer with `bash -n installer/full-stack-installer.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a8cb0428832c9e90934149e7440e)