### PR TITLE
Harden RL weight initialization and network binding defaults

### DIFF
--- a/services/rl-trainer/src/hierarchical_rl.py
+++ b/services/rl-trainer/src/hierarchical_rl.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-import random
 from typing import Iterable
 
 
 class HierarchicalRL:
+    @staticmethod
+    def _initial_weights(dim: int) -> list[float]:
+        return [((index + 1) / (dim + 1)) * 2.0 - 1.0 for index in range(dim)]
+
     def __init__(self, dim: int = 2, lr: float = 0.01) -> None:
-        self.lr = lr
-        self.campaign_w = [random.uniform(-1.0, 1.0) for _ in range(dim)]
-        self.adset_w = [random.uniform(-1.0, 1.0) for _ in range(dim)]
-        self.creative_w = [random.uniform(-1.0, 1.0) for _ in range(dim)]
+        self.lr = float(lr)
+        self.campaign_w = self._initial_weights(dim)
+        self.adset_w = self._initial_weights(dim)
+        self.creative_w = self._initial_weights(dim)
 
     @staticmethod
     def _dot(lhs: list[float], rhs: list[float]) -> float:

--- a/services/rl-trainer/src/hybrid_rl.py
+++ b/services/rl-trainer/src/hybrid_rl.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import math
-import random
 
 
 class HybridRL:
     """Hybrid exploration strategy that combines UCB with a lightweight policy term."""
 
+    @staticmethod
+    def _initial_policy_weights(feature_dim: int) -> list[float]:
+        return [((index + 1) / (feature_dim + 1)) * 2.0 - 1.0 for index in range(feature_dim)]
+
     def __init__(self, n_arms: int = 5, feature_dim: int = 2, lr: float = 0.01) -> None:
         self.counts = [0.0 for _ in range(n_arms)]
         self.values = [0.0 for _ in range(n_arms)]
-        self.policy_w = [random.uniform(-1.0, 1.0) for _ in range(feature_dim)]
-        self.lr = lr
+        self.policy_w = self._initial_policy_weights(feature_dim)
+        self.lr = float(lr)
 
     def select_arm(self, x: list[float]) -> int:
         total = sum(self.counts) + 1.0

--- a/services/rl-trainer/src/p2p_agent.py
+++ b/services/rl-trainer/src/p2p_agent.py
@@ -7,16 +7,17 @@ from typing import Iterable
 
 
 class P2PAgent:
-    def __init__(self, weights: Iterable[float], port: int = 9000) -> None:
+    def __init__(self, weights: Iterable[float], port: int = 9000, host: str = "127.0.0.1") -> None:
         self.weights = [float(value) for value in weights]
-        self.port = port
+        self.port = int(port)
+        self.host = host
 
     def start_server(self) -> None:
         def run() -> None:
             sock = socket.socket()
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
-                sock.bind(("0.0.0.0", self.port))
+                sock.bind((self.host, self.port))
             except OSError:
                 sock.close()
                 return

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from pathlib import Path
+import os
 import sys
 
 CURRENT_DIR = Path(__file__).resolve().parent
@@ -133,4 +134,6 @@ def openrtb_bid(request: OpenRTBBidRequest) -> dict[str, Any]:
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    host = os.getenv("RTB_HOST", "127.0.0.1")
+    port = int(os.getenv("RTB_PORT", "8000"))
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
### Motivation
- Address static analysis findings complaining about non-cryptographic `random` usage for model weight initialization (Bandit B311 / CWE-330) by removing insecure pseudo-random initialization in RL modules. 
- Reduce attack surface by avoiding implicit bind-to-all behavior reported by static analysis (Bandit B104 / CWE-605). 
- Ensure deterministic, typed defaults that align with the repository's security and deterministic-output requirements.

### Description
- Replaced `random.uniform(...)` initializations in `HierarchicalRL` with a deterministic helper `._initial_weights(dim)` that produces bounded values in `[-1, 1]` and normalized `lr` via `float(lr)` in `services/rl-trainer/src/hierarchical_rl.py`.
- Replaced `random.uniform(...)` initializations in `HybridRL` with a deterministic helper `._initial_policy_weights(feature_dim)` and normalized `lr` via `float(lr)` in `services/rl-trainer/src/hybrid_rl.py`.
- Added a configurable `host` parameter (default `"127.0.0.1"`) and ensured `port` is cast to `int` in `P2PAgent`, and bind uses `self.host` instead of `"0.0.0.0"` in `services/rl-trainer/src/p2p_agent.py`.
- Made RTB engine startup host/port configurable via the environment variables `RTB_HOST` and `RTB_PORT` with secure loopback defaults and cast `RTB_PORT` to `int` in `services/rtb-engine/src/main.py`.

### Testing
- Ran `python -m compileall services/rl-trainer/src/hierarchical_rl.py services/rl-trainer/src/hybrid_rl.py services/rl-trainer/src/p2p_agent.py services/rtb-engine/src/main.py` which succeeded and confirmed syntax correctness.
- Attempted `bandit -q -r ...` against the modified files but the `bandit` tool is not installed in this environment so the scan could not be executed.
- No other automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ad710ec0832c8f90ba92b6aaeb7b)