### PR TITLE
Harden rl-trainer replicator input handling and deterministic redteam payloads

### DIFF
--- a/services/rl-trainer/src/agent_replicator.py
+++ b/services/rl-trainer/src/agent_replicator.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shlex
 import subprocess
 from dataclasses import dataclass
 from typing import Iterable
 
 log = logging.getLogger("rl-trainer.agent-replicator")
+
+_ALLOWED_RUNTIMES = {"docker-compose", "k8s"}
+_HOST_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,255}$")
+_USER_PATTERN = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+_IMAGE_PATTERN = re.compile(r"^[a-z0-9]+(?:[._/-][a-z0-9]+)*(?::[A-Za-z0-9._-]+)?$")
 
 
 @dataclass(frozen=True)
@@ -33,7 +39,7 @@ class Replicator:
         ssh_target = f"{target.user}@{target.host}"
         cmd = ["ssh", ssh_target, remote_command]
         log.info("deploying autonomous node to %s with runtime=%s", ssh_target, target.runtime)
-        completed = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        completed = subprocess.run(cmd, check=False, capture_output=True, text=True)  # nosec B603
         if completed.returncode != 0:
             log.warning("deployment to %s failed: %s", ssh_target, completed.stderr.strip())
         return completed.returncode
@@ -56,18 +62,21 @@ def parse_targets(raw_targets: str) -> list[DeploymentTarget]:
         if not raw:
             continue
         runtime = "docker-compose"
-        user_host = raw
         if "@" in raw:
             user, host = raw.split("@", 1)
         else:
             user, host = "root", raw
         if ":" in host:
             host, runtime = host.split(":", 1)
-        targets.append(DeploymentTarget(host=host, user=user, runtime=runtime or "docker-compose"))
+        normalized_runtime = runtime or "docker-compose"
+        _validate_target_inputs(host=host, user=user, runtime=normalized_runtime)
+        targets.append(DeploymentTarget(host=host, user=user, runtime=normalized_runtime))
     return targets
 
 
 def build_remote_command(runtime: str, image: str) -> str:
+    _validate_runtime(runtime)
+    _validate_image(image)
     quoted_image = shlex.quote(image)
     if runtime == "k8s":
         return (
@@ -75,3 +84,21 @@ def build_remote_command(runtime: str, image: str) -> str:
             f"{quoted_image} --record && kubectl rollout status deployment/zttato"
         )
     return f"docker pull {quoted_image} && docker compose up -d"
+
+
+def _validate_target_inputs(host: str, user: str, runtime: str) -> None:
+    if not _HOST_PATTERN.fullmatch(host):
+        raise ValueError(f"invalid deployment host: {host!r}")
+    if not _USER_PATTERN.fullmatch(user):
+        raise ValueError(f"invalid deployment user: {user!r}")
+    _validate_runtime(runtime)
+
+
+def _validate_runtime(runtime: str) -> None:
+    if runtime not in _ALLOWED_RUNTIMES:
+        raise ValueError(f"unsupported runtime: {runtime!r}")
+
+
+def _validate_image(image: str) -> None:
+    if not _IMAGE_PATTERN.fullmatch(image):
+        raise ValueError("invalid container image reference")

--- a/services/rl-trainer/src/autonomy/redteam.py
+++ b/services/rl-trainer/src/autonomy/redteam.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import random
+import hashlib
 from dataclasses import dataclass
 
 
@@ -21,15 +21,26 @@ def allow(environment: str) -> bool:
     return environment in ALLOWED_ENVIRONMENTS
 
 
-def sample_payload() -> dict[str, int]:
+def sample_payload(seed: str) -> dict[str, int]:
+    digest = hashlib.sha256(seed.encode("utf-8")).digest()
+    views = int.from_bytes(digest[0:4], "big") % 1_000_001
+    clicks = int.from_bytes(digest[4:8], "big") % 1_001
+    conversions = int.from_bytes(digest[8:12], "big") % 101
     return {
-        "views": random.randint(0, 1_000_000),
-        "clicks": random.randint(0, 1_000),
-        "conversions": random.randint(0, 100),
+        "views": views,
+        "clicks": clicks,
+        "conversions": conversions,
     }
 
 
 def plan(environment: str) -> list[dict[str, object]]:
     if not allow(environment):
         return []
-    return [{"target": target.name, "url": target.url, "payload": sample_payload()} for target in TARGETS]
+    return [
+        {
+            "target": target.name,
+            "url": target.url,
+            "payload": sample_payload(f"{environment}:{target.name}:{target.url}"),
+        }
+        for target in TARGETS
+    ]

--- a/services/rl-trainer/tests/test_security_hardening.py
+++ b/services/rl-trainer/tests/test_security_hardening.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from agent_replicator import build_remote_command, parse_targets
+from autonomy.redteam import plan, sample_payload
+
+
+def test_parse_targets_rejects_invalid_host() -> None:
+    with pytest.raises(ValueError):
+        parse_targets("root@bad host:k8s")
+
+
+def test_build_remote_command_rejects_invalid_image() -> None:
+    with pytest.raises(ValueError):
+        build_remote_command("docker-compose", "bad image")
+
+
+def test_sample_payload_is_deterministic() -> None:
+    seed = "sandbox:model-service:http://model-service:8000/predict"
+    first = sample_payload(seed)
+    second = sample_payload(seed)
+    assert first == second
+
+
+def test_plan_uses_deterministic_payloads() -> None:
+    first = plan("sandbox")
+    second = plan("sandbox")
+    assert first == second


### PR DESCRIPTION
### Motivation
- Address security scanner findings around command-injection risk for remote deployment and insecure pseudo-random usage in payload generation.
- Prevent untrusted or malformed `TARGET_NODES` / image references from producing unsafe `ssh`/container commands.
- Replace non-cryptographic `random` usage with deterministic, auditable payloads for redteam planning.

### Description
- Added strict allowlists and regex validation for deployment `host`, `user`, `runtime`, and container `image` with helper functions `_validate_target_inputs`, `_validate_runtime`, and `_validate_image` in `services/rl-trainer/src/agent_replicator.py`.
- Validate inputs in `parse_targets` and `build_remote_command` before composing remote commands, and document the vetted `subprocess.run` invocation with `# nosec B603` to indicate the call has been hardened.
- Replaced `random.randint` in `services/rl-trainer/src/autonomy/redteam.py` with deterministic SHA-256-derived integers, changed `sample_payload` to accept a `seed` string, and adapted `plan` to pass an explicit seed per target.
- Added `services/rl-trainer/tests/test_security_hardening.py` to assert invalid inputs are rejected and that payload generation and `plan` outputs are deterministic.

### Testing
- Ran unit tests with `pytest -q services/rl-trainer/tests/test_security_hardening.py` which completed successfully (`4 passed`).
- Attempted to run `bandit -q -r services/rl-trainer/src/agent_replicator.py services/rl-trainer/src/autonomy/redteam.py` but `bandit` is not installed in the environment so the static scan could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b73a0ac8832cbae2cfd19b6513b8)