### PR TITLE
Harden network bind behavior for RL trainer and RTB engine

### DIFF
--- a/services/rl-trainer/src/p2p_agent.py
+++ b/services/rl-trainer/src/p2p_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import json
 import socket
 import threading
@@ -7,10 +8,29 @@ from typing import Iterable
 
 
 class P2PAgent:
-    def __init__(self, weights: Iterable[float], port: int = 9000, host: str = "127.0.0.1") -> None:
+    def __init__(
+        self,
+        weights: Iterable[float],
+        port: int = 9000,
+        host: str = "127.0.0.1",
+        allow_wildcard_bind: bool = False,
+    ) -> None:
         self.weights = [float(value) for value in weights]
         self.port = int(port)
-        self.host = host
+        self.host = self._validate_host(host, allow_wildcard_bind)
+
+    @staticmethod
+    def _validate_host(host: str, allow_wildcard_bind: bool) -> str:
+        candidate = host.strip()
+        if not candidate:
+            raise ValueError("host must be a non-empty IP address")
+        try:
+            parsed = ipaddress.ip_address(candidate)
+        except ValueError as exc:
+            raise ValueError("host must be a valid IPv4 or IPv6 address") from exc
+        if parsed.is_unspecified and not allow_wildcard_bind:
+            raise ValueError("wildcard bind addresses are disabled by default")
+        return candidate
 
     def start_server(self) -> None:
         def run() -> None:

--- a/services/rtb-engine/src/main.py
+++ b/services/rtb-engine/src/main.py
@@ -132,8 +132,24 @@ def openrtb_bid(request: OpenRTBBidRequest) -> dict[str, Any]:
     }
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def resolve_bind_host() -> str:
+    host = os.getenv("RTB_HOST", "127.0.0.1").strip()
+    if not host:
+        return "127.0.0.1"
+    if host in {"0.0.0.0", "::"} and not _env_flag("RTB_ALLOW_WILDCARD_BIND"):
+        return "127.0.0.1"
+    return host
+
+
 if __name__ == "__main__":
     import uvicorn
-    host = os.getenv("RTB_HOST", "127.0.0.1")
+    host = resolve_bind_host()
     port = int(os.getenv("RTB_PORT", "8000"))
     uvicorn.run(app, host=host, port=port)

--- a/tests/test_network_bind_hardening.py
+++ b/tests/test_network_bind_hardening.py
@@ -1,0 +1,43 @@
+import sys
+
+import pytest
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, relative_path: str):
+    module_path = ROOT / relative_path
+    spec = spec_from_file_location(module_name, module_path)
+    assert spec and spec.loader
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_p2p_agent_rejects_wildcard_bind_by_default():
+    module = _load_module("test_rl_p2p_agent", "services/rl-trainer/src/p2p_agent.py")
+    with pytest.raises(ValueError, match="wildcard bind addresses are disabled by default"):
+        module.P2PAgent(weights=[0.1, 0.2], host="0.0.0.0")
+
+
+def test_p2p_agent_accepts_loopback_address():
+    module = _load_module("test_rl_p2p_agent_loopback", "services/rl-trainer/src/p2p_agent.py")
+    agent = module.P2PAgent(weights=[0.1, 0.2], host="127.0.0.1")
+    assert agent.host == "127.0.0.1"
+
+
+def test_resolve_bind_host_disables_wildcard_without_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("RTB_HOST", "0.0.0.0")
+    monkeypatch.delenv("RTB_ALLOW_WILDCARD_BIND", raising=False)
+    module = _load_module("test_rtb_bind_default", "services/rtb-engine/src/main.py")
+    assert module.resolve_bind_host() == "127.0.0.1"
+
+
+def test_resolve_bind_host_allows_wildcard_with_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv("RTB_HOST", "::")
+    monkeypatch.setenv("RTB_ALLOW_WILDCARD_BIND", "true")
+    module = _load_module("test_rtb_bind_opt_in", "services/rtb-engine/src/main.py")
+    assert module.resolve_bind_host() == "::"


### PR DESCRIPTION
### Motivation
- Bandit reported potential bind-all-interface risks (B104) for the RL trainer P2P agent and the RTB engine startup, so secure-by-default host binding is required to avoid accidental exposure.
- Provide an explicit, auditable opt-in for wildcard binds to preserve legitimate deployment scenarios while enforcing safer defaults.

### Description
- Validate and canonicalize P2P bind addresses in `services/rl-trainer/src/p2p_agent.py` by using `ipaddress` and adding a `allow_wildcard_bind` flag with `_validate_host()` to reject unspecified addresses by default.
- Add `_env_flag()` and `resolve_bind_host()` to `services/rtb-engine/src/main.py` and wire `resolve_bind_host()` into the `uvicorn.run(...)` invocation so `RTB_HOST` of `0.0.0.0`/`::` is downgraded to loopback unless `RTB_ALLOW_WILDCARD_BIND` is set.
- Add focused unit tests in `tests/test_network_bind_hardening.py` to assert secure defaults and explicit opt-in behavior for both services.

### Testing
- Ran `pytest -q tests/test_network_bind_hardening.py` and all tests passed (`4 passed`).
- Ran `pytest -q tests/test_autonomous_rl_services.py -k 'rtb_engine_uses_floor_bid'` and the selected test passed (`1 passed, 8 deselected`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3ae446c28832cac1bf17e764cbf9f)