### PR TITLE
Harden rl-trainer subprocess execution and deterministic payload validation

### DIFF
--- a/services/rl-trainer/src/agent_replicator.py
+++ b/services/rl-trainer/src/agent_replicator.py
@@ -14,6 +14,7 @@ _ALLOWED_RUNTIMES = {"docker-compose", "k8s"}
 _HOST_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,255}$")
 _USER_PATTERN = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
 _IMAGE_PATTERN = re.compile(r"^[a-z0-9]+(?:[._/-][a-z0-9]+)*(?::[A-Za-z0-9._-]+)?$")
+_SSH_TIMEOUT_SECONDS = 60
 
 
 @dataclass(frozen=True)
@@ -37,7 +38,15 @@ class Replicator:
     def deploy(self, target: DeploymentTarget) -> int:
         remote_command = build_remote_command(target.runtime, self.image)
         ssh_target = f"{target.user}@{target.host}"
-        cmd = ["ssh", ssh_target, remote_command]
+        cmd = [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            ssh_target,
+            remote_command,
+        ]
         log.info("deploying autonomous node to %s with runtime=%s", ssh_target, target.runtime)
         completed = asyncio.run(_execute_ssh_command(cmd))
         if completed.returncode != 0:
@@ -117,7 +126,16 @@ async def _execute_ssh_command(cmd: list[str]) -> CommandResult:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout_bytes, stderr_bytes = await process.communicate()
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(process.communicate(), timeout=_SSH_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+        return CommandResult(
+            returncode=124,
+            stdout="",
+            stderr=f"ssh command timed out after {_SSH_TIMEOUT_SECONDS} seconds",
+        )
     stdout = stdout_bytes.decode("utf-8", errors="replace")
     stderr = stderr_bytes.decode("utf-8", errors="replace")
     returncode = process.returncode if process.returncode is not None else 1

--- a/services/rl-trainer/src/autonomy/redteam.py
+++ b/services/rl-trainer/src/autonomy/redteam.py
@@ -22,6 +22,8 @@ def allow(environment: str) -> bool:
 
 
 def sample_payload(seed: str) -> dict[str, int]:
+    if not seed:
+        raise ValueError("seed must be a non-empty string")
     digest = hashlib.sha256(seed.encode("utf-8")).digest()
     views = int.from_bytes(digest[0:4], "big") % 1_000_001
     clicks = int.from_bytes(digest[4:8], "big") % 1_001


### PR DESCRIPTION
### Motivation
- Prevent unbounded or unsafe remote command execution when deploying agents by constraining SSH invocation and bounding its lifecycle.
- Reduce the security surface associated with remote deployments (CWE-78) by enforcing safer SSH options and explicit timeouts.
- Ensure deterministic payload seeding is validated so downstream code receives explicit, non-empty inputs for reproducible behavior.

### Description
- Add `_SSH_TIMEOUT_SECONDS = 60` and enforce `-o BatchMode=yes` and `-o StrictHostKeyChecking=yes` on the `ssh` invocation in `Replicator.deploy` to reduce unsafe execution surfaces.
- Wrap the SSH subprocess `communicate()` call with `asyncio.wait_for(..., timeout=_SSH_TIMEOUT_SECONDS)`, kill and wait on timeout, and return a controlled `CommandResult` with `returncode=124` and a timeout stderr message.
- Add input validation in `sample_payload` to raise `ValueError` when `seed` is empty to guarantee deterministic hashing input validity.

### Testing
- Compiled updated modules with `python -m compileall services/rl-trainer/src/agent_replicator.py services/rl-trainer/src/autonomy/redteam.py` and the compilation succeeded.
- Ran unit tests with `python -m pytest services/rl-trainer -q` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b8804434832c958b323e8ddd2170)