### PR TITLE
test(rl-trainer): add regression guards for Bandit subprocess/random findings

### DIFF
--- a/services/rl-trainer/tests/test_security_hardening.py
+++ b/services/rl-trainer/tests/test_security_hardening.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import ast
 import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+sys.path.append(str(SRC_DIR))
 
 from agent_replicator import build_remote_command, parse_targets
 from autonomy.redteam import plan, sample_payload
+
+
+def _parse_module(relative_path: str) -> ast.AST:
+    file_path = SRC_DIR / relative_path
+    return ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+
+
+def _iter_calls(tree: ast.AST) -> list[ast.Call]:
+    return [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
 
 
 def test_parse_targets_rejects_invalid_host() -> None:
@@ -32,3 +43,25 @@ def test_plan_uses_deterministic_payloads() -> None:
     first = plan("sandbox")
     second = plan("sandbox")
     assert first == second
+
+
+def test_agent_replicator_does_not_use_subprocess_run() -> None:
+    tree = _parse_module("agent_replicator.py")
+    for call in _iter_calls(tree):
+        if not isinstance(call.func, ast.Attribute):
+            continue
+        if call.func.attr != "run":
+            continue
+        if isinstance(call.func.value, ast.Name) and call.func.value.id == "subprocess":
+            raise AssertionError("subprocess.run is prohibited in agent_replicator.py")
+
+
+def test_redteam_does_not_use_non_deterministic_random_calls() -> None:
+    tree = _parse_module("autonomy/redteam.py")
+    for call in _iter_calls(tree):
+        if not isinstance(call.func, ast.Attribute):
+            continue
+        if call.func.attr != "randint":
+            continue
+        if isinstance(call.func.value, ast.Name) and call.func.value.id == "random":
+            raise AssertionError("random.randint is prohibited in autonomy/redteam.py")


### PR DESCRIPTION
### Motivation
- Address Bandit findings for CWE-78 (`subprocess.run`) and CWE-330 (`random.randint`) by preventing reintroduction of those insecure/non-deterministic patterns. 
- Codify deterministic and security-first expectations as automated regression checks to avoid future regressions.

### Description
- Added AST-based helpers ` _parse_module` and `_iter_calls` to `services/rl-trainer/tests/test_security_hardening.py` to inspect source calls at test time. 
- Added `test_agent_replicator_does_not_use_subprocess_run` to assert that `subprocess.run` is not used in `services/rl-trainer/src/agent_replicator.py`. 
- Added `test_redteam_does_not_use_non_deterministic_random_calls` to assert that `random.randint` is not used in `services/rl-trainer/src/autonomy/redteam.py` and preserved existing deterministic payload tests. 
- Normalized test import path by defining `SRC_DIR` and appending it to `sys.path` for stable module resolution.

### Testing
- Ran `pytest -q services/rl-trainer/tests/test_security_hardening.py`. 
- All tests passed: `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b91c49d8832c8a286d30fe8e8fd5)