### PR TITLE
Harden SSRF controls, secret handling, and CI workflow security pinning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker Images
         run: |

--- a/.github/workflows/enterprise-platform-delivery.yml
+++ b/.github/workflows/enterprise-platform-delivery.yml
@@ -9,14 +9,17 @@ on:
       - 'services/jwt-auth/**'
       - '.github/workflows/enterprise-platform-delivery.yml'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -35,8 +38,8 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Build jwt-auth image
         run: docker build -t zttato/jwt-auth:${{ github.sha }} services/jwt-auth
 
@@ -45,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-kubectl@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-kubectl@c0c8b32d33a5244f1e5947304550403b63930415 # v4
       - name: Kustomize deploy
         run: kubectl apply -k infrastructure/k8s

--- a/.github/workflows/zttato-ci.yml
+++ b/.github/workflows/zttato-ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run Trivy file system scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -94,20 +94,20 @@ jobs:
           - gpu-renderer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: services/${{ matrix.service }}
           push: false
@@ -115,7 +115,7 @@ jobs:
 
       - name: Build and push image
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: services/${{ matrix.service }}
           push: true
@@ -126,7 +126,7 @@ jobs:
     needs: [build-images]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Start local stack
         run: docker compose up -d
@@ -166,10 +166,10 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@c0c8b32d33a5244f1e5947304550403b63930415 # v4
 
       - name: Deploy to production
         run: kubectl apply -f infrastructure/k8s

--- a/apps/platform-core/src/limits.ts
+++ b/apps/platform-core/src/limits.ts
@@ -1,8 +1,32 @@
 import axios from "axios";
 import { Plans, type PlanDefinition, type PlanName } from "../../../packages/shared-types/plans.js";
 
+const BILLING_SERVICE_URL = process.env.BILLING_SERVICE_URL ?? "http://billing-service:3002";
+const ALLOWED_BILLING_HOSTS = new Set((process.env.BILLING_ALLOWED_HOSTS ?? "billing-service,localhost").split(",").map((host) => host.trim()).filter(Boolean));
+
+function assertAllowedBillingUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("Invalid billing service URL configuration");
+  }
+
+  if (!ALLOWED_BILLING_HOSTS.has(parsed.hostname)) {
+    throw new Error("Billing service URL host is not allowed");
+  }
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Billing service URL protocol is not allowed");
+  }
+
+  return parsed;
+}
+
 export async function checkLimits(userId: string): Promise<PlanDefinition> {
-  const billingServiceUrl = process.env.BILLING_SERVICE_URL ?? "http://billing-service:3002";
-  const res = await axios.get<{ ok: boolean; plan: PlanName }>(`${billingServiceUrl}/plan/${userId}`);
+  const billingBaseUrl = assertAllowedBillingUrl(BILLING_SERVICE_URL);
+  const safeUserId = encodeURIComponent(userId.trim());
+  const planUrl = new URL(`/plan/${safeUserId}`, billingBaseUrl).toString();
+  const res = await axios.get<{ ok: boolean; plan: PlanName }>(planUrl, { timeout: 5000 });
   return Plans[res.data.plan] ?? Plans.FREE;
 }

--- a/services/ai-video-generator/src/tts/voice.js
+++ b/services/ai-video-generator/src/tts/voice.js
@@ -1,5 +1,17 @@
-import fs from "fs"
+import fs from "fs/promises"
 import axios from "axios"
+import path from "path"
+
+const OUTPUT_BASE_DIR = process.env.TTS_OUTPUT_DIR ?? "/tmp/zttato-tts"
+
+function resolveOutputPath(output) {
+  const normalized = path.resolve(OUTPUT_BASE_DIR, output)
+  const baseDir = path.resolve(OUTPUT_BASE_DIR)
+  if (!normalized.startsWith(`${baseDir}${path.sep}`) && normalized !== baseDir) {
+    throw new Error("Output path is outside allowed TTS directory")
+  }
+  return normalized
+}
 
 export async function generateVoice(text, output){
 
@@ -11,6 +23,8 @@ url,
 {responseType:"arraybuffer"}
 )
 
-fs.writeFileSync(output,response.data)
+const safeOutputPath = resolveOutputPath(output)
+await fs.mkdir(path.dirname(safeOutputPath), { recursive: true })
+await fs.writeFile(safeOutputPath,response.data)
 
 }

--- a/services/master-orchestrator/src/deployment_controller.py
+++ b/services/master-orchestrator/src/deployment_controller.py
@@ -15,6 +15,10 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger("deployment-controller")
 
 
+def _sanitize_log_value(value: str) -> str:
+    return value.replace("\r", " ").replace("\n", " ").strip()
+
+
 class DeploymentState(str, Enum):
     queued = "queued"
     building = "building"
@@ -150,8 +154,8 @@ class DeploymentStore:
 
     def _log(self, event_type: str, deployment_id: str, context: dict[str, Any]) -> None:
         message = {
-            "event_type": event_type,
-            "deployment_id": deployment_id,
+            "event_type": _sanitize_log_value(event_type),
+            "deployment_id": _sanitize_log_value(deployment_id),
             "context": context,
             "timestamp": self._now_iso(),
         }

--- a/services/master-orchestrator/src/distributed_loop.py
+++ b/services/master-orchestrator/src/distributed_loop.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 from fastapi import HTTPException
 
 TIMEOUT = 10
+ALLOWED_INTERNAL_HOSTS = {"feature-store", "rl-coordinator", "budget-allocator", "rtb-engine", "scaling-engine"}
+
+
+def _assert_internal_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "http" or parsed.hostname not in ALLOWED_INTERNAL_HOSTS:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    return url
 
 
 def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
+    url = _assert_internal_url(url)
     kwargs.setdefault("timeout", TIMEOUT)
     try:
         response = method(url, **kwargs)

--- a/services/master-orchestrator/src/federated_loop.py
+++ b/services/master-orchestrator/src/federated_loop.py
@@ -6,6 +6,7 @@ import hmac
 import json
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 from fastapi import HTTPException
@@ -15,9 +16,18 @@ FEDERATION_SECRET = os.getenv("FEDERATION_SECRET", "change-me")
 DEFAULT_REGION = os.getenv("FEDERATED_DEFAULT_REGION", "asia")
 DEFAULT_TENANT = os.getenv("FEDERATED_DEFAULT_TENANT", "default")
 DEFAULT_MAX_BUDGET = float(os.getenv("FEDERATED_MAX_BUDGET", "100"))
+ALLOWED_INTERNAL_HOSTS = {"feature-store", "rl-coordinator", "capital-allocator", "scheduler"}
+
+
+def _assert_internal_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "http" or parsed.hostname not in ALLOWED_INTERNAL_HOSTS:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    return url
 
 
 def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
+    url = _assert_internal_url(url)
     kwargs.setdefault("timeout", TIMEOUT)
     try:
         response = method(url, **kwargs)

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Literal
 from urllib.parse import quote
+from urllib.parse import urlparse
 
 import requests
 from fastapi import FastAPI, HTTPException
@@ -33,6 +34,14 @@ MODEL_SERVICE_URL = os.getenv("MODEL_SERVICE_URL", "http://model-service:8000")
 EXECUTION_ENGINE_URL = os.getenv("EXECUTION_ENGINE_URL", "http://execution-engine:9600")
 APP_PORT = int(os.getenv("MASTER_ORCHESTRATOR_PORT", "8000"))
 deployment_store = DeploymentStore()
+ALLOWED_UPSTREAM_HOSTS = {
+    "click-tracker",
+    "payment-gateway",
+    "feature-store",
+    "model-service",
+    "execution-engine",
+    "scheduler",
+}
 
 
 class PaymentConfig(BaseModel):
@@ -73,6 +82,10 @@ class ProfitModeResponse(BaseModel):
 
 
 def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname not in ALLOWED_UPSTREAM_HOSTS:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+
     kwargs.setdefault("timeout", TIMEOUT)
     session = requests.Session()
     retries = Retry(
@@ -96,9 +109,9 @@ def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:
-        raise HTTPException(status_code=502, detail=f"Upstream call failed for {url}: {exc}") from exc
+        raise HTTPException(status_code=502, detail=f"Upstream call failed: {exc}") from exc
     except ValueError as exc:
-        raise HTTPException(status_code=502, detail=f"Invalid JSON response from {url}: {exc}") from exc
+        raise HTTPException(status_code=502, detail=f"Invalid JSON response from upstream: {exc}") from exc
 
 
 class Offer(BaseModel):

--- a/services/model-registry/src/main.py
+++ b/services/model-registry/src/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Any
@@ -26,6 +27,26 @@ def _ensure_writable_directory(path: Path, env_override_name: str) -> Path:
 
 BASE = _ensure_writable_directory(BASE, "MODEL_REGISTRY_PATH")
 SHARED = _ensure_writable_directory(SHARED, "MODEL_REGISTRY_SHARED_PATH")
+SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_model_component(value: str, field_name: str) -> str:
+    cleaned = value.strip()
+    if not SAFE_NAME_RE.fullmatch(cleaned):
+        raise HTTPException(status_code=422, detail=f"invalid {field_name}")
+    return cleaned
+
+
+def _resolve_source_file(model_path: str) -> Path:
+    candidate = Path(model_path).expanduser().resolve(strict=False)
+    if not candidate.exists() or not candidate.is_file():
+        raise HTTPException(status_code=400, detail="model path not found")
+
+    base_allowed = BASE.resolve(strict=False)
+    shared_allowed = SHARED.resolve(strict=False)
+    if not (candidate.is_relative_to(base_allowed) or candidate.is_relative_to(shared_allowed)):
+        raise HTTPException(status_code=400, detail="model path is outside allowed registries")
+    return candidate
 
 
 class Register(BaseModel):
@@ -45,11 +66,11 @@ def healthz() -> dict[str, Any]:
 
 @app.post("/register")
 def register(model: Register) -> dict[str, str]:
-    source = Path(model.path)
-    if not source.exists() or not source.is_file():
-        raise HTTPException(status_code=400, detail=f"model path not found: {source}")
+    source = _resolve_source_file(model.path)
+    safe_name = _safe_model_component(model.name, "name")
+    safe_version = _safe_model_component(model.version, "version")
 
-    destination = BASE / f"{model.name}_{model.version}.pt"
+    destination = BASE / f"{safe_name}_{safe_version}.pt"
     shutil.copy2(source, destination)
     shutil.copy2(source, SHARED / destination.name)
     return {"stored": str(destination), "shared": str(SHARED / destination.name)}
@@ -57,7 +78,8 @@ def register(model: Register) -> dict[str, str]:
 
 @app.get("/latest/{name}")
 def latest(name: str) -> dict[str, str | None]:
-    files = sorted((path.name for path in BASE.glob(f"{name}_*.pt")), reverse=True)
+    safe_name = _safe_model_component(name, "name")
+    files = sorted((path.name for path in BASE.glob(f"{safe_name}_*.pt")), reverse=True)
     return {"model": files[0] if files else None}
 
 

--- a/services/model-service/src/main.py
+++ b/services/model-service/src/main.py
@@ -109,7 +109,7 @@ def healthz() -> dict[str, Any]:
         "status": "ok",
         "service": "model-service",
         "model_version": MODEL_VERSION,
-        "kafka_broker": KAFKA_BROKER,
+        "kafka_configured": bool(KAFKA_BROKER),
         "onnx_ready": model.ready,
     }
 

--- a/services/model-service/src/result_store.py
+++ b/services/model-service/src/result_store.py
@@ -14,6 +14,10 @@ REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
 REDIS_CLUSTER_URL = os.getenv("REDIS_CLUSTER_URL", "")
 
 
+def _sanitize_log_value(value: str) -> str:
+    return value.replace("\r", " ").replace("\n", " ").strip()
+
+
 class ResultStore:
     def __init__(self) -> None:
         self._client = self._build_client()
@@ -58,7 +62,7 @@ class ResultStore:
             if isinstance(decoded, dict):
                 return decoded
         except Exception:  # pragma: no cover - defensive fallback
-            log.warning("Failed to decode result for job_id=%s", job_id, exc_info=True)
+            log.warning("Failed to decode result for job_id=%s", _sanitize_log_value(job_id), exc_info=True)
         return None
 
 

--- a/services/tenant-service/src/main.py
+++ b/services/tenant-service/src/main.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import os
 import secrets
@@ -12,6 +13,27 @@ DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://zttato:zttato@postgres:54
 DEFAULT_DAILY_SPEND_LIMIT = float(os.getenv("DEFAULT_DAILY_SPEND_LIMIT", "100.0"))
 SERVICE_HOST = os.getenv("SERVICE_HOST", "127.0.0.1")
 SERVICE_PORT = int(os.getenv("SERVICE_PORT", "8000"))
+SCRYPT_N = int(os.getenv("API_KEY_SCRYPT_N", str(2**14)))
+SCRYPT_R = int(os.getenv("API_KEY_SCRYPT_R", "8"))
+SCRYPT_P = int(os.getenv("API_KEY_SCRYPT_P", "1"))
+SCRYPT_DKLEN = int(os.getenv("API_KEY_SCRYPT_DKLEN", "32"))
+
+
+def hash_api_key(api_key: str) -> str:
+    salt = secrets.token_bytes(16)
+    digest = hashlib.scrypt(
+        api_key.encode("utf-8"),
+        salt=salt,
+        n=SCRYPT_N,
+        r=SCRYPT_R,
+        p=SCRYPT_P,
+        dklen=SCRYPT_DKLEN,
+    )
+    return (
+        f"scrypt${SCRYPT_N}${SCRYPT_R}${SCRYPT_P}$"
+        f"{base64.urlsafe_b64encode(salt).decode('utf-8')}$"
+        f"{base64.urlsafe_b64encode(digest).decode('utf-8')}"
+    )
 
 
 def db_connection():
@@ -50,7 +72,7 @@ def healthz() -> dict[str, Any]:
 @app.post("/tenant", response_model=TenantCreateResponse)
 def create_tenant(payload: TenantCreateRequest) -> TenantCreateResponse:
     api_key = f"zt_{secrets.token_urlsafe(24)}"
-    api_key_hash = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+    api_key_hash = hash_api_key(api_key)
 
     try:
         with db_connection() as conn:

--- a/services/tracking/server.py
+++ b/services/tracking/server.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 import uuid
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
@@ -13,6 +13,7 @@ from fastapi.responses import RedirectResponse
 logger = logging.getLogger("tracking.server")
 
 AFFILIATE_BASE_URL = os.getenv("AFFILIATE_BASE_URL", "")
+AFFILIATE_ALLOWED_HOSTS = {host.strip() for host in os.getenv("AFFILIATE_ALLOWED_HOSTS", "").split(",") if host.strip()}
 DATABASE_URL = os.getenv("DATABASE_URL", "")
 app = FastAPI(title="Tracking Service")
 
@@ -37,6 +38,21 @@ def _assert_campaign_id(campaign_id: str) -> str:
     return cid
 
 
+def _sanitize_log_value(value: str) -> str:
+    return value.replace("\r", " ").replace("\n", " ").strip()
+
+
+def _validated_affiliate_base_url() -> str:
+    parsed = urlparse(AFFILIATE_BASE_URL)
+    if parsed.scheme not in {"http", "https"}:
+        raise HTTPException(status_code=500, detail="affiliate base url must be http or https")
+    if not parsed.netloc:
+        raise HTTPException(status_code=500, detail="affiliate base url host is required")
+    if AFFILIATE_ALLOWED_HOSTS and parsed.hostname not in AFFILIATE_ALLOWED_HOSTS:
+        raise HTTPException(status_code=500, detail="affiliate base url host is not allowed")
+    return AFFILIATE_BASE_URL
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, str]:
     return {"status": "ok", "service": "tracking"}
@@ -47,6 +63,7 @@ async def track(campaign_id: str, request: Request) -> RedirectResponse:
     if not AFFILIATE_BASE_URL:
         raise HTTPException(status_code=500, detail="affiliate base url not configured")
 
+    affiliate_base_url = _validated_affiliate_base_url()
     cid = _assert_campaign_id(campaign_id)
     click_id = str(uuid.uuid4())
     ip = request.client.host if request.client else "unknown"
@@ -64,6 +81,14 @@ async def track(campaign_id: str, request: Request) -> RedirectResponse:
         conn.commit()
 
     query = urlencode({"cid": cid, "click_id": click_id})
-    target = f"{AFFILIATE_BASE_URL}?{query}"
-    logger.info(json.dumps({"event": "click_tracked", "campaign_id": cid, "click_id": click_id}))
+    target = f"{affiliate_base_url}?{query}"
+    logger.info(
+        json.dumps(
+            {
+                "event": "click_tracked",
+                "campaign_id": _sanitize_log_value(cid),
+                "click_id": _sanitize_log_value(click_id),
+            }
+        )
+    )
     return RedirectResponse(target, status_code=307)


### PR DESCRIPTION
### Motivation
- Remediate multiple CodeQL findings (SSRF, log injection, weak hashing, path traversal, file-write, and workflow supply-chain issues) by enforcing stricter input validation and least-privilege defaults. 
- Prevent untrusted outbound/redirect targets and reduce sensitive data exposure from health endpoints and logs. 

### Description
- Added strict upstream URL validation and allowlists to protect against SSRF by validating hostnames/protocols before any outbound call in `distributed_loop`, `federated_loop`, and the orchestrator `safe_call`, and added `assertAllowedBillingUrl` for billing calls in `apps/platform-core/src/limits.ts`.  
- Hardened redirects and logging in `services/tracking/server.py` by validating `AFFILIATE_BASE_URL`, supporting an optional `AFFILIATE_ALLOWED_HOSTS` allowlist, and sanitizing logged values to mitigate log injection.  
- Restricted file/path operations: validated model `name`/`version` and constrained allowed source locations in `services/model-registry/src/main.py`, and confined TTS output writes to a safe base directory and switched to async `fs/promises` in `services/ai-video-generator/src/tts/voice.js`.  
- Improved secrets and sensitive-data handling by replacing SHA-256 API-key hashing with a salted `scrypt` derivation in `services/tenant-service/src/main.py`, removing raw broker info from `model-service` health output (replaced with `kafka_configured`), sanitizing several log emission sites, and standardizing safer error details for upstream call failures.  
- Strengthened CI workflow security by adding missing top-level `permissions` and pinning non-immutable GitHub Actions to commit SHAs in workflow files under `.github/workflows`.

### Testing
- Ran Python byte-compile across modified services with `python -m compileall services/master-orchestrator/src services/model-service/src services/tracking services/model-registry/src services/tenant-service/src`, which completed successfully.  
- Performed a JS syntax check with `node --check services/ai-video-generator/src/tts/voice.js`, which succeeded.  
- Executed `pytest -q services/master-orchestrator/src services/model-registry/src services/tenant-service/src services/tracking`, which completed (no tests discovered in those paths).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3c71f438c832ca1b6fb439a490231)