### PR TITLE
Harden services against SSRF, path traversal, and sensitive-data leaks

### DIFF
--- a/services/ai-video-generator/src/tts/voice.js
+++ b/services/ai-video-generator/src/tts/voice.js
@@ -1,8 +1,10 @@
 import fs from "fs/promises"
 import axios from "axios"
 import path from "path"
+import { constants as fsConstants } from "fs"
 
 const OUTPUT_BASE_DIR = process.env.TTS_OUTPUT_DIR ?? "/tmp/zttato-tts"
+const MAX_AUDIO_BYTES = Number.parseInt(process.env.TTS_MAX_AUDIO_BYTES ?? "5242880", 10)
 
 function resolveOutputPath(output) {
   const normalized = path.resolve(OUTPUT_BASE_DIR, output)
@@ -20,11 +22,19 @@ const url = "https://api.elevenlabs.io/v1/text-to-speech"
 const response = await axios.post(
 url,
 {text},
-{responseType:"arraybuffer"}
+{responseType:"arraybuffer", maxContentLength: MAX_AUDIO_BYTES, timeout: 15000}
 )
+
+const contentType = String(response.headers["content-type"] ?? "")
+if (!contentType.startsWith("audio/")) {
+  throw new Error("Unexpected content type returned by TTS provider")
+}
+if (!response.data || response.data.byteLength > MAX_AUDIO_BYTES) {
+  throw new Error("TTS audio response exceeds configured size limit")
+}
 
 const safeOutputPath = resolveOutputPath(output)
 await fs.mkdir(path.dirname(safeOutputPath), { recursive: true })
-await fs.writeFile(safeOutputPath,response.data)
+await fs.writeFile(safeOutputPath,response.data,{ mode: 0o600, flag: fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY })
 
 }

--- a/services/execution-engine/src/main.py
+++ b/services/execution-engine/src/main.py
@@ -73,6 +73,10 @@ def acquire_token() -> None:
         TOKENS -= 1
 
 
+def _sanitize_log_value(value: str) -> str:
+    return value.replace("\r", " ").replace("\n", " ").strip()
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
     return {
@@ -98,7 +102,7 @@ def publish(req: PublishRequest) -> PublishResponse:
         "metadata": {"campaign_id": req.campaign_id},
     }
 
-    log.info("Publishing campaign=%s", req.campaign_id)
+    log.info("Publishing campaign=%s", _sanitize_log_value(req.campaign_id))
     data = http_post(f"{API_BASE}/content/publish", payload)
 
     return PublishResponse(

--- a/services/master-orchestrator/src/distributed_loop.py
+++ b/services/master-orchestrator/src/distributed_loop.py
@@ -8,11 +8,16 @@ from fastapi import HTTPException
 
 TIMEOUT = 10
 ALLOWED_INTERNAL_HOSTS = {"feature-store", "rl-coordinator", "budget-allocator", "rtb-engine", "scaling-engine"}
+ALLOWED_INTERNAL_PORTS = {8000}
 
 
 def _assert_internal_url(url: str) -> str:
     parsed = urlparse(url)
-    if parsed.scheme != "http" or parsed.hostname not in ALLOWED_INTERNAL_HOSTS:
+    if parsed.scheme != "http" or parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    if parsed.hostname not in ALLOWED_INTERNAL_HOSTS or parsed.port not in ALLOWED_INTERNAL_PORTS:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    if parsed.path in {"", "/"}:
         raise HTTPException(status_code=400, detail="upstream url is not allowed")
     return url
 
@@ -21,7 +26,7 @@ def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
     url = _assert_internal_url(url)
     kwargs.setdefault("timeout", TIMEOUT)
     try:
-        response = method(url, **kwargs)
+        response = method(url, allow_redirects=False, **kwargs)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:

--- a/services/master-orchestrator/src/federated_loop.py
+++ b/services/master-orchestrator/src/federated_loop.py
@@ -17,11 +17,16 @@ DEFAULT_REGION = os.getenv("FEDERATED_DEFAULT_REGION", "asia")
 DEFAULT_TENANT = os.getenv("FEDERATED_DEFAULT_TENANT", "default")
 DEFAULT_MAX_BUDGET = float(os.getenv("FEDERATED_MAX_BUDGET", "100"))
 ALLOWED_INTERNAL_HOSTS = {"feature-store", "rl-coordinator", "capital-allocator", "scheduler"}
+ALLOWED_INTERNAL_PORTS = {8000}
 
 
 def _assert_internal_url(url: str) -> str:
     parsed = urlparse(url)
-    if parsed.scheme != "http" or parsed.hostname not in ALLOWED_INTERNAL_HOSTS:
+    if parsed.scheme != "http" or parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    if parsed.hostname not in ALLOWED_INTERNAL_HOSTS or parsed.port not in ALLOWED_INTERNAL_PORTS:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    if parsed.path in {"", "/"}:
         raise HTTPException(status_code=400, detail="upstream url is not allowed")
     return url
 
@@ -30,7 +35,7 @@ def safe_call(method, url: str, **kwargs: Any) -> dict[str, Any]:
     url = _assert_internal_url(url)
     kwargs.setdefault("timeout", TIMEOUT)
     try:
-        response = method(url, **kwargs)
+        response = method(url, allow_redirects=False, **kwargs)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:

--- a/services/master-orchestrator/src/main.py
+++ b/services/master-orchestrator/src/main.py
@@ -42,6 +42,7 @@ ALLOWED_UPSTREAM_HOSTS = {
     "execution-engine",
     "scheduler",
 }
+ALLOWED_UPSTREAM_PORTS = {8000, 8080, 9600}
 
 
 class PaymentConfig(BaseModel):
@@ -81,9 +82,31 @@ class ProfitModeResponse(BaseModel):
     audit: dict[str, Any]
 
 
+def _validate_base_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "http" or parsed.username or parsed.password:
+        raise RuntimeError(f"Invalid configured upstream URL: {url}")
+    if parsed.hostname not in ALLOWED_UPSTREAM_HOSTS or parsed.port not in ALLOWED_UPSTREAM_PORTS:
+        raise RuntimeError(f"Invalid configured upstream URL host/port: {url}")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise RuntimeError(f"Invalid configured upstream URL path/query: {url}")
+    return f"{parsed.scheme}://{parsed.hostname}:{parsed.port}"
+
+
+CLICK_TRACKER_URL = _validate_base_url(CLICK_TRACKER_URL)
+PAYMENT_GATEWAY_URL = _validate_base_url(PAYMENT_GATEWAY_URL)
+FEATURE_STORE_URL = _validate_base_url(FEATURE_STORE_URL)
+MODEL_SERVICE_URL = _validate_base_url(MODEL_SERVICE_URL)
+EXECUTION_ENGINE_URL = _validate_base_url(EXECUTION_ENGINE_URL)
+
+
 def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
     parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"} or parsed.hostname not in ALLOWED_UPSTREAM_HOSTS:
+    if parsed.scheme != "http" or parsed.username or parsed.password:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    if parsed.hostname not in ALLOWED_UPSTREAM_HOSTS or parsed.port not in ALLOWED_UPSTREAM_PORTS:
+        raise HTTPException(status_code=400, detail="upstream url is not allowed")
+    if parsed.path in {"", "/"}:
         raise HTTPException(status_code=400, detail="upstream url is not allowed")
 
     kwargs.setdefault("timeout", TIMEOUT)
@@ -105,7 +128,7 @@ def safe_call(method_func, url: str, **kwargs: Any) -> dict[str, Any]:
     if method_name not in {"get", "post", "put", "patch", "delete", "head", "options"}:
         raise HTTPException(status_code=500, detail=f"Unsupported HTTP method callable: {method_func}")
     try:
-        response = getattr(session, method_name)(url, **kwargs)
+        response = getattr(session, method_name)(url, allow_redirects=False, **kwargs)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as exc:

--- a/services/model-registry/src/main.py
+++ b/services/model-registry/src/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import shutil
+import stat
 from pathlib import Path
 from typing import Any
 
@@ -48,6 +49,11 @@ def _resolve_source_file(model_path: str) -> Path:
     candidate = Path(model_path).expanduser().resolve(strict=False)
     if not candidate.exists() or not candidate.is_file():
         raise HTTPException(status_code=400, detail="model path not found")
+    if candidate.is_symlink():
+        raise HTTPException(status_code=400, detail="symlink source files are not allowed")
+    mode = candidate.stat().st_mode
+    if not stat.S_ISREG(mode):
+        raise HTTPException(status_code=400, detail="source must be a regular file")
 
     allowed_roots = _allowed_source_roots()
     if not any(candidate.is_relative_to(allowed_root) for allowed_root in allowed_roots):
@@ -77,9 +83,12 @@ def register(model: Register) -> dict[str, str]:
     safe_version = _safe_model_component(model.version, "version")
 
     destination = BASE / f"{safe_name}_{safe_version}.pt"
+    shared_destination = SHARED / destination.name
+    if destination.exists() or shared_destination.exists():
+        raise HTTPException(status_code=409, detail="model version already exists")
     shutil.copy2(source, destination)
-    shutil.copy2(source, SHARED / destination.name)
-    return {"stored": str(destination), "shared": str(SHARED / destination.name)}
+    shutil.copy2(source, shared_destination)
+    return {"stored": str(destination), "shared": str(shared_destination)}
 
 
 @app.get("/latest/{name}")

--- a/services/rl-trainer/src/main.py
+++ b/services/rl-trainer/src/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import time
+from hashlib import sha256
 from pathlib import Path
 
 import numpy as np
@@ -88,6 +89,18 @@ def build_autonomous_snapshot(features: np.ndarray, reward: float) -> dict[str, 
     }
 
 
+def _redact_snapshot(snapshot: dict[str, object]) -> dict[str, object]:
+    redacted = dict(snapshot)
+    identity_payload = snapshot.get("identity")
+    if isinstance(identity_payload, dict):
+        did = str(identity_payload.get("did", ""))
+        redacted["identity"] = {
+            "did_sha256": sha256(did.encode("utf-8")).hexdigest(),
+            "has_signature": bool(identity_payload.get("signature_b64")),
+        }
+    return redacted
+
+
 def loop() -> None:
     MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
     while True:
@@ -109,8 +122,9 @@ def loop() -> None:
         old_prob = float(data.get("prob", 0.5))
         prob = ppo.update(x, reward, old_prob)
         snapshot = build_autonomous_snapshot(x, reward)
-        MODEL_PATH.write_text(json.dumps({"weights": ppo.w.tolist(), "prob": prob, "autonomous_snapshot": snapshot}))
-        log.info("updated policy weights=%s autonomous_snapshot=%s", ppo.w.tolist(), snapshot)
+        safe_snapshot = _redact_snapshot(snapshot)
+        MODEL_PATH.write_text(json.dumps({"weights": ppo.w.tolist(), "prob": prob, "autonomous_snapshot": safe_snapshot}))
+        log.info("updated policy weights=%s autonomous_snapshot=%s", ppo.w.tolist(), safe_snapshot)
 
 
 if __name__ == "__main__":

--- a/services/tracking/server.py
+++ b/services/tracking/server.py
@@ -43,12 +43,16 @@ def _sanitize_log_value(value: str) -> str:
 
 
 def _validated_affiliate_base_url() -> str:
+    if not AFFILIATE_ALLOWED_HOSTS:
+        raise HTTPException(status_code=500, detail="affiliate allowed hosts must be configured")
     parsed = urlparse(AFFILIATE_BASE_URL)
     if parsed.scheme not in {"http", "https"}:
         raise HTTPException(status_code=500, detail="affiliate base url must be http or https")
     if not parsed.netloc:
         raise HTTPException(status_code=500, detail="affiliate base url host is required")
-    if AFFILIATE_ALLOWED_HOSTS and parsed.hostname not in AFFILIATE_ALLOWED_HOSTS:
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise HTTPException(status_code=500, detail="affiliate base url credentials/query are not allowed")
+    if parsed.hostname not in AFFILIATE_ALLOWED_HOSTS:
         raise HTTPException(status_code=500, detail="affiliate base url host is not allowed")
     return AFFILIATE_BASE_URL
 


### PR DESCRIPTION
### Motivation
- Address multiple CodeQL findings around partial SSRF, uncontrolled path usage, insecure file writes, and clear-text logging/storage across services. 
- Prevent redirect-based SSRF bypasses and credentialed/complex upstream URLs from being used by internal callers. 
- Reduce risk of sensitive data leakage in logs and persisted artifacts by sanitizing and redacting before writing or logging.

### Description
- Added strict upstream URL validation and allowed-port checks in `master-orchestrator` (`src/main.py`) and enforced the same hostname/port/path/credential restrictions and `allow_redirects=False` on runtime calls in `distributed_loop.py` and `federated_loop.py`. 
- Required configured base URLs to be canonical and host/port-validated at startup via `_validate_base_url` in `master-orchestrator` to fail-fast on bad environment settings. 
- Hardened `model-registry` (`src/main.py`) to reject symlink/non-regular source files and prevent overwriting existing model versions by returning `409` on duplicates. 
- Mitigated log injection in `execution-engine` by sanitizing `campaign_id` before logging and limited persisted snapshot contents in `rl-trainer` by redacting identity details and storing a hashed identifier instead of raw payloads. 
- Strengthened tracking redirect safety in `tracking/server.py` by requiring an explicit affiliate allowlist and rejecting affiliate base URLs containing credentials, queries, or fragments. 
- Secured TTS output in `ai-video-generator/src/tts/voice.js` by enforcing response `content-type` starts with `audio/`, bounding response size via `MAX_AUDIO_BYTES`, and writing files with exclusive-create flags and restrictive permissions.

### Testing
- Ran `python -m compileall` across the modified Python modules and it completed successfully. 
- Ran `node --check services/ai-video-generator/src/tts/voice.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4405754ec832c8b4d5efb0d56c179)