### PR TITLE
fix: sync service surface manifest with affiliate-marketing app

### DIFF
--- a/config/service-surface-manifest.json
+++ b/config/service-surface-manifest.json
@@ -81,6 +81,41 @@
       "write_policies": []
     },
     {
+      "app": true,
+      "compose": false,
+      "docs": false,
+      "docs_path": null,
+      "endpoints": [
+        "GET /healthz",
+        "POST /v1/copy/generate",
+        "POST /v1/copy/optimize",
+        "POST /v1/trends/analyze"
+      ],
+      "name": "affiliate-marketing",
+      "runtime": false,
+      "runtime_language": null,
+      "write_policies": [
+        {
+          "auth": "required",
+          "endpoint": "POST /v1/copy/generate",
+          "schema": "required",
+          "tenant": "required"
+        },
+        {
+          "auth": "required",
+          "endpoint": "POST /v1/copy/optimize",
+          "schema": "required",
+          "tenant": "required"
+        },
+        {
+          "auth": "required",
+          "endpoint": "POST /v1/trends/analyze",
+          "schema": "required",
+          "tenant": "required"
+        }
+      ]
+    },
+    {
       "app": false,
       "compose": true,
       "docs": false,


### PR DESCRIPTION
### Motivation
- CI detected a manifest drift when regenerating the service surface, caused by a missing `affiliate-marketing` record in `config/service-surface-manifest.json`, so the committed manifest must be brought back in sync with the repository source-of-truth.

### Description
- Added an `affiliate-marketing` service entry to `config/service-surface-manifest.json` with `app: true`, detected endpoints (`GET /healthz`, `POST /v1/copy/generate`, `POST /v1/copy/optimize`, `POST /v1/trends/analyze`), and deterministic `write_policies` (each write endpoint set to `auth: required`, `tenant: required`, `schema: required`).

### Testing
- Reproduced the issue with `python scripts/feature_impact_dive.py --write-manifest && git diff --exit-code config/service-surface-manifest.json` which showed drift, then committed the synced manifest and confirmed `python scripts/feature_impact_dive.py --validate-manifest` returns success (no drift).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d488da8778832ca21e92ec6227bbd4)