### PR TITLE
Harden CodeQL-reported sinks in model-registry, rl-trainer, and TTS writer

### DIFF
--- a/services/ai-video-generator/src/tts/voice.js
+++ b/services/ai-video-generator/src/tts/voice.js
@@ -26,6 +26,17 @@ function hasKnownAudioHeader(buffer) {
   return isWav || isMp3 || isOgg
 }
 
+function toSafeAudioBuffer(payload) {
+  const audioBuffer = Buffer.isBuffer(payload) ? payload : Buffer.from(payload)
+  if (audioBuffer.length === 0 || audioBuffer.length > MAX_AUDIO_BYTES) {
+    throw new Error("TTS audio response exceeds configured size limit")
+  }
+  if (!hasKnownAudioHeader(audioBuffer)) {
+    throw new Error("Unexpected audio binary payload returned by TTS provider")
+  }
+  return audioBuffer
+}
+
 export async function generateVoice(text, output){
 
 const url = "https://api.elevenlabs.io/v1/text-to-speech"
@@ -40,15 +51,10 @@ const contentType = String(response.headers["content-type"] ?? "")
 if (!contentType.startsWith("audio/")) {
   throw new Error("Unexpected content type returned by TTS provider")
 }
-if (!response.data || response.data.byteLength > MAX_AUDIO_BYTES) {
-  throw new Error("TTS audio response exceeds configured size limit")
-}
-if (!hasKnownAudioHeader(response.data)) {
-  throw new Error("Unexpected audio binary payload returned by TTS provider")
-}
+const safeAudioBuffer = toSafeAudioBuffer(response.data)
 
 const safeOutputPath = resolveOutputPath(output)
 await fs.mkdir(path.dirname(safeOutputPath), { recursive: true })
-await fs.writeFile(safeOutputPath,response.data,{ mode: 0o600, flag: fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY })
+await fs.writeFile(safeOutputPath,safeAudioBuffer,{ mode: 0o600, flag: fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY })
 
 }

--- a/services/model-registry/src/main.py
+++ b/services/model-registry/src/main.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import stat
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -61,6 +62,29 @@ def _resolve_source_file(model_path: str) -> Path:
     raise HTTPException(status_code=400, detail="model path not found in allowed source roots")
 
 
+def _resolve_destination(base_dir: Path, file_name: str) -> Path:
+    candidate = (base_dir / file_name).resolve(strict=False)
+    base_resolved = base_dir.resolve(strict=False)
+    if candidate.parent != base_resolved:
+        raise HTTPException(status_code=400, detail="invalid destination path")
+    return candidate
+
+
+def _atomic_copy(source: Path, destination: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        raise HTTPException(status_code=409, detail="model version already exists")
+    with tempfile.NamedTemporaryFile(dir=destination.parent, prefix=".tmp-", delete=False) as tmp_file:
+        temp_path = Path(tmp_file.name)
+    try:
+        shutil.copy2(source, temp_path)
+        os.chmod(temp_path, 0o600)
+        os.replace(temp_path, destination)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
 class Register(BaseModel):
     name: str = Field(min_length=1)
     version: str = Field(min_length=1)
@@ -82,12 +106,13 @@ def register(model: Register) -> dict[str, str]:
     safe_name = _safe_model_component(model.name, "name")
     safe_version = _safe_model_component(model.version, "version")
 
-    destination = BASE / f"{safe_name}_{safe_version}.pt"
-    shared_destination = SHARED / destination.name
+    destination_name = f"{safe_name}_{safe_version}.pt"
+    destination = _resolve_destination(BASE, destination_name)
+    shared_destination = _resolve_destination(SHARED, destination_name)
     if destination.exists() or shared_destination.exists():
         raise HTTPException(status_code=409, detail="model version already exists")
-    shutil.copy2(source, destination)
-    shutil.copy2(source, shared_destination)
+    _atomic_copy(source, destination)
+    _atomic_copy(source, shared_destination)
     return {"stored": str(destination), "shared": str(shared_destination)}
 
 

--- a/services/rl-trainer/src/main.py
+++ b/services/rl-trainer/src/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from hashlib import sha256
 from pathlib import Path
@@ -26,6 +27,7 @@ from autonomy.simulation import World
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("rl-trainer")
 MODEL_PATH = Path("/models/policy.onnx")
+MODEL_FILE_MODE = 0o600
 consumer = Consumer(
     {
         "bootstrap.servers": "redpanda:9092",
@@ -101,6 +103,11 @@ def _redact_snapshot(snapshot: dict[str, object]) -> dict[str, object]:
     return redacted
 
 
+def _snapshot_fingerprint(snapshot: dict[str, object]) -> str:
+    canonical = json.dumps(snapshot, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return sha256(canonical).hexdigest()
+
+
 def loop() -> None:
     MODEL_PATH.parent.mkdir(parents=True, exist_ok=True)
     while True:
@@ -123,8 +130,24 @@ def loop() -> None:
         prob = ppo.update(x, reward, old_prob)
         snapshot = build_autonomous_snapshot(x, reward)
         safe_snapshot = _redact_snapshot(snapshot)
-        MODEL_PATH.write_text(json.dumps({"weights": ppo.w.tolist(), "prob": prob, "autonomous_snapshot": safe_snapshot}))
-        log.info("updated policy weights=%s autonomous_snapshot=%s", ppo.w.tolist(), safe_snapshot)
+        persisted_payload = {
+            "weights": ppo.w.tolist(),
+            "prob": prob,
+            "autonomous_snapshot_sha256": _snapshot_fingerprint(safe_snapshot),
+            "updated_at": int(time.time()),
+        }
+        encoded_payload = json.dumps(persisted_payload, sort_keys=True, separators=(",", ":"))
+        with os.fdopen(
+            os.open(MODEL_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, MODEL_FILE_MODE),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            handle.write(encoded_payload)
+        log.info(
+            "updated policy weights_sha256=%s autonomous_snapshot_sha256=%s",
+            sha256(np.asarray(ppo.w, dtype=float).tobytes()).hexdigest(),
+            persisted_payload["autonomous_snapshot_sha256"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Remediate multiple CodeQL findings (SSRF/uncontrolled path expressions, clear-text storage/logging, and unsafe network-to-file flows) observed in registry, RL trainer, and TTS components.
- Prevent tainted/unvalidated input from being used in path expressions or written directly to disk or logs.
- Enforce least-privilege storage and atomic write semantics to reduce risk of data leakage and race conditions.

### Description
- In `services/model-registry/src/main.py` added `_resolve_destination` to strictly bound destination paths, and introduced `_atomic_copy` which writes via a temporary file, applies `0600` permissions, and atomically replaces the final file.
- In `services/rl-trainer/src/main.py` removed direct clear-text persistence/logging of snapshot payloads and instead persist only a fingerprint (`autonomous_snapshot_sha256`) and `updated_at` timestamp with secure file mode (`0600`) when writing model metadata, and replaced raw snapshot logging with hashed indicators (`weights_sha256`, `autonomous_snapshot_sha256`).
- In `services/ai-video-generator/src/tts/voice.js` added `toSafeAudioBuffer` to normalize and re-validate network audio payloads (size and header checks) before writing to disk, and updated the write call to use the validated buffer while preserving existing path sandbox checks and secure file flags.
- Small housekeeping: added required imports and ensured consistent secure modes and deterministic fingerprinting across the changes.

### Testing
- Ran `python -m py_compile services/rl-trainer/src/main.py services/model-registry/src/main.py` which completed successfully without syntax errors.
- Ran `node --check services/ai-video-generator/src/tts/voice.js` which returned clean syntax validation.
- Committed changes and verified the repository diff shows the three modified files updated as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d489d1c894832cb2566f10e7402430)