### PR TITLE
Harden reward collector against partial SSRF

### DIFF
--- a/services/reward-collector/src/main.py
+++ b/services/reward-collector/src/main.py
@@ -1,4 +1,5 @@
 from typing import Any
+from urllib.parse import quote
 
 import requests
 from fastapi import FastAPI, HTTPException
@@ -11,7 +12,7 @@ TIMEOUT = 10
 
 
 class RewardEvent(BaseModel):
-    campaign_id: str = Field(min_length=1)
+    campaign_id: str = Field(min_length=1, max_length=64, pattern=r"^[A-Za-z0-9_-]+$")
     revenue: float = Field(default=0.0, ge=0.0)
     conversions: int = Field(default=0, ge=0)
     clicks: int = Field(default=0, ge=0)
@@ -46,7 +47,8 @@ def reward(event: RewardEvent) -> RewardResponse:
     profit = event.revenue - (event.clicks * 0.02)
     reward_value = round(max(-1.0, min(1.0, profit)), 6)
 
-    features = safe_call(requests.get, f"http://feature-store:8000/features/{event.campaign_id}")
+    campaign_id = quote(event.campaign_id, safe="")
+    features = safe_call(requests.get, f"http://feature-store:8000/features/{campaign_id}")
     safe_call(
         requests.post,
         "http://rl-coordinator:8000/update",


### PR DESCRIPTION
### Motivation
- Prevent partial SSRF flagged by CodeQL (`py/partial-ssrf`) by ensuring untrusted `campaign_id` cannot manipulate the outbound feature-store path.
- Enforce strict input constraints for `campaign_id` to reduce attack surface and meet repository security standards.
- Keep the upstream destination fixed while ensuring path components are safe for interpolation into URLs.

### Description
- Added `from urllib.parse import quote` and URL-encoded the `campaign_id` with `quote(event.campaign_id, safe="")` before constructing the feature-store request URL.
- Tightened `RewardEvent.campaign_id` validation to `Field(min_length=1, max_length=64, pattern=r"^[A-Za-z0-9_-]+$")` to allow only a safe allowlist and bounded length.
- Left the existing `safe_call` behavior intact and preserved the fixed upstream `rl-coordinator` destination.

### Testing
- Ran `python -m compileall services/reward-collector/src/main.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48c5377a8832cb58fdcd08afefc56)