### PR TITLE
Harden model-registry file path validation

### DIFF
--- a/services/model-registry/src/main.py
+++ b/services/model-registry/src/main.py
@@ -70,7 +70,20 @@ def _resolve_destination(base_dir: Path, file_name: str) -> Path:
     return candidate
 
 
+def _is_within_roots(path: Path, roots: tuple[Path, ...]) -> bool:
+    resolved_path = path.resolve(strict=False)
+    for root in roots:
+        resolved_root = root.resolve(strict=False)
+        if resolved_path == resolved_root or resolved_root in resolved_path.parents:
+            return True
+    return False
+
+
 def _atomic_copy(source: Path, destination: Path) -> None:
+    if not _is_within_roots(source, _allowed_source_roots()):
+        raise HTTPException(status_code=400, detail="invalid source path")
+    if not _is_within_roots(destination.parent, (BASE, SHARED)):
+        raise HTTPException(status_code=400, detail="invalid destination path")
     destination.parent.mkdir(parents=True, exist_ok=True)
     if destination.exists():
         raise HTTPException(status_code=409, detail="model version already exists")


### PR DESCRIPTION
### Motivation
- Address a CodeQL `py/path-injection` report by enforcing a trust boundary at the filesystem sink to prevent path traversal/targeted file access. 
- Ensure model file operations only use sources from configured allowed roots and only write into the official storage roots (`BASE`/`SHARED`) as a defense-in-depth measure.

### Description
- Added helper ` _is_within_roots(path, roots)` that canonicalizes a `Path` and verifies it is contained within any of the provided `roots` using `resolve(strict=False)`.
- Hardened ` _atomic_copy` to validate the `source` against `_allowed_source_roots()` and to validate `destination.parent` against `(BASE, SHARED)` and return `HTTPException(status_code=400)` on invalid paths.
- Preserved existing atomic behavior with a temp file, permission hardening (`os.chmod(temp_path, 0o600)`), and `os.replace` semantics, and preserved existing conflict handling (`409` for existing destination).

### Testing
- Ran `python -m compileall services/model-registry/src/main.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48c714e70832ca3ca0af8ef71e5ed)