### PR TITLE
ci: add enterprise-grade CodeQL configuration and analysis workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,41 @@
+name: "Enterprise Meta Full CodeQL Config"
+
+disable-default-queries: false
+
+# Language packs for enterprise-scale multi-language repositories.
+packs:
+  - github/codeql-javascript
+  - github/codeql-python
+  - github/codeql-java
+  - github/codeql-cpp
+  - github/codeql-go
+  - github/codeql-ruby
+
+queries:
+  - uses: security-extended
+  - uses: security-and-quality
+
+query-filters:
+  - exclude:
+      id: js/redundant-assignment
+  - exclude:
+      id: py/unreachable-code
+  - exclude:
+      id: cpp/memory-leak
+  - exclude:
+      id: java/unnecessary-boxing
+
+# Scope analysis to production paths and skip non-runtime content.
+paths:
+  - services
+  - workers
+  - cloudflare-devops
+
+paths-ignore:
+  - tests
+  - docs
+  - examples
+  - '**/*.md'
+
+max-paths: 2000
+threads: 4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,66 @@
+name: Enterprise CodeQL Analysis
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'release/*'
+  pull_request:
+    branches:
+      - main
+      - develop
+      - 'release/*'
+  schedule:
+    - cron: '0 2 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+          - language: java
+            build-mode: autobuild
+          - language: cpp
+            build-mode: autobuild
+          - language: go
+            build-mode: autobuild
+          - language: ruby
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
### Motivation
- Provide an enterprise-grade, multi-language CodeQL setup to run consistent security and quality scans across the monorepo and enforce governance for critical branches.
- Scope analysis to runtime code and tune performance for a large repo by limiting paths and increasing `max-paths`/`threads` for reliable, scalable scans.

### Description
- Add `./.github/codeql/codeql-config.yml` which enables multi-language packs (JS/TS, Python, Java, C++, Go, Ruby), applies `security-extended` and `security-and-quality` query suites, configures query filters, and restricts `paths` to `services`, `workers`, and `cloudflare-devops` with `paths-ignore`, `max-paths`, and `threads` tuned for large codebases.
- Add `./.github/workflows/codeql-analysis.yml` which runs on `push`, `pull_request`, and a weekly schedule, uses least-privilege `permissions`, concurrency controls (`cancel-in-progress`), and a language matrix with per-language `build-mode` and steps for `init`, conditional `autobuild`, and `analyze` to generate CodeQL results.
- Configure matrix-specific `build-mode` values to use `autobuild` for compiled languages and `none` for interpreted languages to improve analysis reliability in the monorepo.

### Testing
- Ran `git diff --check` to validate the patch formatting and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d48e3a7478832c95a20bb954f3cd08)