### PR TITLE
fix(security): harden SSRF validation and subtitle path handling

### DIFF
--- a/services/ai-video-generator/src/subtitle/subtitle.js
+++ b/services/ai-video-generator/src/subtitle/subtitle.js
@@ -1,4 +1,22 @@
 import fs from "fs"
+import path from "path"
+
+const SUBTITLE_OUTPUT_DIR = process.env.SUBTITLE_OUTPUT_DIR ?? process.cwd()
+const SAFE_FILENAME_PATTERN = /^[A-Za-z0-9._-]+$/
+
+function safeSubtitlePath(output) {
+  if (!SAFE_FILENAME_PATTERN.test(output)) {
+    throw new Error("Invalid subtitle filename")
+  }
+
+  const baseDir = path.resolve(SUBTITLE_OUTPUT_DIR)
+  const resolvedPath = path.resolve(baseDir, output)
+  if (!resolvedPath.startsWith(`${baseDir}${path.sep}`) && resolvedPath !== baseDir) {
+    throw new Error("Subtitle output path is outside the allowed directory")
+  }
+
+  return resolvedPath
+}
 
 export function generateSubtitle(text, output){
 
@@ -14,6 +32,8 @@ srt += l + "\n\n"
 
 })
 
-fs.writeFileSync(output,srt)
+const subtitlePath = safeSubtitlePath(output)
+fs.mkdirSync(path.dirname(subtitlePath), { recursive: true })
+fs.writeFileSync(subtitlePath,srt,{ flag: "wx", mode: 0o600 })
 
 }

--- a/services/network-egress/src/client.py
+++ b/services/network-egress/src/client.py
@@ -1,12 +1,15 @@
 import ipaddress
 import logging
+import socket
 import time
 from collections.abc import Mapping
+from typing import Union
 from urllib.parse import urlparse
 
 import requests
 
 logger = logging.getLogger(__name__)
+IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
 
 
 class SafeHttpClient:
@@ -29,6 +32,33 @@ class SafeHttpClient:
         self.retries = retries
         self.backoff = backoff
         self.allowed_hosts = {host.lower() for host in allowed_hosts} if allowed_hosts else None
+        self._session = requests.Session()
+        self._session.trust_env = False
+
+    @staticmethod
+    def _is_blocked_address(address: IPAddress) -> bool:
+        return (
+            address.is_private
+            or address.is_loopback
+            or address.is_link_local
+            or address.is_multicast
+            or address.is_unspecified
+            or address.is_reserved
+        )
+
+    def _resolve_host_addresses(self, hostname: str) -> set[IPAddress]:
+        resolved_addresses: set[IPAddress] = set()
+        try:
+            addrinfo = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+        except socket.gaierror as exc:
+            raise ValueError(f"url host '{hostname}' could not be resolved") from exc
+
+        for _, _, _, _, sockaddr in addrinfo:
+            resolved_addresses.add(ipaddress.ip_address(sockaddr[0]))
+
+        if not resolved_addresses:
+            raise ValueError(f"url host '{hostname}' did not resolve to an address")
+        return resolved_addresses
 
     def _validate_url(self, url: str) -> None:
         parsed = urlparse(url)
@@ -42,12 +72,16 @@ class SafeHttpClient:
             raise ValueError(f"url host '{hostname}' is not allowed")
 
         try:
-            host_ip = ipaddress.ip_address(hostname)
+            literal_ip = ipaddress.ip_address(hostname)
         except ValueError:
-            # Non-IP hostnames are allowed and resolved by network policy.
+            for resolved_ip in self._resolve_host_addresses(hostname):
+                if self._is_blocked_address(resolved_ip):
+                    raise ValueError(
+                        f"url host '{hostname}' resolved to a blocked address: {resolved_ip}"
+                    )
             return
 
-        if host_ip.is_loopback or host_ip.is_private or host_ip.is_link_local:
+        if self._is_blocked_address(literal_ip):
             raise ValueError("private or loopback host targets are not allowed")
 
     def post(
@@ -62,7 +96,7 @@ class SafeHttpClient:
 
         for attempt in range(1, self.retries + 1):
             try:
-                response = requests.post(url, json=json, headers=headers, timeout=self.timeout)
+                response = self._session.post(url, json=json, headers=headers, timeout=self.timeout)
                 if response.status_code < 500:
                     return response
                 last_response = response


### PR DESCRIPTION
### Motivation

- Close a partial SSRF gap in the shared egress client to prevent hostnames resolving to internal/private addresses and proxy-based bypasses. 
- Prevent path traversal and arbitrary overwrite when generating subtitle files from user-provided output names. 
- Enforce safer defaults for outbound HTTP and file writes to reduce attack surface for CodeQL-flagged issues.

### Description

- Strengthened `SafeHttpClient` in `services/network-egress/src/client.py` by adding a dedicated `requests.Session` with `trust_env = False` and switching outbound calls to use the session. 
- Added DNS resolution and address checks in `SafeHttpClient` so hostnames are resolved and any resolved IP that is private, loopback, link-local, multicast, unspecified, or reserved is rejected. 
- Added `_is_blocked_address` helper and `_resolve_host_addresses` to raise on unresolved or unsafe hosts and retained strict `http/https` and allowlist checks. 
- Hardened subtitle output handling in `services/ai-video-generator/src/subtitle/subtitle.js` by adding `safeSubtitlePath`, a filename regex (`^[A-Za-z0-9._-]+$`), resolving/containment checks under a base output dir (`SUBTITLE_OUTPUT_DIR`), creating parent directories safely, and writing with exclusive-create mode (`flag: "wx"`) and restrictive permissions (`0o600`).

### Testing

- Ran `python -m compileall services/network-egress/src/client.py` and it completed successfully. 
- Ran `node --check services/ai-video-generator/src/subtitle/subtitle.js` and it completed successfully. 
- No automated test failures were observed from the syntax/compile checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4900322b8832cbea95a40afb48191)