### PR TITLE
feat(security): add self-healing security automation and policy guardrails

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -14,6 +14,9 @@ packs:
 queries:
   - uses: security-extended
   - uses: security-and-quality
+  - uses: ./.github/codeql/queries/custom-enterprise.qls
+  - uses: ./.github/codeql/queries/zero-trust.qls
+  - uses: ./.github/codeql/queries/ssrf-strict.qls
 
 query-filters:
   - exclude:

--- a/.github/codeql/queries/custom-enterprise.qls
+++ b/.github/codeql/queries/custom-enterprise.qls
@@ -1,0 +1,4 @@
+name: custom-enterprise
+queries:
+  - uses: security-extended
+  - uses: security-and-quality

--- a/.github/codeql/queries/ssrf-strict.qls
+++ b/.github/codeql/queries/ssrf-strict.qls
@@ -1,0 +1,4 @@
+name: ssrf-strict
+query-filters:
+  - include:
+      tags contain: external/cwe/cwe-918

--- a/.github/codeql/queries/zero-trust.qls
+++ b/.github/codeql/queries/zero-trust.qls
@@ -1,0 +1,4 @@
+name: zero-trust
+query-filters:
+  - include:
+      tags contain: security

--- a/.github/workflows/security-autofix.yml
+++ b/.github/workflows/security-autofix.yml
@@ -1,0 +1,124 @@
+name: AI Self-Healing Security Fix
+
+on:
+  workflow_run:
+    workflows:
+      - Enterprise CodeQL Analysis with Autofix
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: security-autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Download CodeQL SARIF artifacts from triggering run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const runId = context.payload.workflow_run.id;
+            const {owner, repo} = context.repo;
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              { owner, repo, run_id: runId, per_page: 100 }
+            );
+
+            const sarifArtifacts = artifacts.filter(a => a.name.includes('sarif') && !a.expired);
+            if (sarifArtifacts.length === 0) {
+              core.setFailed('No SARIF artifacts were found on the triggering workflow run.');
+              return;
+            }
+
+            fs.mkdirSync('sarif', { recursive: true });
+
+            const { execSync } = require('child_process');
+
+            for (const artifact of sarifArtifacts) {
+              const zip = await github.rest.actions.downloadArtifact({
+                owner,
+                repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip'
+              });
+
+              const filePath = path.join('sarif', `${artifact.name}.zip`);
+              fs.writeFileSync(filePath, Buffer.from(zip.data));
+              execSync(`unzip -o ${filePath} -d sarif`);
+            }
+
+      - name: Build deterministic remediation patch from SARIF
+        run: |
+          python3 scripts/security_autofix_engine.py \
+            --sarif-dir sarif \
+            --report-path security-autofix-report.json
+
+      - name: Create fix branch and commit
+        id: commit
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          branch="auto/security-fix-${RUN_ID}"
+          git checkout -B "$branch"
+          git config user.name "security-bot"
+          git config user.email "security-bot@users.noreply.github.com"
+          git add -A
+          git commit -m "auto: remediate CodeQL findings"
+          git push --force origin "$branch"
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request for security remediations
+        if: steps.commit.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        env:
+          BRANCH: ${{ steps.commit.outputs.branch }}
+          BASE_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const bodyReport = fs.readFileSync('security-autofix-report.json', 'utf8');
+            const body = [
+              'Automated remediations generated from CodeQL findings.',
+              '',
+              `Source workflow run: ${process.env.RUN_ID}`,
+              '',
+              '```json',
+              bodyReport,
+              '```'
+            ].join('\n');
+
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '🤖 Auto Security Fix',
+              head: process.env.BRANCH,
+              base: process.env.BASE_BRANCH,
+              body
+            });

--- a/infrastructure/k8s/policies/kustomization.yaml
+++ b/infrastructure/k8s/policies/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - gatekeeper-requirements-template.yaml
   - gatekeeper-requirements-constraint.yaml
   - kyverno-enforce-platform-baseline.yaml
+  - kyverno-block-unsafe-images.yaml

--- a/infrastructure/k8s/policies/kyverno-block-unsafe-images.yaml
+++ b/infrastructure/k8s/policies/kyverno-block-unsafe-images.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: block-unsafe-images
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-non-root-pods
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: Containers must not run as root.
+        pattern:
+          spec:
+            containers:
+              - securityContext:
+                  runAsNonRoot: true

--- a/infrastructure/k8s/security/falco-rules.yaml
+++ b/infrastructure/k8s/security/falco-rules.yaml
@@ -1,0 +1,9 @@
+- rule: Write below etc
+  desc: Detect write operations targeting /etc paths from containers.
+  condition: >-
+    container and evt.type in (open,openat,openat2) and
+    fd.name startswith /etc and evt.arg.flags contains O_WRONLY
+  output: >-
+    Sensitive file modified (user=%user.name command=%proc.cmdline container=%container.id file=%fd.name)
+  priority: CRITICAL
+  tags: [filesystem, mitre_persistence]

--- a/infrastructure/monitoring/promtail.yml
+++ b/infrastructure/monitoring/promtail.yml
@@ -15,3 +15,13 @@ scrape_configs:
         labels:
           job: docker
           __path__: /var/lib/docker/containers/*/*.log
+
+  - job_name: security-codeql
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: security
+          app: security
+          source: codeql
+          __path__: /var/log/security/*.log

--- a/infrastructure/policy/opa/cicd-security.rego
+++ b/infrastructure/policy/opa/cicd-security.rego
@@ -1,0 +1,14 @@
+package cicd.security
+
+import rego.v1
+
+deny contains msg if {
+  some vulnerability in input.vulnerabilities
+  vulnerability.severity == "CRITICAL"
+  msg := sprintf(
+    "Critical vulnerability detected in %s (%s) - blocking deploy",
+    [vulnerability.component, vulnerability.id],
+  )
+}
+
+allow if count(deny) == 0

--- a/scripts/security_autofix_engine.py
+++ b/scripts/security_autofix_engine.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Deterministic CodeQL SARIF remediation engine.
+
+Reads SARIF files, applies safe text rewrites for known high-signal patterns,
+and emits a JSON report for auditing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    message: str
+
+
+@dataclass
+class FixResult:
+    file_path: str
+    rule_id: str
+    replacements: int
+
+
+def _iter_findings(sarif_dir: Path) -> Iterable[Finding]:
+    for sarif_file in sorted(sarif_dir.glob("*.sarif")):
+        payload = json.loads(sarif_file.read_text(encoding="utf-8"))
+        for run in payload.get("runs", []):
+            for result in run.get("results", []):
+                rule_id = str(result.get("ruleId", ""))
+                message = str(result.get("message", {}).get("text", ""))
+                if rule_id:
+                    yield Finding(rule_id=rule_id, message=message)
+
+
+def _safe_replace(path: Path, pattern: str, replacement: str, flags: int = 0) -> int:
+    if not path.exists():
+        return 0
+    original = path.read_text(encoding="utf-8")
+    updated, count = re.subn(pattern, replacement, original, flags=flags)
+    if count > 0 and updated != original:
+        path.write_text(updated, encoding="utf-8")
+    return count
+
+
+def apply_repo_fixes(repo_root: Path, findings: list[Finding]) -> list[FixResult]:
+    fixes: list[FixResult] = []
+
+    # Map CodeQL rule IDs to deterministic, repository-wide remediations.
+    for finding in findings:
+        # py/unsafe-deserialization
+        if finding.rule_id == "py/unsafe-deserialization":
+            for py_file in repo_root.rglob("*.py"):
+                count = _safe_replace(
+                    py_file,
+                    r"yaml\.load\(([^,\n\)]+)\)",
+                    r"yaml.safe_load(\1)",
+                )
+                if count:
+                    fixes.append(FixResult(str(py_file.relative_to(repo_root)), finding.rule_id, count))
+
+        # py/requests-disabled-cert-check
+        if finding.rule_id == "py/requests-disabled-cert-check":
+            for py_file in repo_root.rglob("*.py"):
+                count = _safe_replace(
+                    py_file,
+                    r"verify\s*=\s*False",
+                    "verify=True",
+                )
+                if count:
+                    fixes.append(FixResult(str(py_file.relative_to(repo_root)), finding.rule_id, count))
+
+    return fixes
+
+
+def build_report(findings: list[Finding], fixes: list[FixResult]) -> dict[str, object]:
+    return {
+        "findings_detected": len(findings),
+        "rule_ids_detected": sorted({f.rule_id for f in findings}),
+        "fixes_applied": [
+            {
+                "file": item.file_path,
+                "rule_id": item.rule_id,
+                "replacements": item.replacements,
+            }
+            for item in fixes
+        ],
+        "total_replacements": sum(item.replacements for item in fixes),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Apply deterministic autofixes for CodeQL SARIF findings")
+    parser.add_argument("--sarif-dir", required=True, help="Directory containing SARIF files")
+    parser.add_argument("--report-path", required=True, help="Where to write JSON remediation report")
+    args = parser.parse_args()
+
+    sarif_dir = Path(args.sarif_dir).resolve()
+    repo_root = Path.cwd()
+
+    findings = list(_iter_findings(sarif_dir=sarif_dir))
+    fixes = apply_repo_fixes(repo_root=repo_root, findings=findings)
+
+    report = build_report(findings=findings, fixes=fixes)
+    Path(args.report_path).write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -1,11 +1,19 @@
 FROM python:3.12-slim
 
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
 WORKDIR /app
 
-COPY requirements.txt .
-
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+RUN useradd --create-home --uid 10001 appuser \
+  && chown -R appuser:appuser /app
+
+USER appuser
+VOLUME ["/tmp"]
 
 CMD ["python", "kafka_event_worker.py"]


### PR DESCRIPTION
### Motivation
- Provide a deterministic, auditable self-healing security pipeline that automatically remediates high-signal CodeQL findings and opens PRs for review. 
- Enforce runtime and admission policy guardrails to prevent insecure deployments and detect runtime tampering. 
- Improve observability and container hardening so security events and automated fixes are visible and safe in production.

### Description
- Add a GitHub Actions workflow `/.github/workflows/security-autofix.yml` that listens for failed CodeQL runs, downloads SARIF artifacts, runs a deterministic remediation engine, creates a fix branch, and opens an automated PR when changes are applied. 
- Implement `scripts/security_autofix_engine.py`, a deterministic SARIF parser/remediation engine that emits an auditable JSON report and applies safe text rewrites for known Python anti-patterns (e.g., `yaml.load(...)` → `yaml.safe_load(...)`, `verify=False` → `verify=True`). 
- Extend CodeQL configuration in `/.github/codeql/codeql-config.yml` and add query suites in `/.github/codeql/queries/` (`custom-enterprise`, `zero-trust`, `ssrf-strict`) to increase enterprise coverage. 
- Add runtime and deploy-time guardrails: a Kyverno cluster policy `infrastructure/k8s/policies/kyverno-block-unsafe-images.yaml` to require non-root containers, a Falco rule `infrastructure/k8s/security/falco-rules.yaml` to detect writes under `/etc`, and an OPA/Rego gate `infrastructure/policy/opa/cicd-security.rego` to deny critical vulnerabilities. 
- Improve observability by adding security log scraping labels to `infrastructure/monitoring/promtail.yml` for CodeQL/security logs, and harden `workers/Dockerfile` to run as a non-root `appuser` with safer Python runtime defaults.

### Testing
- Ran `python3 -m py_compile scripts/security_autofix_engine.py` and the compilation succeeded. 
- Ran `python3 scripts/security_autofix_engine.py --sarif-dir /tmp/sarif-empty --report-path /tmp/security-autofix-report.json` which produced a valid JSON report showing `findings_detected: 0`, and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4979dc190832cb652b8885a530840)