### PR TITLE
fix: harden SSRF and path traversal protections in product-discovery & ai-video-generator

### DIFF
--- a/services/ai-video-generator/src/tts/voice.js
+++ b/services/ai-video-generator/src/tts/voice.js
@@ -5,8 +5,22 @@ import { constants as fsConstants } from "fs"
 
 const OUTPUT_BASE_DIR = process.env.TTS_OUTPUT_DIR ?? "/tmp/zttato-tts"
 const MAX_AUDIO_BYTES = Number.parseInt(process.env.TTS_MAX_AUDIO_BYTES ?? "5242880", 10)
+const SAFE_FILENAME_PATTERN = /^[A-Za-z0-9._-]+$/
+
+function validateFilename(output) {
+  if (typeof output !== "string" || output.length === 0) {
+    throw new Error("Audio output filename is required")
+  }
+  if (!SAFE_FILENAME_PATTERN.test(output)) {
+    throw new Error("Audio output filename contains disallowed characters")
+  }
+  if (path.basename(output) !== output) {
+    throw new Error("Audio output filename must not include path segments")
+  }
+}
 
 function resolveOutputPath(output) {
+  validateFilename(output)
   const normalized = path.resolve(OUTPUT_BASE_DIR, output)
   const baseDir = path.resolve(OUTPUT_BASE_DIR)
   if (!normalized.startsWith(`${baseDir}${path.sep}`) && normalized !== baseDir) {

--- a/services/product-discovery/src/main.py
+++ b/services/product-discovery/src/main.py
@@ -1,11 +1,14 @@
 import json
+import ipaddress
 import logging
 import os
 import random
+import socket
 import sys
 import time
 from contextvars import ContextVar
 from typing import Any
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import requests
@@ -17,6 +20,11 @@ MARKET_CRAWLER_URL = os.getenv("MARKET_CRAWLER_URL", "http://market-crawler:8000
 HTTP_TIMEOUT = float(os.getenv("HTTP_TIMEOUT", "5"))
 HTTP_RETRIES = int(os.getenv("HTTP_RETRIES", "3"))
 HTTP_BACKOFF = float(os.getenv("HTTP_BACKOFF", "0.5"))
+ALLOWED_MARKET_CRAWLER_HOSTS = {
+    host.strip().lower()
+    for host in os.getenv("MARKET_CRAWLER_ALLOWED_HOSTS", "market-crawler").split(",")
+    if host.strip()
+}
 REQUEST_ID_CTX: ContextVar[str] = ContextVar("request_id", default="-")
 
 
@@ -48,11 +56,50 @@ log = logging.getLogger(SERVICE_NAME)
 app = FastAPI(title="Product Discovery")
 
 
+def _is_blocked_ip(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )
+
+
+def _validate_market_crawler_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise RuntimeError("MARKET_CRAWLER_URL must use http/https")
+    if not parsed.hostname:
+        raise RuntimeError("MARKET_CRAWLER_URL must include a hostname")
+
+    hostname = parsed.hostname.lower()
+    if hostname not in ALLOWED_MARKET_CRAWLER_HOSTS:
+        raise RuntimeError(f"MARKET_CRAWLER_URL host '{hostname}' is not allowlisted")
+
+    try:
+        resolved_records = socket.getaddrinfo(hostname, parsed.port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise RuntimeError(f"MARKET_CRAWLER_URL host '{hostname}' could not be resolved") from exc
+
+    if not resolved_records:
+        raise RuntimeError(f"MARKET_CRAWLER_URL host '{hostname}' did not resolve")
+
+    for _, _, _, _, sockaddr in resolved_records:
+        if _is_blocked_ip(ipaddress.ip_address(sockaddr[0])) and hostname not in {"localhost", "market-crawler"}:
+            raise RuntimeError(
+                f"MARKET_CRAWLER_URL host '{hostname}' resolved to a blocked address ({sockaddr[0]})"
+            )
+
+    return url
+
+
 def fetch_products() -> list[dict[str, Any]]:
     last_error: str | None = None
     for attempt in range(1, HTTP_RETRIES + 1):
         try:
-            response = requests.get(MARKET_CRAWLER_URL, timeout=HTTP_TIMEOUT)
+            response = requests.get(MARKET_CRAWLER_URL, timeout=HTTP_TIMEOUT, allow_redirects=False)
             response.raise_for_status()
             payload = response.json()
             if not isinstance(payload, list):
@@ -149,3 +196,6 @@ def discover() -> dict[str, Any]:
         extra={"event": {"input_count": len(products), "selected_count": len(top_products)}},
     )
     return {"ok": True, "count": len(top_products), "items": top_products}
+
+
+MARKET_CRAWLER_URL = _validate_market_crawler_url(MARKET_CRAWLER_URL)


### PR DESCRIPTION
### Motivation
- Reduce SSRF exposure from configurable upstream targets by validating outbound URLs and preventing requests to private/loopback addresses.
- Eliminate path traversal and unsafe file-write risks in TTS output handling by enforcing strict filename validation and preserving exclusive-create semantics.

### Description
- Added startup-time validation for `MARKET_CRAWLER_URL` in `services/product-discovery/src/main.py` that enforces `http(s)` schemes, requires a hostname, checks against an allowlist via `MARKET_CRAWLER_ALLOWED_HOSTS`, resolves DNS, and rejects blocked/private addresses.
- Disabled automatic redirects on outbound market-crawler fetches by adding `allow_redirects=False` to requests in `fetch_products`.
- Introduced `_is_blocked_ip` helper and DNS resolution checks to ensure resolved addresses are not private/loopback/link-local/multicast/reserved/unspecified.
- Hardened `services/ai-video-generator/src/tts/voice.js` by adding strict `SAFE_FILENAME_PATTERN` validation, forbidding path segments via `path.basename` checks, and validating filenames before resolving paths while preserving exclusive-create file writes (`O_EXCL` / `wx`).

### Testing
- Ran `python -m py_compile services/product-discovery/src/main.py` and it completed successfully.
- Ran `node --check services/ai-video-generator/src/tts/voice.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ad0c2eec832cbbe4d9d11db85385)