### PR TITLE
chore: rename zttato-platform references to zlttbots

### DIFF
--- a/generate-zttato.sh
+++ b/generate-zttato.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PROJECT="zTTato-platform"
+PROJECT="zlttbots"
 
 echo "Creating project structure..."
 

--- a/infrastructure/scripts/generate-devops-pack.sh
+++ b/infrastructure/scripts/generate-devops-pack.sh
@@ -1,7 +1,7 @@
 # path: scripts/generate-devops-pack.sh
 #!/usr/bin/env bash
 #
-# Generator: DevOps script pack for zTTato-platform
+# Generator: DevOps script pack for zlttbots
 # Creates production helper scripts under infrastructure/scripts
 #
 # Usage:


### PR DESCRIPTION
### Motivation
- Standardize the project identifier and documentation strings by replacing remaining `zTTato-platform`/`zttato-platform` occurrences with `zlttbots` to reflect the new project name.

### Description
- Updated `generate-zttato.sh` to set `PROJECT="zlttbots"` and changed the generator header comment in `infrastructure/scripts/generate-devops-pack.sh` from `zTTato-platform` to `zlttbots`.

### Testing
- Ran a case-insensitive repository search `rg -ni "zttato-platform"` and confirmed no matches remain, and reviewed the modified files to verify the substitutions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4b3ad5954832ca85f87fbe9411287)