### PR TITLE
Fix startup scripts: installer path, export `log`, and robust Postgres readiness check

### DIFF
--- a/scripts/start-zlttbots-platform.sh
+++ b/scripts/start-zlttbots-platform.sh
@@ -63,7 +63,7 @@ compose_up_with_recovery(){
 }
 
 ensure_env(){
-  [[ -f .env ]] || bash "$ROOT_DIR/scripts/install-zlttbots.sh"
+  [[ -f .env ]] || bash "$ROOT_DIR/scripts/install-zlttbots-platform.sh"
 }
 
 print_usage(){

--- a/scripts/start-zlttbots.sh
+++ b/scripts/start-zlttbots.sh
@@ -59,7 +59,8 @@ log "Waiting Postgres"
 
 for i in {1..30}; do
 
-if docker exec zlttbots-postgres-1 pg_isready -U zlttbots >/dev/null 2>&1; then
+POSTGRES_CONTAINER="$($COMPOSE -f "$COMPOSE_FILE" ps -q postgres 2>/dev/null || true)"
+if [ -n "$POSTGRES_CONTAINER" ] && docker exec "$POSTGRES_CONTAINER" pg_isready -U zlttbots >/dev/null 2>&1; then
 log "Postgres ready"
 break
 fi
@@ -110,6 +111,7 @@ fi
 }
 
 export -f install_node_service
+export -f log
 
 find "$NODE_SERVICES_DIR" -maxdepth 1 -type d \
 | tail -n +2 \

--- a/scripts/zlttbots-manager.sh
+++ b/scripts/zlttbots-manager.sh
@@ -49,7 +49,7 @@ USAGE
 
 case "${1:-}" in
   install)
-    bash "$ROOT_DIR/scripts/install-zlttbots.sh"
+    bash "$ROOT_DIR/scripts/install-zlttbots-platform.sh"
     ;;
   start)
     bash "$ROOT_DIR/scripts/start-zlttbots.sh"


### PR DESCRIPTION
### Motivation
- Running the manager/start scripts failed with `No such file or directory` because the code referenced a non-existent installer script. 
- Parallel Node service installs printed `environment: line 4: log: command not found` because the `log` function was not available to child shells. 
- Postgres readiness could be falsely reported due to relying on a hardcoded container name that may differ under compose. 

### Description
- Updated `scripts/zlttbots-manager.sh` to call the existing installer `install-zlttbots-platform.sh` for the `install` command. 
- Updated `scripts/start-zlttbots-platform.sh` to bootstrap `.env` using `install-zlttbots-platform.sh`. 
- In `scripts/start-zlttbots.sh` replaced the hardcoded Postgres container check with resolving the container ID via `docker compose -f "$COMPOSE_FILE" ps -q postgres` and using that ID for `pg_isready`. 
- Exported the `log` function in `scripts/start-zlttbots.sh` so parallel `bash -c` workers can call it during Node dependency installation. 

### Testing
- Ran a shell syntax check with `bash -n scripts/start-zlttbots.sh scripts/zlttbots-manager.sh scripts/start-zlttbots-platform.sh` which reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c5e26b08832c90e891093db3e2b3)