### PR TITLE
Add rebuild automation script and pin Compose network name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -919,6 +919,7 @@ services:
 
 networks:
   zlttbots-net:
+    name: zlttbots-net
     driver: bridge
 
 volumes:

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "================================="
+echo "[REBUILD] Clean + Reinstall Workflow for zlttbots"
+echo "================================="
+
+# -------------------------------
+# Phase 1: Clean
+# -------------------------------
+echo ">>> Phase 1: Cleaning environment..."
+
+# Stop and remove all containers safely
+if [ -n "$(docker ps -q)" ]; then
+  docker stop $(docker ps -q)
+fi
+
+if [ -n "$(docker ps -aq)" ]; then
+  docker rm -f $(docker ps -aq)
+fi
+
+# Prune networks, volumes, images
+docker network prune -f
+docker volume prune -f
+docker image prune -af
+
+# Remove old auto-generated network if present
+if docker network ls --format "{{.Name}}" | grep -q "^zlttbots_zlttbots-net$"; then
+  echo ">>> Removing old network zlttbots_zlttbots-net"
+  docker network rm zlttbots_zlttbots-net || true
+fi
+
+# Ensure correct network exists
+if ! docker network ls --format "{{.Name}}" | grep -q "^zlttbots-net$"; then
+  echo ">>> Creating network zlttbots-net"
+  docker network create zlttbots-net
+fi
+
+# Clear Node caches for all services
+for svc in services/*; do
+  if [ -f "$svc/package.json" ]; then
+    echo " -> Cleaning $svc"
+    (
+      cd "$svc"
+      rm -rf node_modules || true
+      find . -name "node_modules" -type d -prune -exec rm -rf {} + || true
+      npm cache clean --force || true
+    )
+  fi
+done
+
+# Extra: wipe npm cache directory if ENOTEMPTY occurs
+rm -rf ~/.npm/_cacache || true
+
+# Reset local data directories if present
+rm -rf ./data/postgres/* || true
+rm -rf ./data/redis/* || true
+
+echo ">>> Phase 1 complete"
+echo "================================="
+
+# -------------------------------
+# Phase 2: Reinstall
+# -------------------------------
+echo ">>> Phase 2: Reinstalling zlttbots platform..."
+
+bash scripts/start-zlttbots.sh --core
+bash scripts/zlttbots-manager.sh install
+bash scripts/zlttbots-manager.sh status
+
+echo ">>> Phase 2 complete"
+echo "================================="
+
+# -------------------------------
+# Phase 3: Auto-Restart Loop
+# -------------------------------
+echo ">>> Phase 3: Checking for Restarting containers..."
+for c in $(docker ps --filter "status=restarting" --format "{{.Names}}"); do
+  echo " -> Attempting restart for $c"
+  for i in 1 2 3; do
+    docker restart "$c" || true
+    sleep 5
+    status=$(docker inspect --format='{{.State.Status}}' "$c")
+    if [ "$status" = "running" ]; then
+      echo "    $c recovered after $i attempt(s)"
+      break
+    fi
+  done
+done
+
+# -------------------------------
+# Phase 4: Status Summary
+# -------------------------------
+echo ">>> Phase 4: Docker service summary"
+echo "================================="
+
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" \
+  | grep -E "zlttbots|zttato-" \
+  | awk 'NR==1 {print; next}
+         /healthy/ {print "\033[32m" $0 "\033[0m"}
+         /unhealthy/ {print "\033[31m" $0 "\033[0m"}
+         /Restarting/ {print "\033[33m" $0 "\033[0m"}
+         !/healthy|unhealthy|Restarting/ {print $0}'
+
+echo "================================="
+echo "[REBUILD] Workflow complete"
+echo "================================="


### PR DESCRIPTION
### Motivation
- Ensure deterministic network naming so services attach to `zlttbots-net` instead of an auto‑prefixed `zlttbots_zlttbots-net` to avoid runtime/network drift. 
- Provide a single, hardened end‑to‑end rebuild workflow that fully cleans, reinstalls, and recovers common container failures. 
- Improve operator diagnostics with an auto‑restart recovery loop and color‑coded service health summary for quick status checks.

### Description
- Add executable `scripts/rebuild.sh` implementing a 4‑phase workflow: cleanup (stop/remove containers, prune resources, wipe caches/data, normalize network), reinstall (invoke existing start/install scripts), auto‑restart loop (retry containers in `restarting` state up to 3 times), and a color‑coded Docker service summary. 
- Normalize Docker network handling by removing any legacy `zlttbots_zlttbots-net` and ensuring `zlttbots-net` exists before bringing services up. 
- Patch `docker-compose.yml` to explicitly pin the network name under `networks.zlttbots-net.name: zlttbots-net` so Compose uses the exact network name instead of prefixing with the project name.

### Testing
- Executed a shell syntax check with `bash -n scripts/rebuild.sh`, which succeeded. 
- Attempted `docker compose -f docker-compose.yml config` to validate the compose file, but the Docker CLI was not available in the execution environment (`docker: command not found`), so runtime compose validation could not be performed. 
- No other automated tests were run as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d2f55fe4832c86eed16a810132b1)