### PR TITLE
Improve service surface manifest validation diagnostics

### DIFF
--- a/scripts/feature_impact_dive.py
+++ b/scripts/feature_impact_dive.py
@@ -9,6 +9,7 @@ import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable
+from json import JSONDecodeError
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_OUTPUT = REPO_ROOT / "docs" / "development" / "feature-impact-dive-2026-04-06.md"
@@ -299,9 +300,52 @@ def validate_manifest(report: ImpactReport, manifest_path: Path) -> list[str]:
         return [f"manifest not found: {manifest_path}"]
 
     expected = json.loads(json.dumps(manifest_to_dict(build_surface_manifest(report))))
-    actual = json.loads(manifest_path.read_text(encoding="utf-8"))
+    try:
+        actual = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except JSONDecodeError as exc:
+        return [f"manifest JSON decode error at line {exc.lineno}, column {exc.colno}: {exc.msg}"]
 
     errors: list[str] = []
+
+    services = actual.get("services")
+    if not isinstance(services, list):
+        return ["manifest shape error: services must be an array"]
+
+    for index, service in enumerate(services):
+        if not isinstance(service, dict):
+            errors.append(f"manifest shape error: services[{index}] must be an object")
+            continue
+
+        service_name = service.get("name", f"index-{index}")
+        write_policies = service.get("write_policies")
+        endpoints = service.get("endpoints")
+        if not isinstance(endpoints, list):
+            errors.append(f"manifest shape error: service {service_name} endpoints must be an array")
+            continue
+        if not isinstance(write_policies, list):
+            errors.append(f"manifest shape error: service {service_name} write_policies must be an array")
+            continue
+
+        for policy_index, policy in enumerate(write_policies):
+            if not isinstance(policy, dict):
+                errors.append(
+                    f"manifest shape error: service {service_name} write_policies[{policy_index}] must be an object"
+                )
+                continue
+            for field in ("auth", "tenant", "schema", "endpoint"):
+                if not isinstance(policy.get(field), str):
+                    errors.append(
+                        f"manifest shape error: service {service_name} write_policies[{policy_index}].{field} must be a string"
+                    )
+            policy_endpoint = policy.get("endpoint")
+            if isinstance(policy_endpoint, str) and policy_endpoint not in endpoints:
+                errors.append(
+                    f"manifest integrity error: service {service_name} policy endpoint not listed in endpoints ({policy_endpoint})"
+                )
+
+    if errors:
+        return errors
+
     if expected != actual:
         errors.append("service surface manifest drift detected; run scripts/feature_impact_dive.py --write-manifest")
 

--- a/tests/test_feature_impact_dive.py
+++ b/tests/test_feature_impact_dive.py
@@ -122,6 +122,39 @@ def test_validate_manifest_detects_drift(tmp_path: Path) -> None:
     assert errors
 
 
+def test_validate_manifest_reports_json_decode_errors(tmp_path: Path) -> None:
+    report = ImpactReport(
+        compose_services=("platform",),
+        app_features=(AppFeature(name="platform", endpoints=("GET /healthz",)),),
+        runtime_services=(),
+        documented_features=(),
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text('{"services": [}', encoding="utf-8")
+
+    errors = validate_manifest(report, manifest_path)
+    assert "manifest JSON decode error" in errors[0]
+
+
+def test_validate_manifest_rejects_non_string_policy_fields(tmp_path: Path) -> None:
+    report = ImpactReport(
+        compose_services=("platform",),
+        app_features=(AppFeature(name="platform", endpoints=("POST /deploy",)),),
+        runtime_services=(),
+        documented_features=(),
+    )
+    manifest = build_surface_manifest(report)
+    manifest_path = tmp_path / "manifest.json"
+    write_manifest(manifest, manifest_path)
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["services"][0]["write_policies"][0]["schema"] = True
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    errors = validate_manifest(report, manifest_path)
+    assert any(".schema must be a string" in error for error in errors)
+
+
 def test_format_markdown_contains_counts() -> None:
     report = ImpactReport(
         compose_services=("api",),


### PR DESCRIPTION
### Motivation
- CI was failing with an opaque exit code when a patched `service-surface-manifest.json` was malformed or contained unexpected types, which made debugging difficult. 
- The manifest validator needed actionable parse errors and basic shape/integrity checks to surface the real problem (malformed JSON, wrong field types, or policy endpoints not listed). 

### Description
- Add JSON parse error handling in `validate_manifest` to return a clear `manifest JSON decode error` with line/column context when `json.loads` fails. 
- Add structural checks to ensure top-level `services` is an array and each `service` is an object with `endpoints` and `write_policies` arrays. 
- Enforce that each `write_policies` entry is an object and that `auth`, `tenant`, `schema`, and `endpoint` are strings, and validate that policy `endpoint` values appear in the service `endpoints` list. 
- Preserve the existing drift-detection comparison (`expected != actual`) after shape/integrity validation passes, and add tests to cover the new checks. 

### Testing
- Added unit tests in `tests/test_feature_impact_dive.py` covering malformed JSON and non-string `write_policies` fields and ran `pytest -q tests/test_feature_impact_dive.py`. 
- All tests passed: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d466cd88832cb80e2abff39f16f8)