### PR TITLE
fix(ci): resolve setup-node cache path for frontend workflow

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-          cache-dependency-path: apps/frontend/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
### Motivation
- The Next.js CI job referenced `apps/frontend/package-lock.json` for `actions/setup-node` cache hashing but that file does not exist in the repository root, causing `Some specified paths were not resolved, unable to cache dependencies`; the cache must point to an existing lockfile so the setup action can compute keys.

### Description
- Update `.github/workflows/nextjs.yml` to change `cache-dependency-path` from `apps/frontend/package-lock.json` to `package-lock.json`, preserving the job `working-directory: apps/frontend` while making the cache lookup correct.

### Testing
- Verified the modified workflow YAML parses with `python -c "import yaml; yaml.safe_load(open('.github/workflows/nextjs.yml'))"` and confirmed dependency installation succeeds with `cd apps/frontend && npm ci`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4d643b524832ca17cd7f4ef1caf1f)