### PR TITLE
ci: migrate Node workflows to Node.js 24 and fix npm cache path

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -3,6 +3,9 @@ name: Codex Automation
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:
@@ -20,7 +23,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install Codex
         run: npm install -g @openai/codex

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -16,6 +16,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci-security:
     name: Node ${{ matrix.node-version }}
@@ -23,7 +26,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [24]
 
     defaults:
       run:
@@ -38,7 +41,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: apps/frontend/package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
### Motivation

- Prevent CI failures and Node deprecation warnings by upgrading Node-based workflows to Node.js 24 to align with upcoming GitHub runner changes.
- Ensure dependency caching works correctly for the frontend by pointing the cache key at the actual lockfile location.
- Opt-in immediately to GitHub's Node 24 JavaScript action runtime for deterministic CI behavior.

### Description

- Updated `.github/workflows/nextjs.yml` to set `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`, change the Node matrix to `node-version: [24]`, and correct `cache-dependency-path` to `apps/frontend/package-lock.json`.
- Updated `.github/workflows/codex.yml` to set `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` and change `actions/setup-node` `node-version` from `20` to `24`.
- The changes are limited to CI workflow configuration and do not modify application source code.

### Testing

- Ran `git diff --check` to validate there are no whitespace or index errors, which passed.
- Executed a Python assertion script that verified `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is present in both modified workflows and that the Next.js cache dependency path is `apps/frontend/package-lock.json`, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5928bdf1483219288359113c822b8)