### PR TITLE
fix(model-service): resolve pydantic dependency conflict with ray[serve] and feast

### DIFF
--- a/services/model-service/requirements.txt
+++ b/services/model-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.116.1
 uvicorn==0.34.0
-pydantic==2.10.6
+pydantic==2.12.5
 numpy==2.0.2
 torch==2.8.0
 confluent-kafka==2.5.0
@@ -9,5 +9,5 @@ msgpack==1.0.8
 prometheus-client==0.23.1
 onnxruntime==1.18.0
 ray[serve]==2.54.0
-feast==0.54.0
+feast==0.61.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
### Motivation
- Fix a pip resolver failure during the model-service image build caused by conflicting `pydantic` pins (Feast required `2.10.6` while `ray[serve]==2.54.0` excludes `2.10.*`).

### Description
- Bumped `services/model-service/requirements.txt` to `pydantic==2.12.5` and `feast==0.61.0` to align dependency constraints and allow the pip resolver to find a compatible set.

### Testing
- Ran a dependency resolution dry-run with `pip install --dry-run --no-cache-dir --prefer-binary -r services/model-service/requirements.txt`, which completed successfully with no `ResolutionImpossible` error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59699d9708321a2abea4141f9e417)