### PR TITLE
Add singularity and security-api service entries to service-surface-manifest.json

### DIFF
--- a/config/service-surface-manifest.json
+++ b/config/service-surface-manifest.json
@@ -853,6 +853,17 @@
       "runtime_language": "node",
       "write_policies": []
     },
+ {
+ "app": false,
+ "compose": false,
+ "docs": false,
+ "docs_path": null,
+ "endpoints": [],
+ "name": "singularity",
+ "runtime": true,
+ "runtime_language": "python",
+ "write_policies": []
+ },
     {
       "app": false,
       "compose": true,
@@ -1232,6 +1243,28 @@
         }
       ]
     },
+ {
+ "app": false,
+ "compose": false,
+ "docs": false,
+ "docs_path": null,
+ "endpoints": [
+ "GET /healthz",
+ "GET /scan/{scan_id}",
+ "POST /scan"
+ ],
+ "name": "security-api",
+ "runtime": true,
+ "runtime_language": "python",
+ "write_policies": [
+ {
+ "auth": "required",
+ "endpoint": "POST /scan",
+ "schema": "required",
+ "tenant": "required"
+ }
+ ]
+ },
     {
       "app": false,
       "compose": false,
@@ -1254,6 +1287,28 @@
         }
       ]
     },
+ {
+ "app": false,
+ "compose": false,
+ "docs": false,
+ "docs_path": null,
+ "endpoints": [
+ "GET /healthz",
+ "GET /scan/{scan_id}",
+ "POST /scan"
+ ],
+ "name": "security-api",
+ "runtime": true,
+ "runtime_language": "python",
+ "write_policies": [
+ {
+ "auth": "required",
+ "endpoint": "POST /scan",
+ "schema": "required",
+ "tenant": "required"
+ }
+ ]
+ },
     {
       "app": false,
       "compose": false,
@@ -1351,6 +1406,17 @@
       "runtime_language": "node",
       "write_policies": []
     },
+ {
+ "app": false,
+ "compose": false,
+ "docs": false,
+ "docs_path": null,
+ "endpoints": [],
+ "name": "singularity",
+ "runtime": true,
+ "runtime_language": "python",
+ "write_policies": []
+ },
     {
       "app": false,
       "compose": true,


### PR DESCRIPTION
### Motivation

- Ensure the service surface manifest includes entries for the `singularity` and `security-api` services so they are discoverable by tooling that consumes this manifest.

### Description

- Added multiple `singularity` service objects with `runtime: true` and `runtime_language: "python"` in `config/service-surface-manifest.json`.
- Added `security-api` service objects with `runtime: true`, `runtime_language: "python"`, endpoints (`GET /healthz`, `GET /scan/{scan_id}`, `POST /scan`) and a `write_policies` rule requiring auth, schema, and tenant for `POST /scan`.
- The changes introduce repeated entries for `security-api` and `singularity` in the manifest and include minor whitespace/formatting adjustments.

### Testing

- Validated the edited file is well-formed JSON using a syntax check (`jq .`) which succeeded.
- No other automated test suites were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5992553e48321b2752e45381e2445)