### PR TITLE
Add CI skip diagnostics job to explain skipped workflow jobs

### DIFF
--- a/.github/workflows/zlttbots-ci.yml
+++ b/.github/workflows/zlttbots-ci.yml
@@ -194,3 +194,38 @@ jobs:
 
       - name: Deploy to production
         run: kubectl apply -f infrastructure/k8s
+
+  explain-skips:
+    if: always()
+    needs:
+      - lint-and-validate
+      - security-scans
+      - build-images
+      - dast-scan
+      - promote-dev
+      - promote-staging
+      - promote-production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped jobs
+        shell: bash
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Ref: ${{ github.ref }}"
+          echo "Needs status:"
+          echo "  lint-and-validate=${{ needs.lint-and-validate.result }}"
+          echo "  security-scans=${{ needs.security-scans.result }}"
+          echo "  build-images=${{ needs.build-images.result }}"
+          echo "  dast-scan=${{ needs.dast-scan.result }}"
+          echo "  promote-dev=${{ needs.promote-dev.result }}"
+          echo "  promote-staging=${{ needs.promote-staging.result }}"
+          echo "  promote-production=${{ needs.promote-production.result }}"
+
+          {
+            echo "## Skip diagnostics"
+            echo ""
+            echo "- \`build-images\` requires both \`lint-and-validate\` and \`security-scans\` to succeed."
+            echo "- \`dast-scan\` requires \`build-images\` to succeed."
+            echo "- Promotion jobs run only on \`refs/heads/main\`."
+            echo "- Pull requests use refs like \`refs/pull/<id>/merge\`, so promotion jobs are expected to be skipped."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Provide clear, actionable diagnostics in workflow output when jobs show as "Skipped". 
- Make it explicit why downstream jobs (builds, DAST, promotion) are skipped on PR runs.

### Description
- Added an `explain-skips` job to `.github/workflows/zlttbots-ci.yml` that runs with `if: always()` and depends on the main pipeline jobs (`lint-and-validate`, `security-scans`, `build-images`, `dast-scan`, `promote-dev`, `promote-staging`, `promote-production`).
- The job prints the event and ref, echoes each needed job's `result`, and appends a concise explanation to the GitHub Actions step summary (`$GITHUB_STEP_SUMMARY`).
- The summary documents the key skip rules: `build-images` requires both `lint-and-validate` and `security-scans`, `dast-scan` requires `build-images`, and promotion jobs are gated to `refs/heads/main` (so PR refs are expected to skip).

### Testing
- Ran `git diff --check` and it passed successfully. 
- Verified the working tree with `git status --short` and inspected the last change with `git show --stat --oneline -1`, both showing the workflow update. 
- Local validation of the edited file (`.github/workflows/zlttbots-ci.yml`) was performed by viewing the diff and file contents to ensure correct YAML insertion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59a89c3788321989eae8ee7dcc0fb)