### PR TITLE
Fix duplicate service entries in service-surface-manifest.json

### DIFF
--- a/config/service-surface-manifest.json
+++ b/config/service-surface-manifest.json
@@ -853,17 +853,6 @@
       "runtime_language": "node",
       "write_policies": []
     },
- {
- "app": false,
- "compose": false,
- "docs": false,
- "docs_path": null,
- "endpoints": [],
- "name": "singularity",
- "runtime": true,
- "runtime_language": "python",
- "write_policies": []
- },
     {
       "app": false,
       "compose": true,
@@ -1243,28 +1232,6 @@
         }
       ]
     },
- {
- "app": false,
- "compose": false,
- "docs": false,
- "docs_path": null,
- "endpoints": [
- "GET /healthz",
- "GET /scan/{scan_id}",
- "POST /scan"
- ],
- "name": "security-api",
- "runtime": true,
- "runtime_language": "python",
- "write_policies": [
- {
- "auth": "required",
- "endpoint": "POST /scan",
- "schema": "required",
- "tenant": "required"
- }
- ]
- },
     {
       "app": false,
       "compose": false,
@@ -1287,28 +1254,6 @@
         }
       ]
     },
- {
- "app": false,
- "compose": false,
- "docs": false,
- "docs_path": null,
- "endpoints": [
- "GET /healthz",
- "GET /scan/{scan_id}",
- "POST /scan"
- ],
- "name": "security-api",
- "runtime": true,
- "runtime_language": "python",
- "write_policies": [
- {
- "auth": "required",
- "endpoint": "POST /scan",
- "schema": "required",
- "tenant": "required"
- }
- ]
- },
     {
       "app": false,
       "compose": false,
@@ -1406,17 +1351,6 @@
       "runtime_language": "node",
       "write_policies": []
     },
- {
- "app": false,
- "compose": false,
- "docs": false,
- "docs_path": null,
- "endpoints": [],
- "name": "singularity",
- "runtime": true,
- "runtime_language": "python",
- "write_policies": []
- },
     {
       "app": false,
       "compose": true,


### PR DESCRIPTION
### Motivation
- CI manifest-drift validation was failing due to duplicated service blocks in `config/service-surface-manifest.json` (notably repeated `security-api` and `singularity` entries). 
- The change restores a single canonical entry per service so the manifest is deterministic and stable for downstream tooling.

### Description
- Regenerated `config/service-surface-manifest.json` using the repository manifest generator so duplicates were removed and canonical ordering restored. 
- Removed duplicated `security-api` and `singularity` entries and normalized the manifest structure to the expected shape. 
- Ensured the generated manifest remains compatible with existing feature/manifest tooling.

### Testing
- Ran `python scripts/feature_impact_dive.py --write-manifest` which updated the manifest as expected and completed successfully. 
- Ran `python scripts/feature_impact_dive.py --validate-manifest` which returned OK, confirming the manifest passes validation. 
- Verified the repository validation step that compares the generated manifest to the committed file now passes locally (manifest validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a3c21a2c8321887dbabe1d685366)