### PR TITLE
Fix generator script: env export typo and shell-safety hardening

### DIFF
--- a/generate-zlttbots.sh
+++ b/generate-zlttbots.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 PROJECT="zlttbots"
 
 echo "Creating project structure..."
 
-mkdir -p $PROJECT
+mkdir -p "$PROJECT"
 
-cd $PROJECT
+cd "$PROJECT"
 
 mkdir -p \
 services/tiktok-uploader \
@@ -49,7 +49,7 @@ import dotenv from "dotenv"
 
 dotenv.config()
 
-7export const config = {
+export const config = {
 db: process.env.DB_URL,
 videoDir: process.env.VIDEO_DIR || "./videos",
 }
@@ -2175,7 +2175,7 @@ EOF
 cat > infrastructure/scripts/rollback.sh << 'EOF'
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 DEPLOYMENT=$1
 
@@ -2185,7 +2185,7 @@ EOF
 cat > infrastructure/ci/build-all.sh << 'EOF'
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 services=(
 analytics
@@ -2209,7 +2209,7 @@ EOF
 cat > infrastructure/ci/deploy.sh << 'EOF'
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 kubectl apply -f infrastructure/k8s
 EOF


### PR DESCRIPTION
### Motivation
- Prevent generation of runtime-breaking JavaScript in the TikTok uploader by removing a stray character in the env template.
- Improve robustness and deterministic behavior of the generator by tightening shell error handling across generated scripts.
- Avoid word-splitting/path bugs when creating or changing into the target project directory.

### Description
- Fixed a typo in the TikTok uploader env template (`7export` -> `export`) so generated `services/tiktok-uploader/src/config/env.js` is valid JavaScript.
- Hardened the script execution flags in `generate-zlttbots.sh` and in generated script templates by replacing `set -e` with `set -euo pipefail` to catch unset variables and pipeline failures.
- Quoted project path usage by changing `mkdir -p $PROJECT` and `cd $PROJECT` to `mkdir -p "$PROJECT"` and `cd "$PROJECT"` to avoid word-splitting and path issues.
- Applied the safer shell flags to several generated CI/infra script templates (examples include `infrastructure/scripts/rollback.sh`, `infrastructure/ci/build-all.sh`, and `infrastructure/ci/deploy.sh`).

### Testing
- Ran `bash -n generate-zlttbots.sh` to validate script syntax which completed successfully.
- Executed the generator in a temporary directory `(cd "$tmpdir" && bash generate-zlttbots.sh)` and observed successful end-to-end generation with exit code `0`.
- Scanned generated output with `rg` to confirm no remaining malformed `*export` tokens, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a84fae208321a52045f8e4beb3f6)