### PR TITLE
fix(compose): prevent `zlttbots-net` label conflict with existing Docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -919,7 +919,6 @@ services:
 
 networks:
   zlttbots-net:
-    name: zlttbots-net
     driver: bridge
 
 volumes:


### PR DESCRIPTION
### Motivation
- Removing the fixed network name prevents Docker Compose from colliding with a pre-existing host network that was not created/labeled by Compose and producing `incorrect label com.docker.compose.network` warnings.

### Description
- Deleted the `name: zlttbots-net` override in `docker-compose.yml` under `networks.zlttbots-net` so Compose will use a project-scoped network name and avoid label mismatches.

### Testing
- Verified the change is minimal and targeted by inspecting the diff of `docker-compose.yml` with `git diff`.
- Attempted to run `docker compose -f docker-compose.yml config` but the `docker` CLI is not available in this environment so the compose config check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d5098ecc832195c118a8da1ed433)