### PR TITLE
Fix arbitrage-engine healthcheck to probe /healthz endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,13 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ['CMD-SHELL', 'python -c "import os,socket; p=int(os.getenv(\"ARBITRAGE_ENGINE_PORT\",\"9500\")); s=socket.create_connection((\"127.0.0.1\", p), 2); s.close()"']
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import os,urllib.request; p=os.getenv('ARBITRAGE_ENGINE_PORT','9500').strip() or '9500'; url=f'http://127.0.0.1:{int(p)}/healthz'; r=urllib.request.urlopen(url, timeout=2); assert r.status == 200",
+        ]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
### Motivation
- Reduce false unhealthy states for `zlttbots-arbitrage-engine` by replacing a fragile raw socket shell healthcheck with an HTTP readiness probe that verifies the service's `/healthz` endpoint and HTTP 200 response.

### Description
- Replace the Compose `arbitrage-engine` healthcheck that used a `CMD-SHELL` socket connect with a `CMD` array that runs a Python stdlib HTTP request using `urllib.request` to `http://127.0.0.1:{ARBITRAGE_ENGINE_PORT:-9500}/healthz` and asserts `r.status == 200`, while preserving existing `interval`, `timeout`, `retries`, `start_period`, and `ARBITRAGE_ENGINE_PORT` configurability in `docker-compose.yml`.

### Testing
- Parsed `docker-compose.yml` with Python + `yaml.safe_load` to validate the file and confirm `services.arbitrage-engine.healthcheck.test` remains a list command (succeeded). 
- Attempted runtime container verification with `docker compose up` and `docker logs` but the `docker` CLI was not available in the environment so container-level validation could not be executed (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5e20496e88321947a606bac1b0bb1)