### PR TITLE
Harden env parsing & fix viral-predictor healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,13 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: python -c 'import os,socket; p=int(os.getenv("ARBITRAGE_ENGINE_PORT","9500")); s=socket.create_connection(("127.0.0.1", p), 2); s.close()'
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import os,socket; raw=os.getenv('VIRAL_PREDICTOR_PORT','9100').strip(); p=int(raw or '9100'); s=socket.create_connection(('127.0.0.1', p), 2); s.close()",
+        ]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/services/arbitrage-engine/src/main.py
+++ b/services/arbitrage-engine/src/main.py
@@ -1,11 +1,26 @@
 import os
 
 
+def _safe_port(env_key: str, default: int) -> int:
+    raw = os.getenv(env_key)
+    if raw is None:
+        return default
+    value = raw.strip()
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    if parsed <= 0 or parsed > 65535:
+        return default
+    return parsed
+
 
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(
         "api.server:app",
         host="0.0.0.0",
-        port=int(os.getenv("ARBITRAGE_ENGINE_PORT", "9500")),
+        port=_safe_port("ARBITRAGE_ENGINE_PORT", 9500),
     )

--- a/services/federation/src/main.py
+++ b/services/federation/src/main.py
@@ -19,10 +19,6 @@ SECRET = os.getenv("FEDERATION_SECRET", "change-me")
 DB_URL = os.getenv("DATABASE_URL", "postgresql://zlttbots:zlttbots@postgres:5432/zlttbots")
 AUDIT_LOG_PATH = Path(os.getenv("FEDERATION_AUDIT_LOG", "/tmp/federation-audit.log"))
 DEFAULT_TENANT = os.getenv("FEDERATION_DEFAULT_TENANT", "default")
-STARTUP_DB_MAX_ATTEMPTS = max(1, int(os.getenv("FEDERATION_DB_STARTUP_MAX_ATTEMPTS", "15")))
-STARTUP_DB_RETRY_SECONDS = max(1.0, float(os.getenv("FEDERATION_DB_STARTUP_RETRY_SECONDS", "2")))
-
-
 def _safe_int_env(env_key: str, default_value: int) -> int:
     raw_value = os.getenv(env_key)
     if raw_value is None:
@@ -44,7 +40,33 @@ def _safe_int_env(env_key: str, default_value: int) -> int:
     return parsed
 
 
+def _safe_float_env(env_key: str, default_value: float) -> float:
+    raw_value = os.getenv(env_key)
+    if raw_value is None:
+        return default_value
+    value = raw_value.strip()
+    if not value:
+        return default_value
+    try:
+        parsed = float(value)
+    except ValueError:
+        logger.warning(
+            json.dumps(
+                {
+                    "event": "federation.invalid_env_float",
+                    "env_key": env_key,
+                    "raw_value": raw_value,
+                    "default_used": default_value,
+                }
+            )
+        )
+        return default_value
+    return parsed
+
+
 TOKEN_TTL_SECONDS = max(60, _safe_int_env("FEDERATION_TOKEN_TTL", 3600))
+STARTUP_DB_MAX_ATTEMPTS = max(1, _safe_int_env("FEDERATION_DB_STARTUP_MAX_ATTEMPTS", 15))
+STARTUP_DB_RETRY_SECONDS = max(1.0, _safe_float_env("FEDERATION_DB_STARTUP_RETRY_SECONDS", 2.0))
 
 
 class NodeRegister(BaseModel):

--- a/services/viral-predictor/src/main.py
+++ b/services/viral-predictor/src/main.py
@@ -1,7 +1,25 @@
 import os
 
 SERVICE_HOST = os.getenv("SERVICE_HOST", "127.0.0.1")
-SERVICE_PORT = int(os.getenv("VIRAL_PREDICTOR_PORT", "9100"))
+
+
+def _safe_port(env_key: str, default: int) -> int:
+    raw = os.getenv(env_key)
+    if raw is None:
+        return default
+    value = raw.strip()
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    if parsed <= 0 or parsed > 65535:
+        return default
+    return parsed
+
+
+SERVICE_PORT = _safe_port("VIRAL_PREDICTOR_PORT", 9100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent service startup failures caused by blank, malformed, or out-of-range environment variables that left dependent containers unhealthy.  
- Correct an incorrect healthcheck that probed the wrong service port causing compose dependency chains to stall.

### Description
- Added defensive port parsing `_safe_port` and used it in `services/arbitrage-engine/src/main.py` to safely resolve `ARBITRAGE_ENGINE_PORT` with a default of `9500`.  
- Added defensive port parsing `_safe_port` and used it in `services/viral-predictor/src/main.py` to safely resolve `VIRAL_PREDICTOR_PORT` with a default of `9100`.  
- Added `_safe_float_env` and switched `services/federation/src/main.py` to use safe integer/float env parsing for `FEDERATION_DB_STARTUP_MAX_ATTEMPTS` and `FEDERATION_DB_STARTUP_RETRY_SECONDS` to avoid crashes from malformed `.env` values.  
- Updated `docker-compose.yml` viral-predictor `healthcheck` to probe `VIRAL_PREDICTOR_PORT` (and handle blank env values) instead of incorrectly targeting `ARBITRAGE_ENGINE_PORT`.

### Testing
- Ran bytecode compilation: `python -m compileall services/arbitrage-engine/src/main.py services/federation/src/main.py services/viral-predictor/src/main.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f5bdc4f88321a1111d8aad054390)