### PR TITLE
Add production self-healing deployment stack and infra tuner pipeline

### DIFF
--- a/.github/workflows/infra-autotune-train.yml
+++ b/.github/workflows/infra-autotune-train.yml
@@ -1,0 +1,47 @@
+name: infra-autotune-train
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */6 * * *"
+
+jobs:
+  train-infra-policy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy==2.3.2 scikit-learn==1.7.1
+
+      - name: Generate deterministic sample metrics
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/infra-metrics.jsonl <<'JSONL'
+          {"latency_ms": 320, "error_rate": 0.01, "cpu_utilization": 0.45, "memory_utilization": 0.48, "restart_count": 0}
+          {"latency_ms": 970, "error_rate": 0.02, "cpu_utilization": 0.72, "memory_utilization": 0.75, "restart_count": 0}
+          {"latency_ms": 1430, "error_rate": 0.08, "cpu_utilization": 0.88, "memory_utilization": 0.93, "restart_count": 1}
+          {"latency_ms": 680, "error_rate": 0.03, "cpu_utilization": 0.63, "memory_utilization": 0.68, "restart_count": 0}
+          JSONL
+
+      - name: Train policy
+        run: |
+          python services/rl-trainer/src/autonomy/infra_tuner_pipeline.py \
+            --input artifacts/infra-metrics.jsonl \
+            --output artifacts/infra-policy.json
+
+      - name: Upload policy artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: infra-policy
+          path: artifacts/infra-policy.json

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,15 @@
+# Production Deployment Stack
+
+This directory contains production-ready infrastructure definitions for the self-healing arbitrage control plane:
+
+- `helm/zlttbots`: Kubernetes Helm chart with startup/readiness/liveness probes, HPA, PDB, ServiceMonitor, and NetworkPolicy.
+- `argocd/apps/zlttbots-production.yaml`: Argo CD application for GitOps sync.
+
+## Usage
+
+```bash
+helm template zlttbots deploy/helm/zlttbots
+kubectl apply -f deploy/argocd/apps/zlttbots-production.yaml
+```
+
+For cluster bootstrapping via Terraform, see `infra/terraform/environments/production`.

--- a/deploy/argocd/apps/zlttbots-production.yaml
+++ b/deploy/argocd/apps/zlttbots-production.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: zlttbots-production
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/cvsz/zlttbots.git
+    targetRevision: main
+    path: deploy/helm/zlttbots
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: image.tag
+          value: "2026.04.08"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: zlttbots
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/deploy/helm/zlttbots/Chart.yaml
+++ b/deploy/helm/zlttbots/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: zlttbots
+version: 0.1.0
+appVersion: "1.0.0"
+type: application
+description: Production-grade deployment chart for zlttbots control plane.

--- a/deploy/helm/zlttbots/templates/deployment.yaml
+++ b/deploy/helm/zlttbots/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-arbitrage-engine
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: zlttbots
+    app.kubernetes.io/component: arbitrage-engine
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zlttbots
+      app.kubernetes.io/component: arbitrage-engine
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zlttbots
+        app.kubernetes.io/component: arbitrage-engine
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        fsGroup: 10001
+      containers:
+        - name: arbitrage-engine
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          env:
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: zlttbots-secrets
+                  key: DB_URL
+            - name: LOG_LEVEL
+              value: {{ .Values.env.LOG_LEVEL | quote }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.health.livenessPath }}
+              port: {{ .Values.health.port }}
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.health.readinessPath }}
+              port: {{ .Values.health.port }}
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          startupProbe:
+            httpGet:
+              path: {{ .Values.health.startupPath }}
+              port: {{ .Values.health.port }}
+            failureThreshold: {{ .Values.health.startupFailureThreshold }}
+            periodSeconds: {{ .Values.health.startupPeriodSeconds }}

--- a/deploy/helm/zlttbots/templates/hpa.yaml
+++ b/deploy/helm/zlttbots/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-arbitrage-engine
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-arbitrage-engine
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/zlttbots/templates/networkpolicy.yaml
+++ b/deploy/helm/zlttbots/templates/networkpolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-arbitrage-engine
+  namespace: {{ .Values.namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: zlttbots
+      app.kubernetes.io/component: arbitrage-engine
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.namespace }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+    - from:
+{{- range .Values.networkPolicy.allowedNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+{{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.namespace }}
+      ports:
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 6379
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/deploy/helm/zlttbots/templates/pdb.yaml
+++ b/deploy/helm/zlttbots/templates/pdb.yaml
@@ -1,0 +1,11 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-arbitrage-engine
+  namespace: {{ .Values.namespace }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zlttbots
+      app.kubernetes.io/component: arbitrage-engine

--- a/deploy/helm/zlttbots/templates/service.yaml
+++ b/deploy/helm/zlttbots/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-arbitrage-engine
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: zlttbots
+    app.kubernetes.io/component: arbitrage-engine
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: zlttbots
+    app.kubernetes.io/component: arbitrage-engine
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/deploy/helm/zlttbots/templates/servicemonitor.yaml
+++ b/deploy/helm/zlttbots/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-arbitrage-engine
+  namespace: {{ .Values.namespace }}
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zlttbots
+      app.kubernetes.io/component: arbitrage-engine
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/helm/zlttbots/values.yaml
+++ b/deploy/helm/zlttbots/values.yaml
@@ -1,0 +1,41 @@
+namespace: zlttbots
+image:
+  repository: ghcr.io/cvsz/zlttbots-arbitrage-engine
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+replicaCount: 3
+service:
+  type: ClusterIP
+  port: 9500
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+  limits:
+    cpu: "1500m"
+    memory: "2Gi"
+health:
+  livenessPath: /health/live
+  readinessPath: /health/ready
+  startupPath: /healthz
+  port: 9500
+  startupFailureThreshold: 30
+  startupPeriodSeconds: 5
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 12
+  targetCPUUtilizationPercentage: 65
+  targetMemoryUtilizationPercentage: 75
+podDisruptionBudget:
+  minAvailable: 2
+env:
+  DB_URL: postgresql://zlttbots:change-me@postgres:5432/zlttbots
+  LOG_LEVEL: INFO
+networkPolicy:
+  enabled: true
+  allowedNamespaces:
+    - monitoring
+serviceMonitor:
+  enabled: true
+  interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,12 +108,12 @@ services:
           "CMD",
           "python",
           "-c",
-          "import os,socket; raw=os.getenv('ARBITRAGE_ENGINE_PORT','9500'); value=(raw or '').strip(); port=9500 if not value or not value.isdigit() else int(value); s=socket.create_connection(('127.0.0.1', port),2); s.close()",
+          "import json,os,urllib.request; raw=os.getenv('ARBITRAGE_ENGINE_PORT','9500'); value=(raw or '').strip(); port=9500 if not value or not value.isdigit() else int(value); req=urllib.request.Request(f'http://127.0.0.1:{port}/health/ready'); resp=urllib.request.urlopen(req, timeout=3); data=json.loads(resp.read().decode('utf-8')); assert data.get('status') == 'ready'",
         ]
-      interval: 15s
+      interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 20s
+      retries: 10
+      start_period: 60s
     networks:
       - zlttbots-net
 

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.14"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_path
+  }
+}
+
+module "zlttbots_platform" {
+  source      = "../../modules/zlttbots-platform"
+  namespace   = var.namespace
+  chart_path  = "${path.root}/../../../../deploy/helm/zlttbots"
+  image_tag   = var.image_tag
+  db_url      = var.db_url
+}

--- a/infra/terraform/environments/production/terraform.tfvars.example
+++ b/infra/terraform/environments/production/terraform.tfvars.example
@@ -1,0 +1,4 @@
+kubeconfig_path = "~/.kube/config"
+namespace       = "zlttbots"
+image_tag       = "2026.04.08"
+db_url          = "postgresql://zlttbots:replace-me@postgres.zlttbots.svc.cluster.local:5432/zlttbots"

--- a/infra/terraform/environments/production/variables.tf
+++ b/infra/terraform/environments/production/variables.tf
@@ -1,0 +1,21 @@
+variable "kubeconfig_path" {
+  type        = string
+  description = "Path to kubeconfig for target cluster"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "zlttbots"
+  description = "Namespace for deployed workloads"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Container image tag for arbitrage engine"
+}
+
+variable "db_url" {
+  type        = string
+  description = "Database URL for application"
+  sensitive   = true
+}

--- a/infra/terraform/modules/zlttbots-platform/main.tf
+++ b/infra/terraform/modules/zlttbots-platform/main.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_namespace" "zlttbots" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "kubernetes_secret" "zlttbots_secrets" {
+  metadata {
+    name      = "zlttbots-secrets"
+    namespace = kubernetes_namespace.zlttbots.metadata[0].name
+  }
+
+  data = {
+    DB_URL = var.db_url
+  }
+
+  type = "Opaque"
+}
+
+resource "helm_release" "zlttbots" {
+  name             = "zlttbots"
+  namespace        = kubernetes_namespace.zlttbots.metadata[0].name
+  create_namespace = false
+  chart            = var.chart_path
+
+  values = [yamlencode({
+    namespace = var.namespace
+    image = {
+      tag = var.image_tag
+    }
+  })]
+
+  depends_on = [kubernetes_secret.zlttbots_secrets]
+}

--- a/infra/terraform/modules/zlttbots-platform/outputs.tf
+++ b/infra/terraform/modules/zlttbots-platform/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  value       = kubernetes_namespace.zlttbots.metadata[0].name
+  description = "Namespace where zlttbots is deployed"
+}
+
+output "release_name" {
+  value       = helm_release.zlttbots.name
+  description = "Helm release name"
+}

--- a/infra/terraform/modules/zlttbots-platform/variables.tf
+++ b/infra/terraform/modules/zlttbots-platform/variables.tf
@@ -1,0 +1,27 @@
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace for zlttbots workloads"
+  default     = "zlttbots"
+}
+
+variable "chart_path" {
+  type        = string
+  description = "Path to the Helm chart"
+}
+
+variable "image_tag" {
+  type        = string
+  description = "Arbitrage engine image tag"
+}
+
+variable "db_url" {
+  type        = string
+  description = "Database URL for arbitrage engine"
+  sensitive   = true
+}
+
+variable "argocd_namespace" {
+  type        = string
+  description = "Namespace where Argo CD is deployed"
+  default     = "argocd"
+}

--- a/infrastructure/monitoring/grafana/dashboards/arbitrage-control-plane.json
+++ b/infrastructure/monitoring/grafana/dashboards/arbitrage-control-plane.json
@@ -1,0 +1,85 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Request Rate",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total{service=\"arbitrage-engine\"}[5m]))", "refId": "A"}
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "title": "5xx Error Ratio",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{service=\"arbitrage-engine\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_requests_total{service=\"arbitrage-engine\"}[5m])), 0.001)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "title": "Latency p99",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{service=\"arbitrage-engine\"}[5m])) by (le))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "title": "Container Restarts",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"zlttbots\",container=\"arbitrage-engine\"}[1h]))", "refId": "A"}
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["zlttbots", "arbitrage", "self-healing"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "utc",
+  "title": "ZLTTBOTS Arbitrage Control Plane",
+  "uid": "zlttbots-arb-control",
+  "version": 1
+}

--- a/infrastructure/monitoring/prometheus/rules/arbitrage-self-healing-rules.yml
+++ b/infrastructure/monitoring/prometheus/rules/arbitrage-self-healing-rules.yml
@@ -1,0 +1,37 @@
+groups:
+  - name: arbitrage-self-healing
+    interval: 30s
+    rules:
+      - alert: ArbitrageEngineHighErrorRate
+        expr: |
+          sum(rate(http_requests_total{service="arbitrage-engine",status=~"5.."}[5m]))
+          /
+          clamp_min(sum(rate(http_requests_total{service="arbitrage-engine"}[5m])), 0.001)
+          > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          service: arbitrage-engine
+        annotations:
+          summary: "arbitrage-engine 5xx ratio exceeds 5%"
+          description: "High 5xx rate detected for 5 minutes; trigger restart playbook and inspect dependency readiness."
+
+      - alert: ArbitrageEngineReadinessFlapping
+        expr: changes(kube_pod_container_status_ready{namespace="zlttbots",container="arbitrage-engine"}[10m]) > 4
+        for: 3m
+        labels:
+          severity: warning
+          service: arbitrage-engine
+        annotations:
+          summary: "arbitrage-engine readiness is flapping"
+          description: "Readiness changed more than four times in 10 minutes. Consider increasing startup tolerance or checking downstream dependencies."
+
+      - alert: ArbitrageEngineLatencyP99High
+        expr: histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{service="arbitrage-engine"}[5m])) by (le)) > 1.5
+        for: 10m
+        labels:
+          severity: warning
+          service: arbitrage-engine
+        annotations:
+          summary: "arbitrage-engine p99 latency > 1.5s"
+          description: "Persistent latency spike detected; RL infra tuner should evaluate timeout/retry/autoscaling policy."

--- a/scripts/wait-for-dependency.sh
+++ b/scripts/wait-for-dependency.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <host> <port> [timeout_seconds]" >&2
+  exit 64
+fi
+
+host="$1"
+port="$2"
+timeout_seconds="${3:-120}"
+start_ts="$(date +%s)"
+
+while true; do
+  if python - "$host" "$port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+with socket.create_connection((host, port), timeout=2):
+    pass
+PY
+  then
+    echo "Dependency ready: ${host}:${port}"
+    exit 0
+  fi
+
+  now="$(date +%s)"
+  elapsed=$((now - start_ts))
+  if (( elapsed >= timeout_seconds )); then
+    echo "Timed out waiting for ${host}:${port} after ${timeout_seconds}s" >&2
+    exit 70
+  fi
+
+  echo "Waiting for ${host}:${port}... (${elapsed}s elapsed)"
+  sleep 2
+done

--- a/services/arbitrage-engine/src/api/server.py
+++ b/services/arbitrage-engine/src/api/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import time
 from datetime import date
+from threading import Lock
 
 import psycopg2
 from fastapi import FastAPI, HTTPException, Response
@@ -32,6 +33,8 @@ from publishing.controller import DailyPublishingController
 app = FastAPI()
 client = UnifiedAffiliateClient()
 controller = DailyPublishingController()
+_readiness_lock = Lock()
+_is_ready = False
 
 
 class PayoutIngestRequest(BaseModel):
@@ -89,18 +92,48 @@ def get_db():
     return psycopg2.connect(os.environ["DB_URL"])
 
 
-@app.get('/healthz')
-def healthz():
-    db_ok = False
-
+def _probe_database() -> bool:
     try:
         with get_db() as db:
             with db.cursor() as cur:
                 cur.execute('select 1')
                 cur.fetchone()
-        db_ok = True
+        return True
     except Exception:
-        db_ok = False
+        return False
+
+
+@app.on_event("startup")
+def startup_probe() -> None:
+    global _is_ready
+    # Retry dependency checks to avoid failing health checks during cold start.
+    for _ in range(30):
+        if _probe_database():
+            with _readiness_lock:
+                _is_ready = True
+            return
+        time.sleep(2)
+
+
+@app.get('/health/live')
+def health_live():
+    return {"status": "alive", "service": "arbitrage-engine"}
+
+
+@app.get('/health/ready')
+def health_ready():
+    with _readiness_lock:
+        ready = _is_ready
+    if not ready:
+        raise HTTPException(status_code=503, detail="service is starting")
+    return {"status": "ready", "service": "arbitrage-engine"}
+
+
+@app.get('/healthz')
+def healthz():
+    db_ok = False
+
+    db_ok = _probe_database()
 
     return {
         'status': 'ok' if db_ok else 'degraded',

--- a/services/rl-trainer/src/autonomy/infra_tuner_pipeline.py
+++ b/services/rl-trainer/src/autonomy/infra_tuner_pipeline.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+from sklearn.ensemble import IsolationForest
+
+LOGGER = logging.getLogger("infra_tuner_pipeline")
+
+
+@dataclass(frozen=True)
+class InfraState:
+    latency_ms: float
+    error_rate: float
+    cpu_utilization: float
+    memory_utilization: float
+    restart_count: float
+
+
+@dataclass(frozen=True)
+class ActionThresholds:
+    timeout_seconds: int
+    retry_count: int
+    min_replicas: int
+    max_replicas: int
+
+
+ALLOWED_ACTIONS = {
+    "increase_timeout",
+    "increase_retries",
+    "scale_up",
+    "scale_down",
+    "no_op",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train deterministic infra tuning policy")
+    parser.add_argument("--input", required=True, type=Path, help="Path to newline-delimited JSON metrics")
+    parser.add_argument("--output", required=True, type=Path, help="Path for generated policy JSON")
+    parser.add_argument("--anomaly-threshold", default=0.65, type=float)
+    return parser.parse_args()
+
+
+def load_states(path: Path) -> List[InfraState]:
+    if not path.exists():
+        raise FileNotFoundError(f"metrics input not found: {path}")
+
+    states: List[InfraState] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, raw in enumerate(handle, start=1):
+            row = raw.strip()
+            if not row:
+                continue
+            payload = json.loads(row)
+            try:
+                states.append(
+                    InfraState(
+                        latency_ms=float(payload["latency_ms"]),
+                        error_rate=float(payload["error_rate"]),
+                        cpu_utilization=float(payload["cpu_utilization"]),
+                        memory_utilization=float(payload["memory_utilization"]),
+                        restart_count=float(payload["restart_count"]),
+                    )
+                )
+            except KeyError as exc:
+                raise ValueError(f"missing key at line {line_number}: {exc}") from exc
+    if not states:
+        raise ValueError("no valid metrics were loaded")
+    return states
+
+
+def to_matrix(states: List[InfraState]) -> np.ndarray:
+    matrix = np.array(
+        [
+            [
+                state.latency_ms,
+                state.error_rate,
+                state.cpu_utilization,
+                state.memory_utilization,
+                state.restart_count,
+            ]
+            for state in states
+        ],
+        dtype=np.float64,
+    )
+    return matrix
+
+
+def choose_action(state: InfraState, is_anomaly: bool) -> str:
+    if is_anomaly and state.error_rate > 0.05:
+        return "increase_retries"
+    if is_anomaly and state.latency_ms > 1200:
+        return "scale_up"
+    if state.cpu_utilization > 0.85 or state.memory_utilization > 0.90:
+        return "scale_up"
+    if state.cpu_utilization < 0.35 and state.memory_utilization < 0.40 and state.restart_count == 0:
+        return "scale_down"
+    if state.latency_ms > 800:
+        return "increase_timeout"
+    return "no_op"
+
+
+def build_policy(states: List[InfraState], anomaly_threshold: float) -> Dict[str, object]:
+    matrix = to_matrix(states)
+    forest = IsolationForest(
+        n_estimators=200,
+        contamination="auto",
+        random_state=42,
+        n_jobs=1,
+    )
+    forest.fit(matrix)
+    raw_scores = -forest.score_samples(matrix)
+
+    action_counts = {action: 0 for action in ALLOWED_ACTIONS}
+    for state, score in zip(states, raw_scores):
+        action = choose_action(state, bool(score >= anomaly_threshold))
+        action_counts[action] += 1
+
+    dominant_action = max(action_counts, key=action_counts.get)
+    thresholds = ActionThresholds(
+        timeout_seconds=10 if dominant_action in {"increase_timeout", "increase_retries"} else 5,
+        retry_count=10 if dominant_action == "increase_retries" else 6,
+        min_replicas=3,
+        max_replicas=12 if dominant_action == "scale_up" else 8,
+    )
+
+    return {
+        "model": "deterministic-isolation-forest-v1",
+        "seed": 42,
+        "records": len(states),
+        "anomaly_threshold": anomaly_threshold,
+        "action_counts": action_counts,
+        "dominant_action": dominant_action,
+        "recommended_thresholds": thresholds.__dict__,
+    }
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    args = parse_args()
+    states = load_states(args.input)
+    policy = build_policy(states, args.anomaly_threshold)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(policy, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    LOGGER.info("wrote policy to %s", args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Prevent cascading failures caused by `arbitrage-engine` failing healthchecks during cold start by separating readiness/liveness and adding startup dependency warm-up. 
- Provide a production-grade deployment pattern (Helm / Terraform / ArgoCD) with secure defaults, probes, autoscaling and network controls to support safe rollouts. 
- Add deterministic infra tuning and observability artifacts so self-healing and RL-based tuning can detect and remediate infra issues automatically.

### Description

- Hardened service health lifecycle in `services/arbitrage-engine/src/api/server.py` by adding `_probe_database()`, a startup probe that retries dependency checks, a thread-safe readiness flag, and new endpoints `GET /health/live` and `GET /health/ready`. 
- Updated `docker-compose.yml` healthcheck for `arbitrage-engine` to call the readiness endpoint and increased tolerance (`interval: 10s`, `retries: 10`, `start_period: 60s`) to avoid premature unhealthy states. 
- Added a production Helm chart under `deploy/helm/zlttbots` with secure container settings, liveness/readiness/startup probes, HPA, PDB, NetworkPolicy and ServiceMonitor, and an Argo CD application manifest at `deploy/argocd/apps/zlttbots-production.yaml`. 
- Added Terraform module/environment (`infra/terraform/modules/zlttbots-platform`, `infra/terraform/environments/production`) to provision namespace, secret (DB URL), and Helm release. 
- Added observability: Prometheus alert rules at `infrastructure/monitoring/prometheus/rules/arbitrage-self-healing-rules.yml` and Grafana dashboard JSON at `infrastructure/monitoring/grafana/dashboards/arbitrage-control-plane.json`. 
- Added deterministic infra-tuning pipeline `services/rl-trainer/src/autonomy/infra_tuner_pipeline.py` (IsolationForest-based, fixed seed) and scheduled GitHub Actions workflow `.github/workflows/infra-autotune-train.yml` to produce policy artifacts. 
- Provided operational helpers: `scripts/wait-for-dependency.sh` for dependency gating and `deploy/README.md` with deployment guidance.

### Testing

- Ran Python compilation check with `python -m compileall services/arbitrage-engine/src/api/server.py services/rl-trainer/src/autonomy/infra_tuner_pipeline.py`, which succeeded. 
- Validated Grafana dashboard JSON with `python -c "import json, pathlib; json.loads(pathlib.Path('infrastructure/monitoring/grafana/dashboards/arbitrage-control-plane.json').read_text())"`, which succeeded. 
- Attempted `terraform fmt -check -recursive infra/terraform/environments/production infra/terraform/modules/zlttbots-platform` which could not run in this environment because the `terraform` CLI is not available. 
- Attempted to run the infra-tuner pipeline locally (`python services/rl-trainer/src/autonomy/infra_tuner_pipeline.py --input ... --output ...`) which failed here because `scikit-learn` is not installed in the runtime; the pipeline is exercised in the included GitHub Action that installs dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f9f9b3548321bc59198f43758154)