### PR TITLE
fix(arbitrage-engine): add missing requests dependency to container image

### DIFF
--- a/services/arbitrage-engine/requirements.txt
+++ b/services/arbitrage-engine/requirements.txt
@@ -5,3 +5,4 @@ redis==6.4.0
 numpy==2.3.3
 pydantic==2.11.7
 prometheus-client==0.23.1
+requests==2.32.5


### PR DESCRIPTION
### Motivation
- The arbitrage engine imports `requests` in `services/arbitrage-engine/src/connectors/providers.py`, and the missing runtime dependency caused the `zlttbots-arbitrage-engine` container to fail startup and block dependent services such as `zlttbots-federation`.

### Description
- Added `requests==2.32.5` to `services/arbitrage-engine/requirements.txt` so the package is available in the container image at runtime.

### Testing
- Ran `python -m compileall services/arbitrage-engine/src` which completed successfully; container build/run verification (`docker compose build` / `docker compose up`) could not be executed in this environment because the Docker CLI is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ff5ba56c8321897a73ef718a3189)