### PR TITLE
Switch relative imports to top-level imports in payment service

### DIFF
--- a/services/payment/adapter.py
+++ b/services/payment/adapter.py
@@ -6,8 +6,8 @@ from typing import Any
 
 import requests
 
-from .audit import log
-from .circuit import allow, fail, success
+from audit import log
+from circuit import allow, fail, success
 
 TIMEOUT = float(os.getenv("PAYMENT_TIMEOUT", "3"))
 DEFAULT_HEADERS = {"Content-Type": "application/json"}

--- a/services/payment/main.py
+++ b/services/payment/main.py
@@ -7,8 +7,8 @@ from typing import Any, Literal
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field, HttpUrl
 
-from .adapter import send
-from .audit import log
+from adapter import send
+from audit import log
 
 app = FastAPI(title="Payment Gateway")
 STRIPE_ENDPOINT = os.getenv("PAYMENT_STRIPE_ENDPOINT", "https://payments.example/stripe")


### PR DESCRIPTION
### Motivation
- Normalize module imports to top-level names to avoid relative import issues when running the service outside the package layout. 

### Description
- Replaced relative imports with absolute imports in `services/payment/adapter.py` and `services/payment/main.py` (e.g. changed `from .audit import log` to `from audit import log` and similar for `circuit` and `adapter`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6011a30248321ae783c40b2dcaced)