### PR TITLE
ci: improve manifest drift validation messaging

### DIFF
--- a/.github/workflows/zlttbots-ci.yml
+++ b/.github/workflows/zlttbots-ci.yml
@@ -50,7 +50,11 @@ jobs:
       - name: Feature/drift manifest validation
         run: |
           python scripts/feature_impact_dive.py --write-manifest
-          git diff --exit-code config/service-surface-manifest.json
+          if ! git diff --quiet -- config/service-surface-manifest.json; then
+            echo "❌ Manifest out of date. Run: python scripts/feature_impact_dive.py --write-manifest"
+            git --no-pager diff -- config/service-surface-manifest.json
+            exit 1
+          fi
           python scripts/feature_impact_dive.py --validate-manifest
 
       - name: Documentation snippet and command-style validation


### PR DESCRIPTION
### Motivation
- The CI `lint-and-validate` manifest gate failed without actionable diagnostics when `config/service-surface-manifest.json` drifted, making triage slow and error-prone.

### Description
- Update the `Feature/drift manifest validation` step in `.github/workflows/zlttbots-ci.yml` to run `python scripts/feature_impact_dive.py --write-manifest`, then use `if ! git diff --quiet -- config/service-surface-manifest.json; then ... fi` to print a clear remediation message, show the inline manifest diff with `git --no-pager diff -- config/service-surface-manifest.json`, and exit with non-zero status while preserving the strict gate.

### Testing
- Ran `python scripts/feature_impact_dive.py --write-manifest` and verified `git diff -- config/service-surface-manifest.json` returned no drift (exit code 0), and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a0217fe88321b9c393ec3c37206c)